### PR TITLE
Update dependencies and migrate to Kotlin 2.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
@@ -16,12 +17,12 @@ val keystoreProperties = Properties().apply {
 
 android {
     namespace = "com.nendo.argosy"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.nendo.argosy"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 39
         versionName = "0.9.0"
 
@@ -78,10 +79,6 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.8"
     }
 
     packaging {

--- a/app/src/main/kotlin/com/nendo/argosy/MainActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/MainActivity.kt
@@ -69,8 +69,8 @@ class MainActivity : ComponentActivity() {
     }
 
     @SuppressLint("RestrictedApi")
-    override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
-        if (event != null && gamepadInputHandler.handleKeyEvent(event)) {
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (gamepadInputHandler.handleKeyEvent(event)) {
             return true
         }
         return super.dispatchKeyEvent(event)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,23 @@
 [versions]
-agp = "8.2.2"
-kotlin = "1.9.22"
-ksp = "1.9.22-1.0.17"
-coreKtx = "1.12.0"
-lifecycleRuntimeKtx = "2.7.0"
-activityCompose = "1.8.2"
-composeBom = "2024.02.00"
-hilt = "2.50"
-hiltNavigation = "1.1.0"
+agp = "8.7.3"
+kotlin = "2.0.21"
+ksp = "2.0.21-1.0.28"
+coreKtx = "1.15.0"
+lifecycleRuntimeKtx = "2.8.7"
+activityCompose = "1.9.3"
+composeBom = "2024.12.01"
+hilt = "2.54"
+hiltNavigation = "1.2.0"
 room = "2.6.1"
-datastore = "1.0.0"
-navigation = "2.7.7"
-coil = "2.5.0"
+datastore = "1.1.1"
+navigation = "2.8.5"
+coil = "2.7.0"
 retrofit = "2.9.0"
 okhttp = "4.12.0"
 moshi = "1.15.0"
-workManager = "2.9.0"
-coroutines = "1.7.3"
-mockk = "1.13.9"
+workManager = "2.10.0"
+coroutines = "1.9.0"
+mockk = "1.13.14"
 tvFoundation = "1.0.0-alpha11"
 tvMaterial = "1.0.0"
 
@@ -89,6 +89,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Migrate to Kotlin 2.0.21 with new Compose compiler plugin
- Update Android Gradle Plugin 8.2.2 -> 8.7.3, Gradle 8.5 -> 8.9
- Bump compileSdk/targetSdk 34 -> 35
- Update Compose BOM, Lifecycle, Navigation, Hilt, Coroutines, Coil
- Fix `dispatchKeyEvent` signature for API 35 compatibility

### Version Changes
| Dependency | Old | New |
|------------|-----|-----|
| Kotlin | 1.9.22 | 2.0.21 |
| AGP | 8.2.2 | 8.7.3 |
| Gradle | 8.5 | 8.9 |
| Compose BOM | 2024.02.00 | 2024.12.01 |
| Lifecycle | 2.7.0 | 2.8.7 |
| Navigation | 2.7.7 | 2.8.5 |
| Hilt | 2.50 | 2.54 |
| Coroutines | 1.7.3 | 1.9.0 |
| Coil | 2.5.0 | 2.7.0 |

Consolidates updates from dependabot PRs #10, #11, #12, #13, #14 with stable versions.

## Test plan
- [x] Debug build passes
- [x] Unit tests pass
- [x] Lint passes
- [ ] CI/CD passes