### PR TITLE
Fix multi-disc m3u launch path for FileUriString extras

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
@@ -1076,9 +1076,16 @@ class GameLauncher @Inject constructor(
                     resolvedExtras += ResolvedExtra.UriExtra(key, uri)
                 }
                 is ExtraValue.FileUriString -> {
-                    val uri = getFileUri(romFile)
-                    fileUri = uri
-                    resolvedExtras += ResolvedExtra.StringExtra(key, uri.toString())
+                    val useAbsolutePathForM3u = romFile.extension.equals("m3u", ignoreCase = true)
+                    if (useAbsolutePathForM3u) {
+                        // Playlist files (.m3u) often rely on relative sibling paths.
+                        // Passing content:// as a string can prevent emulators from resolving those entries.
+                        resolvedExtras += ResolvedExtra.StringExtra(key, romFile.absolutePath)
+                    } else {
+                        val uri = getFileUri(romFile)
+                        fileUri = uri
+                        resolvedExtras += ResolvedExtra.StringExtra(key, uri.toString())
+                    }
                 }
                 is ExtraValue.Platform -> resolvedExtras += ResolvedExtra.StringExtra(key, platformSlug)
                 is ExtraValue.Literal -> resolvedExtras += ResolvedExtra.StringExtra(key, extraValue.value)

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
@@ -38,16 +38,6 @@ import javax.inject.Singleton
 private const val TAG = "GameLauncher"
 private const val EXTRA_ALREADY_LAUNCHED = "argosy.already_launched"
 
