### PR TITLE
feat(in-game menu): Add reset option

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroActivity.kt
@@ -1461,6 +1461,10 @@ class LibretroActivity : ComponentActivity() {
             InGameMenuAction.CustomizeTouchControls -> {
                 enterTouchEditMode()
             }
+            InGameMenuAction.Reset -> {
+                retroView.reset()
+                hideMenu()
+            }
             InGameMenuAction.Quit -> {
                 menuVisible = false
                 isClosing = true

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameMenu.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameMenu.kt
@@ -46,6 +46,7 @@ sealed class InGameMenuAction {
     data object ManageStates : InGameMenuAction()
     data object Settings : InGameMenuAction()
     data object Cheats : InGameMenuAction()
+    data object Reset : InGameMenuAction()
     data object Quit : InGameMenuAction()
     data object OpenToFriends : InGameMenuAction()
     data object InviteFriend : InGameMenuAction()
@@ -140,6 +141,9 @@ fun InGameMenu(
             add("Settings" to InGameMenuAction.Settings)
             if (touchControlsVisible) {
                 add("Touch Controls" to InGameMenuAction.CustomizeTouchControls)
+            }
+            if (!isInNetplaySession) {
+                add("Reset" to InGameMenuAction.Reset)
             }
             add("Quit Game" to InGameMenuAction.Quit)
         }


### PR DESCRIPTION
## Summary
Adds a Reset option to the built-in emulator in-game menu.

## Related Issue
N/A

## Changes
- Add `Reset` to `InGameMenuAction` sealed class
- Add "Reset" menu item between Touch Controls and Quit, hidden during netplay sessions
- Handle `InGameMenuAction.Reset` in `LibretroActivity` via `retroView.reset()`

## Testing
- Unit tests pass
- Lint clean
- Manually verified on Odin 2: Reset appears in menu, triggers core reset without ending session

## Checklist
- [x] Code compiles without errors
- [x] Tests pass locally
- [x] Lint checks pass
- [x] Self-reviewed the code