### PR TITLE
feat(home): add Resync Platform quick action for console platforms

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/home/HomeScreen.kt
@@ -773,6 +773,7 @@ fun HomeScreen(
             if (focusedGame != null) {
                 GameSelectOverlay(
                     game = focusedGame,
+                    isPlatformRow = uiState.currentRow is HomeRow.Platform,
                     focusIndex = uiState.gameMenuFocusIndex,
                     onDismiss = { viewModel.toggleGameMenu() },
                     onPrimaryAction = {
@@ -794,6 +795,10 @@ fun HomeScreen(
                         viewModel.showAddToCollectionModal(focusedGame.id)
                     },
                     onRefresh = { viewModel.refreshGameData(focusedGame.id) },
+                    onResyncPlatform = {
+                        viewModel.toggleGameMenu()
+                        viewModel.syncPlatform(focusedGame.platformId, focusedGame.platformDisplayName)
+                    },
                     onDelete = {
                         viewModel.toggleGameMenu()
                         viewModel.deleteLocalFile(focusedGame.id)
@@ -1504,6 +1509,7 @@ private fun EmptyState(
 @Composable
 private fun GameSelectOverlay(
     game: HomeGameUi,
+    isPlatformRow: Boolean,
     focusIndex: Int,
     onDismiss: () -> Unit,
     onPrimaryAction: () -> Unit,
@@ -1511,6 +1517,7 @@ private fun GameSelectOverlay(
     onDetails: () -> Unit,
     onAddToCollection: () -> Unit,
     onRefresh: () -> Unit,
+    onResyncPlatform: () -> Unit,
     onDelete: () -> Unit,
     onRemoveFromHome: () -> Unit,
     onHide: () -> Unit
@@ -1540,6 +1547,9 @@ private fun GameSelectOverlay(
         add(MenuEntry(Icons.AutoMirrored.Filled.PlaylistAdd, "Add to Collection", onClick = onAddToCollection))
         if (game.isRommGame || game.isAndroidApp) {
             add(MenuEntry(Icons.Default.Refresh, "Refresh Data", onClick = onRefresh))
+        }
+        if (isPlatformRow && game.platformId > 0) {
+            add(MenuEntry(Icons.Default.Refresh, "Resync Platform", onClick = onResyncPlatform))
         }
     }
     val dangerousOptions = buildList {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/home/HomeViewModel.kt
@@ -594,14 +594,17 @@ class HomeViewModel @Inject constructor(
     override fun toggleGameMenu() = gameMenuDelegate.toggleGameMenu()
 
     override fun moveGameMenuFocus(delta: Int) {
-        gameMenuDelegate.moveGameMenuFocus(delta, _uiState.value.focusedGame)
+        val state = _uiState.value
+        val isPlatformRow = state.currentRow is HomeRow.Platform
+        gameMenuDelegate.moveGameMenuFocus(delta, state.focusedGame, isPlatformRow)
     }
 
     override fun confirmGameMenuSelection(onGameSelect: (Long) -> Unit) {
         val state = _uiState.value
         val game = state.focusedGame ?: return
+        val isPlatformRow = state.currentRow is HomeRow.Platform
 
-        when (val action = gameMenuDelegate.resolveMenuAction(state.gameMenuFocusIndex, game)) {
+        when (val action = gameMenuDelegate.resolveMenuAction(state.gameMenuFocusIndex, game, isPlatformRow)) {
             is GameMenuAction.Play -> {
                 toggleGameMenu()
                 when {
@@ -626,6 +629,10 @@ class HomeViewModel @Inject constructor(
                 if (action.isAndroidApp) refreshAndroidGameData(action.gameId)
                 else refreshGameData(action.gameId)
             }
+            is GameMenuAction.ResyncPlatform -> {
+                toggleGameMenu()
+                syncPlatform(action.platformId, action.platformName)
+            }
             is GameMenuAction.Delete -> {
                 toggleGameMenu()
                 deleteLocalFile(action.gameId)
@@ -638,6 +645,12 @@ class HomeViewModel @Inject constructor(
                 toggleGameMenu()
                 hideGame(action.gameId)
             }
+        }
+    }
+
+    fun syncPlatform(platformId: Long, platformName: String) {
+        syncDelegate.resyncPlatform(viewModelScope, platformId, platformName) {
+            refreshCurrentRowInternal()
         }
     }
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/home/delegates/HomeGameMenuDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/home/delegates/HomeGameMenuDelegate.kt
@@ -33,6 +33,7 @@ sealed class GameMenuAction {
     data class ViewDetails(val gameId: Long) : GameMenuAction()
     data class AddToCollection(val gameId: Long) : GameMenuAction()
     data class Refresh(val gameId: Long, val isAndroidApp: Boolean) : GameMenuAction()
+    data class ResyncPlatform(val platformId: Long, val platformName: String) : GameMenuAction()
     data class Delete(val gameId: Long) : GameMenuAction()
     data class RemoveFromHome(val gameId: Long) : GameMenuAction()
     data class Hide(val gameId: Long) : GameMenuAction()
@@ -71,27 +72,30 @@ class HomeGameMenuDelegate @Inject constructor(
         _state.update { it.copy(showGameMenu = false) }
     }
 
-    fun moveGameMenuFocus(delta: Int, focusedGame: HomeGameUi?) {
+    fun moveGameMenuFocus(delta: Int, focusedGame: HomeGameUi?, isPlatformRow: Boolean) {
         _state.update {
             val isDownloaded = focusedGame?.isDownloaded == true
             val needsInstall = focusedGame?.needsInstall == true
             val isRommGame = focusedGame?.isRommGame == true
             val isAndroidApp = focusedGame?.isAndroidApp == true
+            val isSyncable = isPlatformRow && focusedGame != null && focusedGame.platformId > 0
             var maxIndex = if (isDownloaded || needsInstall) MENU_INDEX_MAX_DOWNLOADED else MENU_INDEX_MAX_REMOTE
             if (isRommGame || isAndroidApp) maxIndex++
             if (isAndroidApp) maxIndex++
+            if (isSyncable) maxIndex++
             val newIndex = (it.gameMenuFocusIndex + delta).coerceIn(0, maxIndex)
             it.copy(gameMenuFocusIndex = newIndex)
         }
     }
 
-    fun resolveMenuAction(focusIndex: Int, game: HomeGameUi): GameMenuAction {
+    fun resolveMenuAction(focusIndex: Int, game: HomeGameUi, isPlatformRow: Boolean): GameMenuAction {
         var currentIdx = 0
         val playIdx = currentIdx++
         val favoriteIdx = currentIdx++
         val detailsIdx = currentIdx++
         val addToCollectionIdx = currentIdx++
         val refreshIdx = if (game.isRommGame || game.isAndroidApp) currentIdx++ else -1
+        val resyncIdx = if (isPlatformRow && game.platformId > 0) currentIdx++ else -1
         val deleteIdx = if (game.isDownloaded || game.needsInstall) currentIdx++ else -1
         val removeFromHomeIdx = if (game.isAndroidApp) currentIdx++ else -1
         val hideIdx = currentIdx
@@ -102,6 +106,7 @@ class HomeGameMenuDelegate @Inject constructor(
             detailsIdx -> GameMenuAction.ViewDetails(game.id)
             addToCollectionIdx -> GameMenuAction.AddToCollection(game.id)
             refreshIdx -> GameMenuAction.Refresh(game.id, game.isAndroidApp)
+            resyncIdx -> GameMenuAction.ResyncPlatform(game.platformId, game.platformDisplayName)
             deleteIdx -> GameMenuAction.Delete(game.id)
             removeFromHomeIdx -> GameMenuAction.RemoveFromHome(game.id)
             hideIdx -> GameMenuAction.Hide(game.id)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/home/delegates/HomeSyncDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/home/delegates/HomeSyncDelegate.kt
@@ -110,4 +110,18 @@ class HomeSyncDelegate @Inject constructor(
         }
         return action
     }
+
+    fun resyncPlatform(
+        scope: CoroutineScope,
+        platformId: Long,
+        platformName: String,
+        onComplete: suspend () -> Unit
+    ) {
+        scope.launch {
+            if (!platformSyncQueue.enqueuePlatform(platformId, platformName)) return@launch
+            platformSyncQueue.busyPlatformIds.first { platformId !in it }
+            onComplete()
+        }
+    }
 }
+


### PR DESCRIPTION
## Summary
Adds a "Resync Platform" option to the SELECT (quick actions) overlay menu on the Home screen for console games. Aligned with Library quick actions

## Related Issue
N/A

## Changes
- **HomeScreen**: Added conditional "Resync Platform" menu entry to `GameSelectOverlay` filtered by `isPlatformRow` and `platformId > 0`.
- **HomeViewModel**: Passed down row-context validation (`isPlatformRow`) to `GameSelectOverlay` and exposed a sync delegation wrapper.
- **HomeGameMenuDelegate**: Updated menu index mapping and action resolution to handle the dynamic addition of the "Resync Platform" option.
- **HomeSyncDelegate**: Added `resyncPlatform` to enqueue the sync task on `platformSyncQueue` and refresh the row on completion.

## Testing
- Verified menu option visibility: displays only on console games inside platform-specific rows, and is hidden on non-platform rows (e.g. Favs, Picks, Recent).
- Ran unit tests locally
- Verified successful APK assembly
- Tested on device (Odin 2)

## Checklist
- [x] Code compiles without errors
- [x] Tests pass locally
- [x] Lint checks pass
- [x] Self-reviewed the code