-internal fun resolveFileUriStringArgument(romFile: File, fileUriProvider: () -> String): String {
-    return if (romFile.extension.equals("m3u", ignoreCase = true)) {
-        // Playlist files (.m3u) often rely on relative sibling paths.
-        // Passing content:// as a string can prevent emulators from resolving those entries.
-        romFile.absolutePath
-    } else {
-        fileUriProvider()
-    }
-}
-
 data class DiscOption(
     val fileName: String,
     val filePath: String,
@@ -1086,7 +1076,11 @@ class GameLauncher @Inject constructor(
                     resolvedExtras += ResolvedExtra.UriExtra(key, uri)
                 }
                 is ExtraValue.FileUriString -> {
-                    val value = resolveFileUriStringArgument(romFile) {
+                    val value = if (romFile.extension.equals("m3u", ignoreCase = true)) {
+                        // Playlist files (.m3u) often rely on relative sibling paths.
+                        // Passing content:// as a string can prevent emulators from resolving those entries.
+                        romFile.absolutePath
+                    } else {
                         getFileUri(romFile).also { fileUri = it }.toString()
                     }
                     resolvedExtras += ResolvedExtra.StringExtra(key, value)

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
@@ -38,6 +38,16 @@ import javax.inject.Singleton
 private const val TAG = "GameLauncher"
 private const val EXTRA_ALREADY_LAUNCHED = "argosy.already_launched"
 
+internal fun resolveFileUriStringArgument(romFile: File, fileUriProvider: () -> String): String {
+    return if (romFile.extension.equals("m3u", ignoreCase = true)) {
+        // Playlist files (.m3u) often rely on relative sibling paths.
+        // Passing content:// as a string can prevent emulators from resolving those entries.
+        romFile.absolutePath
+    } else {
+        fileUriProvider()
+    }
+}
+
 data class DiscOption(
     val fileName: String,
     val filePath: String,
@@ -1076,16 +1086,10 @@ class GameLauncher @Inject constructor(
                     resolvedExtras += ResolvedExtra.UriExtra(key, uri)
                 }
                 is ExtraValue.FileUriString -> {
-                    val useAbsolutePathForM3u = romFile.extension.equals("m3u", ignoreCase = true)
-                    if (useAbsolutePathForM3u) {
-                        // Playlist files (.m3u) often rely on relative sibling paths.
-                        // Passing content:// as a string can prevent emulators from resolving those entries.
-                        resolvedExtras += ResolvedExtra.StringExtra(key, romFile.absolutePath)
-                    } else {
-                        val uri = getFileUri(romFile)
-                        fileUri = uri
-                        resolvedExtras += ResolvedExtra.StringExtra(key, uri.toString())
+                    val value = resolveFileUriStringArgument(romFile) {
+                        getFileUri(romFile).also { fileUri = it }.toString()
                     }
+                    resolvedExtras += ResolvedExtra.StringExtra(key, value)
                 }
                 is ExtraValue.Platform -> resolvedExtras += ResolvedExtra.StringExtra(key, platformSlug)
                 is ExtraValue.Literal -> resolvedExtras += ResolvedExtra.StringExtra(key, extraValue.value)

--- a/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
@@ -23,6 +23,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -65,9 +66,13 @@ class GameLauncherTest {
         mockkStatic(FileProvider::class)
         context = mockk(relaxed = true)
         every { context.packageName } returns "com.nendo.argosy"
+        val testUri = mockk<Uri>(relaxed = true)
+        every { testUri.toString() } returns "content://test/file"
+        every { testUri.scheme } returns "content"
+        every { testUri.authority } returns "com.nendo.argosy.fileprovider"
         every {
             FileProvider.getUriForFile(context, "com.nendo.argosy.fileprovider", any())
-        } returns Uri.parse("content://test/file")
+        } returns testUri
         gameDao = mockk(relaxed = true)
         gameDiscDao = mockk(relaxed = true)
         emulatorConfigDao = mockk(relaxed = true)
@@ -281,19 +286,47 @@ class GameLauncherTest {
     @Test
     fun `fileUriString extras use absolute path for m3u files`() = runTest {
         val m3uPath = romFile("m3u")
-        val resolved = resolveFileUriStringArgument(java.io.File(m3uPath)) {
-            "content://test/file"
+        val game = createGame(localPath = m3uPath, platformSlug = "psx")
+        coEvery { gameDao.getById(1L) } returns game
+        coEvery { variantResolver.getVariantOptions(game) } returns null
+
+        val duckstation = EmulatorRegistry.getById("duckstation")!!
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns createConfig(
+            gameId = 1L,
+            packageName = duckstation.packageName,
+            displayName = duckstation.displayName
+        )
+        stubDetectorWith(installedEmulator(duckstation))
+        every { emulatorDetector.getByPackage(duckstation.packageName) } returns duckstation
+
+        launcher.launch(1L)
+
+        verify(exactly = 0) {
+            FileProvider.getUriForFile(any(), any(), match { it.extension.equals("m3u", ignoreCase = true) })
         }
-        assertEquals(m3uPath, resolved)
     }
 
     @Test
     fun `fileUriString extras use content uri string for non m3u files`() = runTest {
         val cuePath = romFile("cue")
-        val resolved = resolveFileUriStringArgument(java.io.File(cuePath)) {
-            "content://test/file"
+        val game = createGame(localPath = cuePath, platformSlug = "psx")
+        coEvery { gameDao.getById(1L) } returns game
+        coEvery { variantResolver.getVariantOptions(game) } returns null
+
+        val duckstation = EmulatorRegistry.getById("duckstation")!!
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns createConfig(
+            gameId = 1L,
+            packageName = duckstation.packageName,
+            displayName = duckstation.displayName
+        )
+        stubDetectorWith(installedEmulator(duckstation))
+        every { emulatorDetector.getByPackage(duckstation.packageName) } returns duckstation
+
+        launcher.launch(1L)
+
+        verify(exactly = 1) {
+            FileProvider.getUriForFile(any(), any(), match { it.extension.equals("cue", ignoreCase = true) })
         }
-        assertEquals("content://test/file", resolved)
     }
 
     // -----------------------------------------------------------------------

--- a/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
@@ -32,6 +32,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.util.UUID
 
 class GameLauncherTest {
 
@@ -61,13 +62,12 @@ class GameLauncherTest {
 
     @Before
     fun setup() {
-        mockkStatic("androidx.core.content.FileProvider")
-        every {
-            FileProvider.getUriForFile(any<Context>(), any<String>(), any<java.io.File>())
-        } returns Uri.parse("content://test/file")
-
+        mockkStatic(FileProvider::class)
         context = mockk(relaxed = true)
         every { context.packageName } returns "com.nendo.argosy"
+        every {
+            FileProvider.getUriForFile(context, "com.nendo.argosy.fileprovider", any())
+        } returns Uri.parse("content://test/file")
         gameDao = mockk(relaxed = true)
         gameDiscDao = mockk(relaxed = true)
         emulatorConfigDao = mockk(relaxed = true)
@@ -116,7 +116,7 @@ class GameLauncherTest {
 
     @After
     fun teardown() {
-        io.mockk.unmockkStatic("androidx.core.content.FileProvider")
+        io.mockk.unmockkStatic(FileProvider::class)
     }
 
     // -----------------------------------------------------------------------
@@ -172,7 +172,7 @@ class GameLauncherTest {
     }
 
     private fun romFile(extension: String = "nes"): String {
-        val file = tempFolder.newFile("game.$extension")
+        val file = tempFolder.newFile("game-${UUID.randomUUID()}.$extension")
         return file.absolutePath
     }
 
@@ -281,45 +281,19 @@ class GameLauncherTest {
     @Test
     fun `fileUriString extras use absolute path for m3u files`() = runTest {
         val m3uPath = romFile("m3u")
-        val game = createGame(localPath = m3uPath, platformSlug = "psx")
-        coEvery { gameDao.getById(1L) } returns game
-        coEvery { variantResolver.getVariantOptions(game) } returns null
-
-        val duckstation = EmulatorRegistry.getById("duckstation")!!
-        coEvery { emulatorConfigDao.getByGameId(1L) } returns createConfig(
-            gameId = 1L,
-            packageName = duckstation.packageName,
-            displayName = duckstation.displayName
-        )
-        stubDetectorWith(installedEmulator(duckstation))
-        every { emulatorDetector.getByPackage(duckstation.packageName) } returns duckstation
-
-        val result = launcher.launch(1L)
-        assertTrue(result is LaunchResult.Success)
-        val intent = (result as LaunchResult.Success).intent
-        assertEquals(m3uPath, intent.getStringExtra("bootPath"))
+        val resolved = resolveFileUriStringArgument(java.io.File(m3uPath)) {
+            "content://test/file"
+        }
+        assertEquals(m3uPath, resolved)
     }
 
     @Test
     fun `fileUriString extras use content uri string for non m3u files`() = runTest {
         val cuePath = romFile("cue")
-        val game = createGame(localPath = cuePath, platformSlug = "psx")
-        coEvery { gameDao.getById(1L) } returns game
-        coEvery { variantResolver.getVariantOptions(game) } returns null
-
-        val duckstation = EmulatorRegistry.getById("duckstation")!!
-        coEvery { emulatorConfigDao.getByGameId(1L) } returns createConfig(
-            gameId = 1L,
-            packageName = duckstation.packageName,
-            displayName = duckstation.displayName
-        )
-        stubDetectorWith(installedEmulator(duckstation))
-        every { emulatorDetector.getByPackage(duckstation.packageName) } returns duckstation
-
-        val result = launcher.launch(1L)
-        assertTrue(result is LaunchResult.Success)
-        val intent = (result as LaunchResult.Success).intent
-        assertEquals("content://test/file", intent.getStringExtra("bootPath"))
+        val resolved = resolveFileUriStringArgument(java.io.File(cuePath)) {
+            "content://test/file"
+        }
+        assertEquals("content://test/file", resolved)
     }
 
     // -----------------------------------------------------------------------

--- a/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
@@ -278,6 +278,50 @@ class GameLauncherTest {
         coVerify(exactly = 0) { emulatorDetector.getByPackage(retroarch.packageName) }
     }
 
+    @Test
+    fun `fileUriString extras use absolute path for m3u files`() = runTest {
+        val m3uPath = romFile("m3u")
+        val game = createGame(localPath = m3uPath, platformSlug = "psx")
+        coEvery { gameDao.getById(1L) } returns game
+        coEvery { variantResolver.getVariantOptions(game) } returns null
+
+        val duckstation = EmulatorRegistry.getById("duckstation")!!
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns createConfig(
+            gameId = 1L,
+            packageName = duckstation.packageName,
+            displayName = duckstation.displayName
+        )
+        stubDetectorWith(installedEmulator(duckstation))
+        every { emulatorDetector.getByPackage(duckstation.packageName) } returns duckstation
+
+        val result = launcher.launch(1L)
+        assertTrue(result is LaunchResult.Success)
+        val intent = (result as LaunchResult.Success).intent
+        assertEquals(m3uPath, intent.getStringExtra("bootPath"))
+    }
+
+    @Test
+    fun `fileUriString extras use content uri string for non m3u files`() = runTest {
+        val cuePath = romFile("cue")
+        val game = createGame(localPath = cuePath, platformSlug = "psx")
+        coEvery { gameDao.getById(1L) } returns game
+        coEvery { variantResolver.getVariantOptions(game) } returns null
+
+        val duckstation = EmulatorRegistry.getById("duckstation")!!
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns createConfig(
+            gameId = 1L,
+            packageName = duckstation.packageName,
+            displayName = duckstation.displayName
+        )
+        stubDetectorWith(installedEmulator(duckstation))
+        every { emulatorDetector.getByPackage(duckstation.packageName) } returns duckstation
+
+        val result = launcher.launch(1L)
+        assertTrue(result is LaunchResult.Success)
+        val intent = (result as LaunchResult.Success).intent
+        assertEquals("content://test/file", intent.getStringExtra("bootPath"))
+    }
+
     // -----------------------------------------------------------------------
     // Emulator resolution: platform default
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes black-screen launches for multi-disc games when launching via `.m3u` playlists through emulators that use `FileUriString` extras (notably DuckStation).

This PR was implemented by **ChatGPT (OpenAI GPT-5, Codex coding agent mode)**.

## User-reported context
- ROM layout was updated per issue #171.
- Multi-disc game launched fine directly in DuckStation.
- Launching the same game from Argosy produced a black screen.
- Manually selecting a variant/disc in Argosy worked.

## Root cause
Argosy was passing `.m3u` launch targets in `FileUriString` extras as a `content://...` string.
For playlist-style `.m3u`, emulators may need a real filesystem path so relative disc entries resolve correctly.
This mismatch caused the black-screen path for the auto multi-disc launch flow.

## What changed
### 1) Generic launcher fix (no DuckStation hardcode)
File:
- `app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt`

Behavior in `commandForCustom(...)` for `ExtraValue.FileUriString`:
- If launch file extension is `.m3u` -> pass absolute filesystem path string.
- Otherwise -> keep existing behavior and pass FileProvider `content://` URI string.

This is intentionally format-driven (`.m3u`) rather than emulator-id-driven.

### 2) Regression tests (reviewer-aligned, JVM-safe)
File:
- `app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt`

Because this is a plain JVM unit test (android.jar stubs), `Intent` extras are not reliable for assertions.
To avoid flaky/brittle tests, coverage now validates branch behavior via `FileProvider.getUriForFile` call counts:
- `.m3u` launch path -> `FileProvider` **not called** for the ROM file (`exactly = 0`)
- non-`.m3u` launch path (`.cue`) -> `FileProvider` **called** (`exactly = 1`)

This directly verifies the intended decision point in `commandForCustom` without requiring Robolectric.

## What was explicitly NOT changed
- No changes to M3U platform support matrix.
  - Argosy still treats M3U support as: `psx`, `saturn`, `dreamcast`/`dc`.
  - PS2 remains non-M3U in Argosy flow.
- No changes to disc picker UX or manual variant/disc selection flow.
- No changes to emulator registry mappings besides existing behavior being consumed by the generic fix.
- No changes to non-`FileUriString` launch bindings.
- No changes to ROM layout handling or migration logic from issue #171.

## Discussion-aligned scope notes
- Why manual variant/disc selection worked:
  - It launched a concrete disc file directly and avoided `.m3u` playlist-relative resolution.
- Will DuckStation disc UI still appear:
  - Yes; passing `.m3u` still uses DuckStation’s multi-disc flow.
- Impacted launchers currently using `FileUriString`:
  - DuckStation, NetherSX2, AetherSX2 (+ their package-family variants).
- Practical impact today:
  - Main practical fix target is DuckStation multi-disc `.m3u` launch.
  - PS2 paths are unaffected in practice because Argosy does not launch PS2 via `.m3u`.

## Validation status
Environment prep used in this worktree:
- `local.properties` with Android SDK path
- `git submodule sync --recursive`
- `git submodule update --init --recursive sigil`

Passing test run on **2026-05-25**:

```bash
./gradlew :app:testDebugUnitTest \
  --tests 'com.nendo.argosy.data.emulator.GameLauncherTest.fileUriString extras use absolute path for m3u files' \
  --tests 'com.nendo.argosy.data.emulator.GameLauncherTest.fileUriString extras use content uri string for non m3u files' \
  --no-daemon --max-workers=1 --console=plain
```

Result:
- `BUILD SUCCESSFUL in 51s`
