### PR TITLE
Fix screen capture prompt when Screen Colors is disabled

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/MainActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/MainActivity.kt
@@ -584,7 +584,7 @@ class MainActivity : ComponentActivity() {
             imageCacheManager.resumePendingLogoCache()
             imageCacheManager.resumePendingBadgeCache()
 
-            if (prefs.ambientLedEnabled) {
+            if (prefs.ambientLedEnabled && prefs.ambientLedScreenEnabled) {
                 if (screenCaptureManager.hasPermission.value && !screenCaptureManager.isCapturing.value) {
                     screenCaptureManager.startCapture()
                 } else if (!screenCaptureManager.hasPermission.value && !screenCapturePromptedThisSession) {

--- a/app/src/main/kotlin/com/nendo/argosy/MainActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/MainActivity.kt
@@ -26,6 +26,7 @@ import com.nendo.argosy.data.cache.ImageCacheManager
 import com.nendo.argosy.data.emulator.EmulatorResolver
 import com.nendo.argosy.data.local.dao.DownloadQueueDao
 import com.nendo.argosy.data.local.dao.GameDao
+import com.nendo.argosy.data.preferences.UserPreferences
 import com.nendo.argosy.data.repository.CollectionRepository
 import com.nendo.argosy.data.repository.PlatformRepository
 import com.nendo.argosy.data.preferences.UserPreferencesRepository
@@ -60,6 +61,8 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 private const val TAG = "MainActivity"
+internal fun shouldInitializeScreenCapture(prefs: UserPreferences): Boolean =
+    prefs.ambientLedEnabled && prefs.ambientLedScreenEnabled
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -584,7 +587,7 @@ class MainActivity : ComponentActivity() {
             imageCacheManager.resumePendingLogoCache()
             imageCacheManager.resumePendingBadgeCache()
 
-            if (prefs.ambientLedEnabled && prefs.ambientLedScreenEnabled) {
+            if (shouldInitializeScreenCapture(prefs)) {
                 if (screenCaptureManager.hasPermission.value && !screenCaptureManager.isCapturing.value) {
                     screenCaptureManager.startCapture()
                 } else if (!screenCaptureManager.hasPermission.value && !screenCapturePromptedThisSession) {

--- a/app/src/test/kotlin/com/nendo/argosy/MainActivityScreenCaptureGateTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/MainActivityScreenCaptureGateTest.kt
@@ -1,0 +1,36 @@
+package com.nendo.argosy
+
+import com.nendo.argosy.data.preferences.UserPreferences
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MainActivityScreenCaptureGateTest {
+
+    @Test
+    fun `returns true only when ambient LED and screen colors are both enabled`() {
+        assertTrue(
+            shouldInitializeScreenCapture(
+                UserPreferences(ambientLedEnabled = true, ambientLedScreenEnabled = true)
+            )
+        )
+
+        assertFalse(
+            shouldInitializeScreenCapture(
+                UserPreferences(ambientLedEnabled = true, ambientLedScreenEnabled = false)
+            )
+        )
+
+        assertFalse(
+            shouldInitializeScreenCapture(
+                UserPreferences(ambientLedEnabled = false, ambientLedScreenEnabled = true)
+            )
+        )
+
+        assertFalse(
+            shouldInitializeScreenCapture(
+                UserPreferences(ambientLedEnabled = false, ambientLedScreenEnabled = false)
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- gate startup MediaProjection permission flow behind both Ambient LED and Screen Colors toggles
- prevent screen-capture permission prompt on launch when Screen Colors is OFF
- add a regression unit test for startup screen-capture gating behavior

## Testing
- ✅ passed: `./gradlew :app:testDebugUnitTest --tests com.nendo.argosy.MainActivityScreenCaptureGateTest --no-daemon --max-workers=1 --console=plain`
- Result: `BUILD SUCCESSFUL` (42m 6s on first full compile)

## Issue
- Fixes #217

## Authorship
This fix was implemented by ChatGPT using the GPT-5 (Codex) model.
