### PR TITLE
Quick menu overlay recent search fixes for touch

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuOverlay.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuOverlay.kt
@@ -121,8 +121,12 @@ fun QuickMenuOverlay(
                     isFocused = uiState.contentFocused,
                     onSearchQueryChange = viewModel::updateSearchQuery,
                     onGameSelect = { gameId ->
+                        viewModel.saveSearchQuery()
                         viewModel.hide()
                         onGameSelect(gameId)
+                    },
+                    onRecentSearchSelect = { query ->
+                        viewModel.selectRecentSearch(query)
                     },
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/QuickMenuViewModel.kt
@@ -216,6 +216,10 @@ class QuickMenuViewModel @Inject constructor(
     fun selectRecentSearch(index: Int) {
         val state = _uiState.value
         val query = state.recentSearches.getOrNull(index) ?: return
+        selectRecentSearch(query)
+    }
+
+    fun selectRecentSearch(query: String) {
         _uiState.update { it.copy(searchQuery = query, focusedContentIndex = 0) }
         performSearch(query)
     }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/components/QuickMenuContent.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/components/QuickMenuContent.kt
@@ -7,6 +7,8 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import com.nendo.argosy.ui.util.clickableNoFocus
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -36,6 +38,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -58,7 +61,8 @@ fun QuickMenuContent(
     isFocused: Boolean,
     onSearchQueryChange: (String) -> Unit,
     onGameSelect: (Long) -> Unit,
-    modifier: Modifier = Modifier
+    onRecentSearchSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val contentAlpha = if (isFocused) 1f else 0.7f
 
@@ -79,7 +83,8 @@ fun QuickMenuContent(
                 isInputFocused = isFocused && uiState.searchInputFocused,
                 isListFocused = isFocused && !uiState.searchInputFocused,
                 onQueryChange = onSearchQueryChange,
-                onGameSelect = onGameSelect
+                onGameSelect = onGameSelect,
+                onRecentSearchSelect = onRecentSearchSelect
             )
             QuickMenuOrb.RANDOM -> RandomContent(
                 game = uiState.randomGame,
@@ -128,6 +133,7 @@ private fun SearchContent(
     isListFocused: Boolean,
     onQueryChange: (String) -> Unit,
     onGameSelect: (Long) -> Unit,
+    onRecentSearchSelect: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val inputShape = RoundedCornerShape(Dimens.radiusLg)
@@ -185,7 +191,8 @@ private fun SearchContent(
                 RecentSearchesList(
                     searches = recentSearches,
                     focusedIndex = focusedIndex,
-                    isFocused = isListFocused
+                    isFocused = isListFocused,
+                    onRecentSearchSelect = onRecentSearchSelect,
                 )
             } else {
                 EmptyState(message = "Type at least 2 characters to search")
@@ -394,7 +401,8 @@ private fun RecentSearchesList(
     searches: List<String>,
     focusedIndex: Int,
     isFocused: Boolean,
-    modifier: Modifier = Modifier
+    onRecentSearchSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
 
@@ -426,7 +434,8 @@ private fun RecentSearchesList(
             itemsIndexed(searches, key = { index, _ -> index }) { index, query ->
                 RecentSearchRow(
                     query = query,
-                    isFocused = isFocused && index == focusedIndex
+                    isFocused = isFocused && index == focusedIndex,
+                    onRecentSearchSelect = onRecentSearchSelect
                 )
             }
         }
@@ -437,7 +446,8 @@ private fun RecentSearchesList(
 private fun RecentSearchRow(
     query: String,
     isFocused: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onRecentSearchSelect: (String) -> Unit
 ) {
     val shape = RoundedCornerShape(Dimens.radiusMd)
     val borderModifier = if (isFocused) {
@@ -453,7 +463,12 @@ private fun RecentSearchRow(
                 else MaterialTheme.colorScheme.surface,
                 shape
             )
-            .padding(horizontal = Dimens.spacingMd, vertical = Dimens.spacingSm),
+            .padding(horizontal = Dimens.spacingMd, vertical = Dimens.spacingSm)
+            .clickable(
+                onClick = { onRecentSearchSelect(query) },
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Dimens.spacingSm)
     ) {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/components/QuickMenuContent.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/quickmenu/components/QuickMenuContent.kt
@@ -7,8 +7,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import com.nendo.argosy.ui.util.clickableNoFocus
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -38,7 +36,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -464,11 +461,7 @@ private fun RecentSearchRow(
                 shape
             )
             .padding(horizontal = Dimens.spacingMd, vertical = Dimens.spacingSm)
-            .clickable(
-                onClick = { onRecentSearchSelect(query) },
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() }
-            ),
+            .clickableNoFocus(onClick = { onRecentSearchSelect(query) }),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Dimens.spacingSm)
     ) {


### PR DESCRIPTION
## Summary
Couple fixes for quick menu overlay:
1. Search is not saved as a recent search when game is selected via touch
2. Recent searches not selectable via touch

## Checklist
- [x] Code compiles without errors
- [x] Tests pass locally
- [x] Lint checks pass
- [x] Self-reviewed the code
