### PR TITLE
feat: Add DOSBox Pure support (dos platform)

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/EmulatorRegistry.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/EmulatorRegistry.kt
@@ -110,7 +110,7 @@ object EmulatorRegistry {
                 "msx", "msx2",
                 "wonderswan", "wonderswancolor",
                 "arcade",
-                "c64", "vic20"
+                "c64", "vic20", "dos"
             ),
             launchAction = Intent.ACTION_MAIN,
             launchConfig = LaunchConfig.RetroArch(),
@@ -130,7 +130,7 @@ object EmulatorRegistry {
                 "msx", "msx2",
                 "wonderswan", "wonderswancolor",
                 "arcade",
-                "c64", "vic20"
+                "c64", "vic20", "dos"
             ),
             launchAction = Intent.ACTION_MAIN,
             launchConfig = LaunchConfig.RetroArch(),
@@ -637,6 +637,7 @@ object EmulatorRegistry {
         "ngpc" to "mednafen_ngp",
         "neogeo" to "fbneo",
         "arcade" to "fbneo",
+        "dos" to "dosbox_pure",
         "msx" to "bluemsx",
         "msx2" to "bluemsx",
         "wonderswan" to "mednafen_wswan",
@@ -678,6 +679,7 @@ object EmulatorRegistry {
         "ngpc" to listOf("mednafen_ngp"),
         "neogeo" to listOf("fbneo", "fbalpha"),
         "arcade" to listOf("fbneo", "mame", "fbalpha"),
+        "dos" to listOf("dosbox_pure", "dosbox_core", "dosbox_svn"),
         "msx" to listOf("bluemsx", "fmsx"),
         "msx2" to listOf("bluemsx", "fmsx"),
         "wonderswan" to listOf("mednafen_wswan"),
@@ -795,6 +797,11 @@ object EmulatorRegistry {
         "atari5200" to listOf(
             RetroArchCore("atari800", "Atari800"),
             RetroArchCore("a5200", "a5200")
+        ),
+        "dos" to listOf(
+            RetroArchCore("dosbox_pure", "DOSBox Pure"),
+            RetroArchCore("dosbox_core", "DOSBox-core"),
+            RetroArchCore("dosbox_svn", "DOSBox-SVN")
         ),
         "atari7800" to listOf(
             RetroArchCore("prosystem", "ProSystem")


### PR DESCRIPTION
## Summary
Minor tweak to enable use of retroarch core dosbox-pure. My first attempt at the code base, happy to receive any feedback if I have missed something obvious.

## Related Issue
n/a

## Changes
- updated EmulatorRegistry.kt with dosbox-pure config

## Testing
Tested in avd and debug build on Odin 2. Was able to successfully launch and play Doom, which runs on everything :).

## Checklist
- [X] Code compiles without errors
- [X] Tests pass locally
- [X] Lint checks pass
- [X] Self-reviewed the code
