### PR TITLE
ci: cap JVM heaps so Kotlin compile stops thrashing on 16GB runners

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,8 @@
-org.gradle.jvmargs=-Xmx12288m -Dfile.encoding=UTF-8
+# Sized so the Gradle daemon + separate Kotlin daemon both fit in the 16 GB CI
+# runner. A 12 GB Gradle heap plus a Kotlin daemon inheriting the same args
+# over-committed RAM and sent compileDebugKotlin into swap/GC thrash (~2h40m).
+org.gradle.jvmargs=-Xmx6g -XX:+UseParallelGC -Dfile.encoding=UTF-8
+kotlin.daemon.jvmargs=-Xmx4g -XX:+UseParallelGC
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,11 @@
 # Sized so the Gradle daemon + separate Kotlin daemon both fit in the 16 GB CI
 # runner. A 12 GB Gradle heap plus a Kotlin daemon inheriting the same args
 # over-committed RAM and sent compileDebugKotlin into swap/GC thrash (~2h40m).
-org.gradle.jvmargs=-Xmx6g -XX:+UseParallelGC -Dfile.encoding=UTF-8
-kotlin.daemon.jvmargs=-Xmx4g -XX:+UseParallelGC
+# The Kotlin daemon gets the larger share because it runs both the K2/Compose
+# compile and the KSP processors (Hilt, Room, Moshi, Hilt Work); the Gradle
+# daemon mostly orchestrates. Total 11 GB leaves headroom for KSP/native/OS.
+org.gradle.jvmargs=-Xmx5g -XX:+UseParallelGC -Dfile.encoding=UTF-8
+kotlin.daemon.jvmargs=-Xmx6g -XX:+UseParallelGC
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=false


### PR DESCRIPTION
## Problem

The debug APK build takes **~2h45m** in CI ([example run](https://github.com/rommapp/argosy-launcher/actions/runs/28747890318/job/85241835218)), and it's chronic — every recent `main` build runs 2h–2h45m.

Per-task timing shows it isn't `-PallAbis` / native builds (those finish in ~2 min). A single task dominates:

| Phase | Duration |
|---|---|
| Setup + native CMake (all 4 ABIs) | ~4 min |
| **`:app:compileDebugKotlin`** | **~2h 40m** |
| javac → hilt → dex → package | ~2 min |

For ~880 files / ~220k LOC of Kotlin+Compose, a healthy compile is single-digit minutes. 2h40m is the signature of heap starvation → GC/swap thrash. It also explains why `test` (~2h30m) and `lint` (~1h24m) are slow — they recompile/analyze the same module under the same JVM config.

## Root cause

`org.gradle.jvmargs=-Xmx12288m` gave the Gradle daemon 12 GB. GitHub's public `ubuntu-latest` runner has **16 GB RAM**. The Kotlin compiler runs in a **separate Kotlin daemon**, and with no `kotlin.daemon.jvmargs` it inherited the same args and also tried to reserve 12 GB. Two ~12 GB heaps (+ KSP + OS) over-commit the runner → swap → the Compose/K2 compile grinds for hours.

## Fix

Size both JVMs to fit in 16 GB:

```properties
org.gradle.jvmargs=-Xmx6g -XX:+UseParallelGC -Dfile.encoding=UTF-8
kotlin.daemon.jvmargs=-Xmx4g -XX:+UseParallelGC
```

Expected result: the build drops from ~2h45m back to a few minutes (and `test`/`lint` recover too).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*