### PR TITLE
saves: resolve RetroArch per-core folder to its real on-disk name

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/RetroArchConfigParser.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/RetroArchConfigParser.kt
@@ -254,7 +254,7 @@ class RetroArchConfigParser @Inject constructor(
         if (config == null && saveDir != null) {
             for (base in baseDirs) {
                 val baseDirFile = File(base)
-                val coreDir = File(base, saveDir)
+                val coreDir = File(base, matchExistingFolder(base, saveDir))
 
                 if (coreDir.exists() && coreDir.isDirectory) {
                     paths.add(coreDir.absolutePath)
@@ -290,9 +290,19 @@ class RetroArchConfigParser @Inject constructor(
             append("/").append(contentDirName)
         }
         if (sortByCore && coreName != null) {
-            append("/").append(coreName)
+            append("/").append(matchExistingFolder(toString(), coreName))
         }
     }
+
+    // RA sorts saves into a per-core folder named after the libretro corename.
+    // Our slug->corename map is incomplete, and the slug only matches RA's folder
+    // on a case-insensitive filesystem, so reuse the real folder name when it
+    // already exists.
+    private fun matchExistingFolder(parent: String, name: String): String =
+        File(parent).listFiles()
+            ?.firstOrNull { it.name.equals(name, ignoreCase = true) && it.isDirectory }
+            ?.name
+            ?: name
 
     private fun getBasePathAlternatives(path: String): List<String> {
         val alternatives = mutableListOf(path)
@@ -396,7 +406,7 @@ class RetroArchConfigParser @Inject constructor(
         if (config == null && coreName != null) {
             for (base in baseDirs) {
                 val statesDir = File(base)
-                val coreDir = File(base, coreName)
+                val coreDir = File(base, matchExistingFolder(base, coreName))
 
                 if (coreDir.exists() && coreDir.isDirectory) {
                     paths.add(coreDir.absolutePath)

--- a/app/src/test/kotlin/com/nendo/argosy/data/emulator/RetroArchConfigParserTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/emulator/RetroArchConfigParserTest.kt
@@ -415,4 +415,85 @@ class RetroArchConfigParserTest {
         assertEquals("VICE x64sc", EmulatorRegistry.getRetroArchSaveDirName("vice_x64sc"))
         assertEquals("melonDS DS", EmulatorRegistry.getRetroArchSaveDirName("melondsds"))
     }
+
+    // --- Existing on-disk core folder wins over the guessed name ---
+    // Resolver should reuse the folder's real name, not the slug guess (which
+    // only matches on a case-insensitive FS).
+
+    @Test
+    fun `save path snaps sort-by-core folder to existing on-disk name despite case`() {
+        val base = tempFolder.newFolder("saves")
+        File(base, "Gambatte").mkdirs()
+        val config = RetroArchSaveConfig(
+            savefileDirectory = base.absolutePath,
+            savefilesInContentDir = false,
+            sortByContentDirectory = false,
+            sortByCore = true
+        )
+        val paths = parser.resolveSavePathsWithConfig(
+            config = config,
+            contentDirName = null,
+            coreName = "gambatte"
+        )
+        assertTrue(
+            "expected resolver to reuse RetroArch's real 'Gambatte' folder; got $paths",
+            paths.contains("${base.absolutePath}/Gambatte")
+        )
+        assertTrue("must not invent a lowercase 'gambatte' folder", paths.none { it.endsWith("/gambatte") })
+    }
+
+    @Test
+    fun `save path leaves core name untouched when no folder exists yet`() {
+        val base = tempFolder.newFolder("saves-fresh")
+        val config = RetroArchSaveConfig(
+            savefileDirectory = base.absolutePath,
+            savefilesInContentDir = false,
+            sortByContentDirectory = false,
+            sortByCore = true
+        )
+        val paths = parser.resolveSavePathsWithConfig(
+            config = config,
+            contentDirName = null,
+            coreName = "Gambatte"
+        )
+        assertTrue(paths.contains("${base.absolutePath}/Gambatte"))
+    }
+
+    @Test
+    fun `null-config save path snaps to existing core folder despite case`() {
+        val base = tempFolder.newFolder("saves-nullcfg")
+        File(base, "Genesis Plus GX").mkdirs()
+        val paths = parser.resolveSavePathsWithConfig(
+            config = null,
+            contentDirName = null,
+            coreName = "genesis plus gx",
+            basePathOverride = base.absolutePath
+        )
+        assertTrue(
+            "config-missing fallback must reuse the real 'Genesis Plus GX' folder; got $paths",
+            paths.contains("${base.absolutePath}/Genesis Plus GX")
+        )
+    }
+
+    @Test
+    fun `state path snaps sort-by-core folder to existing on-disk name despite case`() {
+        val base = tempFolder.newFolder("states")
+        File(base, "Snes9x").mkdirs()
+        val config = RetroArchStateConfig(
+            savestateDirectory = base.absolutePath,
+            savestatesInContentDir = false,
+            sortByContentDirectory = false,
+            sortByCore = true
+        )
+        val paths = parser.resolveStatePathsWithConfig(
+            config = config,
+            contentDirName = null,
+            coreName = "snes9x"
+        )
+        assertTrue(
+            "expected resolver to reuse RetroArch's real 'Snes9x' folder; got $paths",
+            paths.contains("${base.absolutePath}/Snes9x")
+        )
+        assertTrue(paths.none { it.endsWith("/snes9x") })
+    }
 }


### PR DESCRIPTION
## Summary

RetroArch stores per-core saves in a folder named after the libretro corename (e.g. Genesis Plus GX), but Argosy derives that folder from a hand-maintained slug --> corename table and falls back to the raw slug for unlisted cores which only matches RetroArch's folder on a case-insensitive filesystem. When it doesn't match, downloaded cloud saves land in a folder RetroArch never reads, so RetroArch starts a fresh local save instead. This change makes the resolver reuse the actual on-disk folder name (case-insensitive match) whenever the per-core folder already exists, so Argosy reads/writes exactly where RetroArch does.

## Related Issue

- Closes #242.

## Changes

- Added matchExistingFolder(parent, name) to RetroArchConfigParser: resolves a per-core folder to its real on-disk name (case-insensitive) when it exists, else returns the guessed name unchanged.
- Applied it where per-core save/state folders are assembled in buildSortedPath (covers the sort-by-core and content-dir paths, saves + states) and both config == null fallback branches.
- Added 4 unit tests: case-insensitive snap for saves, fresh setup (no folder yet --> name unchanged), config == null fallback snap, and the state-path variant.

## Testing

- 4 new unit tests in RetroArchConfigParserTest; existing tests unaffected (they use non-existent paths, where listFiles() returns null and the name passes through unchanged).
- Tested on device using debug build

## Checklist
- [x] Code compiles without errors
- [x] Tests pass locally
- [x] Lint checks pass
- [x] Self-reviewed the code
