### PR TITLE
feat: Double tap to toggle quick menu overlay

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
@@ -27,6 +27,9 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import android.content.Intent
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import com.nendo.argosy.libretro.LibretroActivity
@@ -96,6 +99,7 @@ import androidx.lifecycle.compose.LifecycleEventEffect
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ArgosyApp(
     viewModel: ArgosyViewModel = hiltViewModel(),
@@ -891,6 +895,12 @@ fun ArgosyApp(
                     .fillMaxSize()
                     .focusRequester(rootFocusRequester)
                     .focusable()
+                    .combinedClickable(
+                        onClick = {},
+                        onDoubleClick = { openQuickMenu() },
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    )
             ) {
                 LaunchedEffect(Unit) {
                     rootFocusRequester.requestFocus()
@@ -1541,7 +1551,8 @@ fun ArgosyApp(
                     navController.navigate(Screen.GameDetail.createRoute(gameId)) {
                         launchSingleTop = true
                     }
-                }
+                },
+                closeQuickMenu = closeQuickMenu
             )
 
             // Quick Settings Panel (right-side drawer)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuOverlay.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuOverlay.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import com.nendo.argosy.ui.quickmenu.components.QuickMenuContent
@@ -56,12 +55,6 @@ fun QuickMenuOverlay(
         targetValue = if (uiState.contentFocused) 0f else 1f,
         animationSpec = Motion.focusSpring,
         label = "topSpacerWeight"
-    )
-
-    val contentAlpha by animateFloatAsState(
-        targetValue = if (uiState.contentFocused) 1f else 0f,
-        animationSpec = tween(200),
-        label = "contentAlpha"
     )
 
     AnimatedVisibility(
@@ -124,19 +117,21 @@ fun QuickMenuOverlay(
 
             Spacer(modifier = Modifier.height(Dimens.spacingLg))
 
-            QuickMenuContent(
-                uiState = uiState,
-                isFocused = uiState.contentFocused,
-                onSearchQueryChange = viewModel::updateSearchQuery,
-                onGameSelect = { gameId ->
-                    viewModel.hide()
-                    onGameSelect(gameId)
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-                    .alpha(contentAlpha)
-            )
+            if (uiState.contentFocused) {
+                QuickMenuContent(
+                    uiState = uiState,
+                    onSearchQueryChange = viewModel::updateSearchQuery,
+                    onGameSelect = { gameId ->
+                        viewModel.hide()
+                        onGameSelect(gameId)
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                )
+            } else {
+                Spacer(modifier = Modifier.weight(1f))
+            }
 
             if (topSpacerWeight > 0.01f) {
                 Spacer(modifier = Modifier.weight(topSpacerWeight))

--- a/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuOverlay.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuOverlay.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import com.nendo.argosy.ui.quickmenu.components.QuickMenuContent
@@ -55,6 +56,12 @@ fun QuickMenuOverlay(
         targetValue = if (uiState.contentFocused) 0f else 1f,
         animationSpec = Motion.focusSpring,
         label = "topSpacerWeight"
+    )
+
+    val contentAlpha by animateFloatAsState(
+        targetValue = if (uiState.contentFocused) 1f else 0f,
+        animationSpec = tween(200),
+        label = "contentAlpha"
     )
 
     AnimatedVisibility(
@@ -117,21 +124,19 @@ fun QuickMenuOverlay(
 
             Spacer(modifier = Modifier.height(Dimens.spacingLg))
 
-            if (uiState.contentFocused) {
-                QuickMenuContent(
-                    uiState = uiState,
-                    onSearchQueryChange = viewModel::updateSearchQuery,
-                    onGameSelect = { gameId ->
-                        viewModel.hide()
-                        onGameSelect(gameId)
-                    },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                )
-            } else {
-                Spacer(modifier = Modifier.weight(1f))
-            }
+            QuickMenuContent(
+                uiState = uiState,
+                isFocused = uiState.contentFocused,
+                onSearchQueryChange = viewModel::updateSearchQuery,
+                onGameSelect = { gameId ->
+                    viewModel.hide()
+                    onGameSelect(gameId)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .alpha(contentAlpha)
+            )
 
             if (topSpacerWeight > 0.01f) {
                 Spacer(modifier = Modifier.weight(topSpacerWeight))

--- a/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuOverlay.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuOverlay.kt
@@ -9,7 +9,10 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -20,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -31,10 +35,12 @@ import com.nendo.argosy.ui.theme.Dimens
 import com.nendo.argosy.ui.theme.LocalLauncherTheme
 import com.nendo.argosy.ui.theme.Motion
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun QuickMenuOverlay(
     viewModel: QuickMenuViewModel,
     onGameSelect: (Long) -> Unit,
+    closeQuickMenu: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -68,6 +74,12 @@ fun QuickMenuOverlay(
             modifier = Modifier
                 .fillMaxSize()
                 .background(overlayColor)
+                .combinedClickable(
+                    onClick = {},
+                    onDoubleClick = { closeQuickMenu() },
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() }
+                )
         )
     }
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuOverlay.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuOverlay.kt
@@ -124,19 +124,23 @@ fun QuickMenuOverlay(
 
             Spacer(modifier = Modifier.height(Dimens.spacingLg))
 
-            QuickMenuContent(
-                uiState = uiState,
-                isFocused = uiState.contentFocused,
-                onSearchQueryChange = viewModel::updateSearchQuery,
-                onGameSelect = { gameId ->
-                    viewModel.hide()
-                    onGameSelect(gameId)
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-                    .alpha(contentAlpha)
-            )
+            if (contentAlpha > 0f) {
+                QuickMenuContent(
+                    uiState = uiState,
+                    isFocused = uiState.contentFocused,
+                    onSearchQueryChange = viewModel::updateSearchQuery,
+                    onGameSelect = { gameId ->
+                        viewModel.hide()
+                        onGameSelect(gameId)
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .alpha(contentAlpha)
+                )
+            } else {
+                Spacer(modifier = Modifier.weight(1f))
+            }
 
             if (topSpacerWeight > 0.01f) {
                 Spacer(modifier = Modifier.weight(topSpacerWeight))

--- a/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/components/QuickMenuContent.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/components/QuickMenuContent.kt
@@ -36,16 +36,13 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import java.io.File
 import com.nendo.argosy.ui.quickmenu.GameCardUi
@@ -57,19 +54,16 @@ import com.nendo.argosy.ui.theme.Dimens
 @Composable
 fun QuickMenuContent(
     uiState: QuickMenuUiState,
-    isFocused: Boolean,
     onSearchQueryChange: (String) -> Unit,
     onGameSelect: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val contentAlpha = if (isFocused) 1f else 0.7f
-
     AnimatedContent(
         targetState = uiState.selectedOrb,
         transitionSpec = {
             fadeIn(animationSpec = tween(150)) togetherWith fadeOut(animationSpec = tween(100))
         },
-        modifier = modifier.alpha(contentAlpha),
+        modifier = modifier,
         label = "quickMenuContent"
     ) { orb ->
         when (orb) {
@@ -78,41 +72,36 @@ fun QuickMenuContent(
                 results = uiState.searchResults,
                 recentSearches = uiState.recentSearches,
                 focusedIndex = uiState.focusedContentIndex,
-                isInputFocused = isFocused && uiState.searchInputFocused,
-                isListFocused = isFocused && !uiState.searchInputFocused,
+                isInputFocused = uiState.searchInputFocused,
+                isListFocused = uiState.searchInputFocused,
                 onQueryChange = onSearchQueryChange,
                 onGameSelect = onGameSelect
             )
             QuickMenuOrb.RANDOM -> RandomContent(
                 game = uiState.randomGame,
-                isFocused = isFocused,
                 onClick = { uiState.randomGame?.id?.let { onGameSelect(it) } }
             )
             QuickMenuOrb.MOST_PLAYED -> ListContent(
                 games = uiState.mostPlayedGames,
                 focusedIndex = uiState.focusedContentIndex,
-                isFocused = isFocused,
                 emptyMessage = "No games played yet",
                 onGameSelect = onGameSelect
             )
             QuickMenuOrb.TOP_UNPLAYED -> ListContent(
                 games = uiState.topUnplayedGames,
                 focusedIndex = uiState.focusedContentIndex,
-                isFocused = isFocused,
                 emptyMessage = "No rated games found",
                 onGameSelect = onGameSelect
             )
             QuickMenuOrb.RECENT -> ListContent(
                 games = uiState.recentGames,
                 focusedIndex = uiState.focusedContentIndex,
-                isFocused = isFocused,
                 emptyMessage = "No recent games",
                 onGameSelect = onGameSelect
             )
             QuickMenuOrb.FAVORITES -> ListContent(
                 games = uiState.favoriteGames,
                 focusedIndex = uiState.focusedContentIndex,
-                isFocused = isFocused,
                 emptyMessage = "No favorites yet",
                 onGameSelect = onGameSelect
             )
@@ -198,7 +187,6 @@ private fun SearchContent(
             GameList(
                 games = results,
                 focusedIndex = focusedIndex,
-                isFocused = isListFocused,
                 onGameSelect = onGameSelect
             )
         }
@@ -208,7 +196,6 @@ private fun SearchContent(
 @Composable
 private fun RandomContent(
     game: GameCardUi?,
-    isFocused: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -218,17 +205,14 @@ private fun RandomContent(
     }
 
     val shape = RoundedCornerShape(Dimens.radiusXl)
-    val borderModifier = if (isFocused) {
-        Modifier.border(Dimens.borderMedium, MaterialTheme.colorScheme.primary, shape)
-    } else Modifier
+    val borderModifier = Modifier.border(Dimens.borderMedium, MaterialTheme.colorScheme.primary, shape)
 
     Row(
         modifier = modifier
             .fillMaxSize()
             .then(borderModifier)
             .background(
-                if (isFocused) MaterialTheme.colorScheme.primaryContainer
-                else MaterialTheme.colorScheme.surface,
+                MaterialTheme.colorScheme.primaryContainer,
                 shape
             )
             .clip(shape)
@@ -337,7 +321,6 @@ private fun RandomContent(
 private fun ListContent(
     games: List<GameRowUi>,
     focusedIndex: Int,
-    isFocused: Boolean,
     emptyMessage: String,
     onGameSelect: (Long) -> Unit,
     modifier: Modifier = Modifier
@@ -350,7 +333,6 @@ private fun ListContent(
     GameList(
         games = games,
         focusedIndex = focusedIndex,
-        isFocused = isFocused,
         onGameSelect = onGameSelect,
         modifier = modifier
     )
@@ -360,7 +342,6 @@ private fun ListContent(
 private fun GameList(
     games: List<GameRowUi>,
     focusedIndex: Int,
-    isFocused: Boolean,
     onGameSelect: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -387,7 +368,7 @@ private fun GameList(
         itemsIndexed(games, key = { _, game -> game.id }) { index, game ->
             QuickMenuGameRow(
                 game = game,
-                isFocused = isFocused && index == focusedIndex,
+                isFocused = index == focusedIndex,
                 onClick = { onGameSelect(game.id) }
             )
         }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/components/QuickMenuContent.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/components/QuickMenuContent.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
@@ -54,16 +55,19 @@ import com.nendo.argosy.ui.theme.Dimens
 @Composable
 fun QuickMenuContent(
     uiState: QuickMenuUiState,
+    isFocused: Boolean,
     onSearchQueryChange: (String) -> Unit,
     onGameSelect: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val contentAlpha = if (isFocused) 1f else 0.7f
+
     AnimatedContent(
         targetState = uiState.selectedOrb,
         transitionSpec = {
             fadeIn(animationSpec = tween(150)) togetherWith fadeOut(animationSpec = tween(100))
         },
-        modifier = modifier,
+        modifier = modifier.alpha(contentAlpha),
         label = "quickMenuContent"
     ) { orb ->
         when (orb) {
@@ -72,36 +76,41 @@ fun QuickMenuContent(
                 results = uiState.searchResults,
                 recentSearches = uiState.recentSearches,
                 focusedIndex = uiState.focusedContentIndex,
-                isInputFocused = uiState.searchInputFocused,
-                isListFocused = uiState.searchInputFocused,
+                isInputFocused = isFocused && uiState.searchInputFocused,
+                isListFocused = isFocused && !uiState.searchInputFocused,
                 onQueryChange = onSearchQueryChange,
                 onGameSelect = onGameSelect
             )
             QuickMenuOrb.RANDOM -> RandomContent(
                 game = uiState.randomGame,
+                isFocused = isFocused,
                 onClick = { uiState.randomGame?.id?.let { onGameSelect(it) } }
             )
             QuickMenuOrb.MOST_PLAYED -> ListContent(
                 games = uiState.mostPlayedGames,
                 focusedIndex = uiState.focusedContentIndex,
+                isFocused = isFocused,
                 emptyMessage = "No games played yet",
                 onGameSelect = onGameSelect
             )
             QuickMenuOrb.TOP_UNPLAYED -> ListContent(
                 games = uiState.topUnplayedGames,
                 focusedIndex = uiState.focusedContentIndex,
+                isFocused = isFocused,
                 emptyMessage = "No rated games found",
                 onGameSelect = onGameSelect
             )
             QuickMenuOrb.RECENT -> ListContent(
                 games = uiState.recentGames,
                 focusedIndex = uiState.focusedContentIndex,
+                isFocused = isFocused,
                 emptyMessage = "No recent games",
                 onGameSelect = onGameSelect
             )
             QuickMenuOrb.FAVORITES -> ListContent(
                 games = uiState.favoriteGames,
                 focusedIndex = uiState.focusedContentIndex,
+                isFocused = isFocused,
                 emptyMessage = "No favorites yet",
                 onGameSelect = onGameSelect
             )
@@ -187,6 +196,7 @@ private fun SearchContent(
             GameList(
                 games = results,
                 focusedIndex = focusedIndex,
+                isFocused = isListFocused,
                 onGameSelect = onGameSelect
             )
         }
@@ -196,6 +206,7 @@ private fun SearchContent(
 @Composable
 private fun RandomContent(
     game: GameCardUi?,
+    isFocused: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -205,14 +216,17 @@ private fun RandomContent(
     }
 
     val shape = RoundedCornerShape(Dimens.radiusXl)
-    val borderModifier = Modifier.border(Dimens.borderMedium, MaterialTheme.colorScheme.primary, shape)
+    val borderModifier = if (isFocused) {
+        Modifier.border(Dimens.borderMedium, MaterialTheme.colorScheme.primary, shape)
+    } else Modifier
 
     Row(
         modifier = modifier
             .fillMaxSize()
             .then(borderModifier)
             .background(
-                MaterialTheme.colorScheme.primaryContainer,
+                if (isFocused) MaterialTheme.colorScheme.primaryContainer
+                else MaterialTheme.colorScheme.surface,
                 shape
             )
             .clip(shape)
@@ -321,6 +335,7 @@ private fun RandomContent(
 private fun ListContent(
     games: List<GameRowUi>,
     focusedIndex: Int,
+    isFocused: Boolean,
     emptyMessage: String,
     onGameSelect: (Long) -> Unit,
     modifier: Modifier = Modifier
@@ -333,6 +348,7 @@ private fun ListContent(
     GameList(
         games = games,
         focusedIndex = focusedIndex,
+        isFocused = isFocused,
         onGameSelect = onGameSelect,
         modifier = modifier
     )
@@ -342,6 +358,7 @@ private fun ListContent(
 private fun GameList(
     games: List<GameRowUi>,
     focusedIndex: Int,
+    isFocused: Boolean,
     onGameSelect: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -368,7 +385,7 @@ private fun GameList(
         itemsIndexed(games, key = { _, game -> game.id }) { index, game ->
             QuickMenuGameRow(
                 game = game,
-                isFocused = index == focusedIndex,
+                isFocused = isFocused && index == focusedIndex,
                 onClick = { onGameSelect(game.id) }
             )
         }


### PR DESCRIPTION
## Summary
Minor pr to allow toggling the quick menu overlay via touch controls. Double tap anywhere that's not already interactable to open the overlay, double tap again to dismiss. Also fixes an issue where the UI behind the overlay is interactable via touch.

## Related Issue
Addresses https://github.com/rommapp/argosy-launcher/issues/134

## Checklist
- [x] Code compiles without errors
- [x] Tests pass locally
- [x] Lint checks pass
- [x] Self-reviewed the code
