### PR TITLE
Built-in libretro saves & states: flat layout, honor explicit restores, surface silent failures

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/core/emulator/LibretroSettingDef.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/core/emulator/LibretroSettingDef.kt
@@ -164,6 +164,14 @@ sealed class LibretroSettingDef(
         type = SettingType.Switch
     )
 
+    data object DefaultToHardcore : LibretroSettingDef(
+        key = "defaultToHardcore",
+        section = "saving",
+        title = "Default to Hardcore",
+        subtitle = "When launching a game, default to hardcore instead of casual",
+        type = SettingType.Switch
+    )
+
     companion object {
         val ALL: List<LibretroSettingDef> = listOf(
             Shader,
@@ -185,7 +193,8 @@ sealed class LibretroSettingDef(
             AudioVolume,
             AutoSaveState,
             AutoRestoreState,
-            HwCoreSaveStates
+            HwCoreSaveStates,
+            DefaultToHardcore
         )
 
         val SECTIONS: Map<String, String> = mapOf(

--- a/app/src/main/kotlin/com/nendo/argosy/core/emulator/LibretroSettingDef.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/core/emulator/LibretroSettingDef.kt
@@ -144,6 +144,7 @@ sealed class LibretroSettingDef(
         key = "autoSaveState",
         section = "saving",
         title = "Save State on Exit",
+        subtitle = "Applies to casual games only",
         type = SettingType.Switch
     )
 
@@ -151,6 +152,7 @@ sealed class LibretroSettingDef(
         key = "autoRestoreState",
         section = "saving",
         title = "Restore State on Launch",
+        subtitle = "Applies to casual games only",
         type = SettingType.Switch
     )
 
@@ -158,7 +160,7 @@ sealed class LibretroSettingDef(
         key = "hwCoreSaveStates",
         section = "saving",
         title = "Hardware-Core Save States",
-        subtitle = "Experimental; cores like Dolphin may black-screen or fail to resume",
+        subtitle = "Experimental; cores like Dolphin may black-screen or fail to resume. Applies to casual games only",
         type = SettingType.Switch
     )
 

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
@@ -523,8 +523,6 @@ class GameLauncher @Inject constructor(
         val builtinBesideRom = emulatorSaveConfigRepository.getByEmulator("builtin")?.savesBesideRom == true
         val effectiveSavePath = if (builtinBesideRom) romFile.parent
             else platformLibretroOverride?.savePath ?: builtinSettings.customSavePath
-        // Single source of truth for the flat live state dir (mirrors save-path override
-        // precedence). LibretroActivity still layers variant isolation on top of this base.
         val effectiveStatePath = libretroStatePathResolver
             .liveStateBaseDir(platformLibretroOverride?.statePath, builtinSettings.customStatePath)
             .absolutePath
@@ -1088,9 +1086,6 @@ class GameLauncher @Inject constructor(
             .getDefaultCoreForPlatform(game.platformSlug)?.coreId
         Logger.debug(TAG, "[BuiltIn] core selection: registry default -> $default")
 
-        // The configured core isn't available for the built-in player. Tell the user instead of
-        // silently substituting a different core -- a silent swap can also silently break saves
-        // (e.g. a vba_next save opened by mGBA).
         val rejected = rejectedCore
         if (rejected != null && default != null) {
             val registry = com.nendo.argosy.libretro.LibretroCoreRegistry

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
@@ -525,7 +525,9 @@ class GameLauncher @Inject constructor(
             else platformLibretroOverride?.savePath ?: builtinSettings.customSavePath
         // Single source of truth for the flat live state dir (mirrors save-path override
         // precedence). LibretroActivity still layers variant isolation on top of this base.
-        val effectiveStatePath = libretroStatePathResolver.liveStateBaseDir(game.id).absolutePath
+        val effectiveStatePath = libretroStatePathResolver
+            .liveStateBaseDir(platformLibretroOverride?.statePath, builtinSettings.customStatePath)
+            .absolutePath
         return Intent(context, LibretroActivity::class.java).apply {
             putExtra(LibretroActivity.EXTRA_ROM_PATH, romFile.absolutePath)
             putExtra(LibretroActivity.EXTRA_VARIANT_FILE_ID, variantFileId ?: -1L)
@@ -1091,16 +1093,15 @@ class GameLauncher @Inject constructor(
         // (e.g. a vba_next save opened by mGBA).
         val rejected = rejectedCore
         if (rejected != null && default != null) {
+            val registry = com.nendo.argosy.libretro.LibretroCoreRegistry
             notificationManager.show(
-                title = "Failed to load ${builtinCoreDisplayName(rejected)}, using ${builtinCoreDisplayName(default)} instead",
+                title = "Failed to load ${registry.displayNameFor(rejected)}, " +
+                    "using ${registry.displayNameFor(default)} instead",
                 type = com.nendo.argosy.core.notification.NotificationType.WARNING
             )
         }
         return default
     }
-
-    private fun builtinCoreDisplayName(coreId: String): String =
-        com.nendo.argosy.libretro.LibretroCoreRegistry.getCoreById(coreId)?.displayName ?: coreId
 
     private suspend fun resolveCoreName(game: GameEntity): String? {
         val gameConfig = emulatorConfigDao.getByGameId(game.id)

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
@@ -87,7 +87,8 @@ class GameLauncher @Inject constructor(
     private val coreSystemDataManager: CoreSystemDataManager,
     private val gameFileDao: GameFileDao,
     private val emulatorSaveConfigRepository: com.nendo.argosy.data.repository.EmulatorSaveConfigRepository,
-    private val saveHandlerRegistry: com.nendo.argosy.data.sync.platform.PlatformSaveHandlerRegistry
+    private val saveHandlerRegistry: com.nendo.argosy.data.sync.platform.PlatformSaveHandlerRegistry,
+    private val libretroStatePathResolver: LibretroStatePathResolver
 ) {
     private val shellAmAvailable: Boolean by lazy {
         try {
@@ -521,7 +522,9 @@ class GameLauncher @Inject constructor(
         val builtinBesideRom = emulatorSaveConfigRepository.getByEmulator("builtin")?.savesBesideRom == true
         val effectiveSavePath = if (builtinBesideRom) romFile.parent
             else platformLibretroOverride?.savePath ?: builtinSettings.customSavePath
-        val effectiveStatePath = platformLibretroOverride?.statePath ?: builtinSettings.customStatePath
+        // Single source of truth for the flat live state dir (mirrors save-path override
+        // precedence). LibretroActivity still layers variant isolation on top of this base.
+        val effectiveStatePath = libretroStatePathResolver.liveStateBaseDir(game.id).absolutePath
         return Intent(context, LibretroActivity::class.java).apply {
             putExtra(LibretroActivity.EXTRA_ROM_PATH, romFile.absolutePath)
             putExtra(LibretroActivity.EXTRA_VARIANT_FILE_ID, variantFileId ?: -1L)
@@ -535,7 +538,7 @@ class GameLauncher @Inject constructor(
             putExtra(LibretroActivity.EXTRA_CORE_VAR_KEYS, coreVariables.map { it.key }.toTypedArray())
             putExtra(LibretroActivity.EXTRA_CORE_VAR_VALUES, coreVariables.map { it.value }.toTypedArray())
             effectiveSavePath?.let { putExtra(LibretroActivity.EXTRA_SAVES_DIR, it) }
-            effectiveStatePath?.let { putExtra(LibretroActivity.EXTRA_STATES_DIR, it) }
+            putExtra(LibretroActivity.EXTRA_STATES_DIR, effectiveStatePath)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
     }

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
@@ -88,7 +88,8 @@ class GameLauncher @Inject constructor(
     private val gameFileDao: GameFileDao,
     private val emulatorSaveConfigRepository: com.nendo.argosy.data.repository.EmulatorSaveConfigRepository,
     private val saveHandlerRegistry: com.nendo.argosy.data.sync.platform.PlatformSaveHandlerRegistry,
-    private val libretroStatePathResolver: LibretroStatePathResolver
+    private val libretroStatePathResolver: LibretroStatePathResolver,
+    private val notificationManager: com.nendo.argosy.core.notification.NotificationManager
 ) {
     private val shellAmAvailable: Boolean by lazy {
         try {
@@ -1064,11 +1065,13 @@ class GameLauncher @Inject constructor(
     private suspend fun resolveBuiltinCoreId(game: GameEntity): String? {
         val validCoreIds = com.nendo.argosy.libretro.LibretroCoreRegistry
             .getCoresForPlatform(game.platformSlug).map { it.coreId }.toSet()
+        var rejectedCore: String? = null
 
         fun accept(coreId: String?, source: String): String? {
             if (coreId.isNullOrBlank()) return null
             if (coreId !in validCoreIds) {
                 Logger.warn(TAG, "[BuiltIn] ignoring unknown core '$coreId' from $source for ${game.platformSlug}")
+                if (rejectedCore == null) rejectedCore = coreId
                 return null
             }
             Logger.debug(TAG, "[BuiltIn] core selection: $source -> $coreId")
@@ -1082,8 +1085,22 @@ class GameLauncher @Inject constructor(
         val default = com.nendo.argosy.libretro.LibretroCoreRegistry
             .getDefaultCoreForPlatform(game.platformSlug)?.coreId
         Logger.debug(TAG, "[BuiltIn] core selection: registry default -> $default")
+
+        // The configured core isn't available for the built-in player. Tell the user instead of
+        // silently substituting a different core -- a silent swap can also silently break saves
+        // (e.g. a vba_next save opened by mGBA).
+        val rejected = rejectedCore
+        if (rejected != null && default != null) {
+            notificationManager.show(
+                title = "Failed to load ${builtinCoreDisplayName(rejected)}, using ${builtinCoreDisplayName(default)} instead",
+                type = com.nendo.argosy.core.notification.NotificationType.WARNING
+            )
+        }
         return default
     }
+
+    private fun builtinCoreDisplayName(coreId: String): String =
+        com.nendo.argosy.libretro.LibretroCoreRegistry.getCoreById(coreId)?.displayName ?: coreId
 
     private suspend fun resolveCoreName(game: GameEntity): String? {
         val gameConfig = emulatorConfigDao.getByGameId(game.id)

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/LibretroStatePathResolver.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/LibretroStatePathResolver.kt
@@ -1,0 +1,49 @@
+package com.nendo.argosy.data.emulator
+
+import android.content.Context
+import com.nendo.argosy.data.local.dao.GameDao
+import com.nendo.argosy.data.local.dao.PlatformLibretroSettingsDao
+import com.nendo.argosy.data.preferences.UserPreferencesRepository
+import com.nendo.argosy.libretro.LibretroStateSlots
+import com.nendo.argosy.util.AppPaths
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.first
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Single source of truth for the built-in libretro core's FLAT live save-state directory.
+ *
+ * Live states are flat ({base}/rom.state.X), mirroring SRAM and external emulators; channels
+ * live only in the cache. The base dir mirrors the precedence [GameLauncher] uses when it builds
+ * the launch intent: per-platform override -> global custom path -> default
+ * ({filesDir}/libretro/states). Routing the cache/restore side through here keeps it in step with
+ * the live engine and fixes the old bug where the cache side used StatePathRegistry's unexpanded
+ * "{filesDir}/libretro/states" token for built-in.
+ *
+ * Keyed by gameId because the cache/restore callers have a gameId but not always the numeric
+ * platformId the per-platform override is keyed on. Variant isolation ({base}/variants/{id}) is
+ * applied by LibretroActivity at launch and is not modelled here (cache/restore is non-variant).
+ */
+@Singleton
+class LibretroStatePathResolver @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val gameDao: GameDao,
+    private val platformLibretroSettingsDao: PlatformLibretroSettingsDao,
+    private val userPreferencesRepository: UserPreferencesRepository,
+) {
+    suspend fun liveStateBaseDir(gameId: Long): File {
+        val platformId = gameDao.getById(gameId)?.platformId
+        val platformOverride = platformId
+            ?.let { platformLibretroSettingsDao.getByPlatformId(it)?.statePath }
+            ?.takeIf { it.isNotBlank() }
+        val custom = userPreferencesRepository.getBuiltinEmulatorSettings().first()
+            .customStatePath?.takeIf { it.isNotBlank() }
+        val base = platformOverride ?: custom ?: AppPaths.libretroStatesDir(context.filesDir).absolutePath
+        return File(base)
+    }
+
+    fun liveStateFile(baseDir: File, romBaseName: String, slotNumber: Int): File =
+        File(baseDir, LibretroStateSlots.fileName(romBaseName, slotNumber))
+}

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/LibretroStatePathResolver.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/LibretroStatePathResolver.kt
@@ -35,12 +35,19 @@ class LibretroStatePathResolver @Inject constructor(
 ) {
     suspend fun liveStateBaseDir(gameId: Long): File {
         val platformId = gameDao.getById(gameId)?.platformId
-        val platformOverride = platformId
-            ?.let { platformLibretroSettingsDao.getByPlatformId(it)?.statePath }
-            ?.takeIf { it.isNotBlank() }
-        val custom = userPreferencesRepository.getBuiltinEmulatorSettings().first()
-            .customStatePath?.takeIf { it.isNotBlank() }
-        val base = platformOverride ?: custom ?: AppPaths.libretroStatesDir(context.filesDir).absolutePath
+        val platformOverride = platformId?.let { platformLibretroSettingsDao.getByPlatformId(it)?.statePath }
+        val custom = userPreferencesRepository.getBuiltinEmulatorSettings().first().customStatePath
+        return liveStateBaseDir(platformOverride, custom)
+    }
+
+    /**
+     * Overload for callers ([GameLauncher]) that already hold the resolved per-platform override and
+     * custom paths -- avoids the extra game/platform/prefs lookups the gameId overload performs.
+     */
+    fun liveStateBaseDir(platformStatePath: String?, customStatePath: String?): File {
+        val base = platformStatePath?.takeIf { it.isNotBlank() }
+            ?: customStatePath?.takeIf { it.isNotBlank() }
+            ?: AppPaths.libretroStatesDir(context.filesDir).absolutePath
         return File(base)
     }
 

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/BuiltinEmulatorPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/BuiltinEmulatorPreferencesRepository.kt
@@ -48,6 +48,7 @@ class BuiltinEmulatorPreferencesRepository @Inject constructor(
         val BUILTIN_AUTO_RESTORE_STATE = booleanPreferencesKey("builtin_auto_restore_state")
         val BUILTIN_AUTO_RESTORE_STATE_MODE = stringPreferencesKey("builtin_auto_restore_state_mode")
         val BUILTIN_HW_CORE_SAVE_STATES = booleanPreferencesKey("builtin_hw_core_save_states")
+        val BUILTIN_DEFAULT_TO_HARDCORE = booleanPreferencesKey("builtin_default_to_hardcore")
         val BUILTIN_CUSTOM_SAVE_PATH = stringPreferencesKey("builtin_custom_save_path")
         val BUILTIN_CUSTOM_STATE_PATH = stringPreferencesKey("builtin_custom_state_path")
         val BUILTIN_MIGRATION_V1 = booleanPreferencesKey("builtin_migration_v2")
@@ -101,6 +102,7 @@ class BuiltinEmulatorPreferencesRepository @Inject constructor(
                 ?: (prefs[Keys.BUILTIN_AUTO_RESTORE_STATE_MODE] != "off"),
             autoRestoreStateMode = prefs[Keys.BUILTIN_AUTO_RESTORE_STATE_MODE] ?: "restore",
             hwCoreSaveStatesEnabled = prefs[Keys.BUILTIN_HW_CORE_SAVE_STATES] ?: false,
+            defaultToHardcore = prefs[Keys.BUILTIN_DEFAULT_TO_HARDCORE] ?: false,
             customSavePath = prefs[Keys.BUILTIN_CUSTOM_SAVE_PATH],
             customStatePath = prefs[Keys.BUILTIN_CUSTOM_STATE_PATH],
             architectureOverride = prefs[Keys.BUILTIN_ARCHITECTURE_OVERRIDE],
@@ -275,6 +277,10 @@ class BuiltinEmulatorPreferencesRepository @Inject constructor(
 
     suspend fun setBuiltinHwCoreSaveStates(enabled: Boolean) {
         dataStore.edit { it[Keys.BUILTIN_HW_CORE_SAVE_STATES] = enabled }
+    }
+
+    suspend fun setBuiltinDefaultToHardcore(enabled: Boolean) {
+        dataStore.edit { it[Keys.BUILTIN_DEFAULT_TO_HARDCORE] = enabled }
     }
 
     suspend fun setBuiltinCustomSavePath(path: String?) {

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
@@ -421,6 +421,7 @@ data class BuiltinEmulatorSettings(
     val autoRestoreState: Boolean = true,
     val autoRestoreStateMode: String = "restore",
     val hwCoreSaveStatesEnabled: Boolean = false,
+    val defaultToHardcore: Boolean = false,
     val customSavePath: String? = null,
     val customStatePath: String? = null,
     val architectureOverride: String? = null,

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/LibretroSettingsRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/LibretroSettingsRepository.kt
@@ -125,6 +125,9 @@ class LibretroSettingsRepository @Inject constructor(
     suspend fun setBuiltinHwCoreSaveStates(enabled: Boolean) =
         builtinPrefs.setBuiltinHwCoreSaveStates(enabled)
 
+    suspend fun setBuiltinDefaultToHardcore(enabled: Boolean) =
+        builtinPrefs.setBuiltinDefaultToHardcore(enabled)
+
     suspend fun setBuiltinCustomSavePath(path: String?) =
         builtinPrefs.setBuiltinCustomSavePath(path)
 

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/SaveSyncApiClient.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/SaveSyncApiClient.kt
@@ -463,11 +463,17 @@ class SaveSyncApiClient @Inject constructor(
         internal const val MIN_VALID_SAVE_SIZE_BYTES = 100L
         internal const val AUTOCLEANUP_LIMIT = 10
 
+        /**
+         * The autosave channel is stored as either null or the literal "autosave" (a restore sets
+         * the string form); recognize both so callers do not each re-inline the check.
+         */
+        fun isAutosaveChannel(channelName: String?): Boolean =
+            channelName == null || channelName.equals(AUTOSAVE_SLOT_NAME, ignoreCase = true)
+
         fun computeUploadFileName(localSavePath: String?, channelName: String?, romBaseName: String?): String {
             val baseName = when {
-                channelName == null || channelName.equals(AUTOSAVE_SLOT_NAME, ignoreCase = true) ->
-                    romBaseName ?: DEFAULT_SAVE_NAME
-                else -> channelName
+                isAutosaveChannel(channelName) -> romBaseName ?: DEFAULT_SAVE_NAME
+                else -> channelName ?: DEFAULT_SAVE_NAME
             }
             val ext = localSavePath?.let { java.io.File(it) }?.let { file ->
                 when {

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/SaveUploader.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/SaveUploader.kt
@@ -313,8 +313,6 @@ class SaveUploader @Inject constructor(
             val filePart = MultipartBody.Part.createFormData("saveFile", uploadFileName, requestBody)
 
             val slotForUpload = channelName ?: SaveSyncApiClient.AUTOSAVE_SLOT_NAME
-            // Autocleanup must fire for autosave in both its null and "autosave"-string forms (a
-            // restore sets the string form), else the server-side autosave history grows unbounded.
             val isAutosaveSlot = SaveSyncApiClient.isAutosaveChannel(channelName)
             val autocleanupEnabled = isAutosaveSlot
             val autocleanupLimit = if (isAutosaveSlot) SaveSyncApiClient.AUTOCLEANUP_LIMIT else null

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/SaveUploader.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/SaveUploader.kt
@@ -313,7 +313,11 @@ class SaveUploader @Inject constructor(
             val filePart = MultipartBody.Part.createFormData("saveFile", uploadFileName, requestBody)
 
             val slotForUpload = channelName ?: SaveSyncApiClient.AUTOSAVE_SLOT_NAME
-            val isAutosaveSlot = channelName == null
+            // The autosave channel is represented as either null or the literal "autosave" (a
+            // restore sets the string form); recognize both, else autocleanup is skipped after a
+            // restore and the server-side autosave history grows unbounded.
+            val isAutosaveSlot = channelName == null ||
+                channelName.equals(SaveSyncApiClient.AUTOSAVE_SLOT_NAME, ignoreCase = true)
             val autocleanupEnabled = isAutosaveSlot
             val autocleanupLimit = if (isAutosaveSlot) SaveSyncApiClient.AUTOCLEANUP_LIMIT else null
             val response = if (deviceId != null) {

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/SaveUploader.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/SaveUploader.kt
@@ -313,11 +313,9 @@ class SaveUploader @Inject constructor(
             val filePart = MultipartBody.Part.createFormData("saveFile", uploadFileName, requestBody)
 
             val slotForUpload = channelName ?: SaveSyncApiClient.AUTOSAVE_SLOT_NAME
-            // The autosave channel is represented as either null or the literal "autosave" (a
-            // restore sets the string form); recognize both, else autocleanup is skipped after a
-            // restore and the server-side autosave history grows unbounded.
-            val isAutosaveSlot = channelName == null ||
-                channelName.equals(SaveSyncApiClient.AUTOSAVE_SLOT_NAME, ignoreCase = true)
+            // Autocleanup must fire for autosave in both its null and "autosave"-string forms (a
+            // restore sets the string form), else the server-side autosave history grows unbounded.
+            val isAutosaveSlot = SaveSyncApiClient.isAutosaveChannel(channelName)
             val autocleanupEnabled = isAutosaveSlot
             val autocleanupLimit = if (isAutosaveSlot) SaveSyncApiClient.AUTOCLEANUP_LIMIT else null
             val response = if (deviceId != null) {

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/StateCacheManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/StateCacheManager.kt
@@ -596,9 +596,6 @@ class StateCacheManager @Inject constructor(
             else -> StatePathRegistry.resolvePath(config, platformSlug)
         }
 
-        // An explicitly-restored save (or state) must not be overridden by a lingering
-        // auto-resume state, so drop both the auto and resume slots from the live dir.
-        // (resume is built-in-only; deleting a non-existent file elsewhere is a no-op.)
         val fileNames = listOf(
             config.slotPattern.buildFileName(romBaseName, -1),
             com.nendo.argosy.libretro.LibretroStateSlots.fileName(

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/StateCacheManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/StateCacheManager.kt
@@ -62,6 +62,7 @@ class StateCacheManager @Inject constructor(
     private val coreVersionExtractor: CoreVersionExtractor,
     private val retroArchConfigParser: RetroArchConfigParser,
     private val retroArchPathResolver: com.nendo.argosy.data.emulator.RetroArchPathResolver,
+    private val libretroStatePathResolver: com.nendo.argosy.data.emulator.LibretroStatePathResolver,
     private val saveSyncApiClient: SaveSyncApiClient,
     private val payloadCodec: com.nendo.argosy.data.sync.SyncPayloadCodec
 ) {
@@ -134,13 +135,7 @@ class StateCacheManager @Inject constructor(
                 retroArchPathResolver.resolveStateDirectories(req)
             }
             userStateOverride != null -> listOf(userStateOverride)
-            emulatorId == "builtin" -> {
-                val baseDir = AppPaths.libretroStatesDir(context.filesDir)
-                val channelDirs = baseDir.listFiles { f -> f.isDirectory }
-                    ?.map { it.absolutePath }
-                    ?: listOf(File(baseDir, "default").absolutePath)
-                channelDirs
-            }
+            emulatorId == "builtin" -> listOf(libretroStatePathResolver.liveStateBaseDir(gameId).absolutePath)
             else -> StatePathRegistry.resolvePath(config, platformId)
         }
         Log.d(TAG, "Searching ${statePaths.size} paths: $statePaths")
@@ -487,7 +482,12 @@ class StateCacheManager @Inject constructor(
         emulatorId: String? = null,
         coreName: String? = null,
         romPath: String? = null,
+        gameId: Long? = null,
     ): String? {
+        if (emulatorId == "builtin" && gameId != null) {
+            val baseDir = libretroStatePathResolver.liveStateBaseDir(gameId)
+            return libretroStatePathResolver.liveStateFile(baseDir, romBaseName, slotNumber).absolutePath
+        }
         val paths = if (emulatorId != null &&
             com.nendo.argosy.data.emulator.RetroArchPathResolver.isRetroArch(emulatorId)
         ) {
@@ -560,16 +560,17 @@ class StateCacheManager @Inject constructor(
     suspend fun getStatesForChannelAndCore(gameId: Long, channelName: String?, coreId: String?): List<StateCacheEntity> =
         stateCacheDao.getByChannelAndCore(gameId, channelName, coreId)
 
-    suspend fun deleteAutoStateFromDisk(
+    suspend fun deleteAutoResumeStatesFromDisk(
         emulatorId: String,
         romPath: String,
         platformSlug: String,
         emulatorPackage: String?,
-        coreId: String?
+        coreId: String?,
+        gameId: Long? = null,
     ): Boolean = withContext(Dispatchers.IO) {
         val config = StatePathRegistry.getConfig(emulatorId)
         if (config == null) {
-            Log.d(TAG, "deleteAutoStateFromDisk: No state config for emulator: $emulatorId")
+            Log.d(TAG, "deleteAutoResumeStatesFromDisk: No state config for emulator: $emulatorId")
             return@withContext false
         }
 
@@ -590,26 +591,36 @@ class StateCacheManager @Inject constructor(
                 retroArchPathResolver.resolveStateDirectories(req)
             }
             userStateOverride != null -> listOf(userStateOverride)
+            emulatorId == "builtin" && gameId != null ->
+                listOf(libretroStatePathResolver.liveStateBaseDir(gameId).absolutePath)
             else -> StatePathRegistry.resolvePath(config, platformSlug)
         }
 
-        val autoFileName = config.slotPattern.buildFileName(romBaseName, -1)
+        // An explicitly-restored save (or state) must not be overridden by a lingering
+        // auto-resume state, so drop both the auto and resume slots from the live dir.
+        // (resume is built-in-only; deleting a non-existent file elsewhere is a no-op.)
+        val fileNames = listOf(
+            config.slotPattern.buildFileName(romBaseName, -1),
+            com.nendo.argosy.libretro.LibretroStateSlots.fileName(
+                romBaseName, com.nendo.argosy.libretro.LibretroStateSlots.RESUME_SLOT
+            ),
+        )
 
+        var deletedAny = false
         for (path in statePaths) {
             val stateDir = File(path)
             if (!stateDir.exists()) continue
-
-            val autoStateFile = File(stateDir, autoFileName)
-            if (autoStateFile.exists()) {
-                autoStateFile.delete()
-                File("${autoStateFile.absolutePath}.png").takeIf { it.exists() }?.delete()
-                Log.d(TAG, "Deleted auto-state from disk: ${autoStateFile.absolutePath}")
-                return@withContext true
+            for (name in fileNames) {
+                val file = File(stateDir, name)
+                if (file.exists() && file.delete()) {
+                    File("${file.absolutePath}.png").takeIf { it.exists() }?.delete()
+                    Log.d(TAG, "Deleted live state: ${file.absolutePath}")
+                    deletedAny = true
+                }
             }
         }
-
-        Log.d(TAG, "deleteAutoStateFromDisk: No auto-state found for $romBaseName")
-        false
+        if (!deletedAny) Log.d(TAG, "deleteAutoResumeStatesFromDisk: nothing to delete for $romBaseName")
+        deletedAny
     }
 
     suspend fun clearAllCache() = withContext(Dispatchers.IO) {

--- a/app/src/main/kotlin/com/nendo/argosy/domain/usecase/save/GetUnifiedSavesUseCase.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/domain/usecase/save/GetUnifiedSavesUseCase.kt
@@ -23,7 +23,8 @@ class GetUnifiedSavesUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(
         gameId: Long,
-        expandHistory: Boolean = false
+        expandHistory: Boolean = false,
+        includeServer: Boolean = true
     ): List<UnifiedSaveEntry> {
         saveCacheManager.dedupeIdenticalCaches(gameId)
         val localCaches = saveCacheManager.getCachesForGameOnce(gameId)
@@ -31,7 +32,7 @@ class GetUnifiedSavesUseCase @Inject constructor(
         val rommId = game?.rommId
         val romBaseName = game?.localPath?.let { File(it).nameWithoutExtension }
 
-        val serverSaves = if (rommId != null) {
+        val serverSaves = if (rommId != null && includeServer) {
             saveSyncRepository.checkSavesForGame(gameId, rommId)
         } else {
             emptyList()

--- a/app/src/main/kotlin/com/nendo/argosy/domain/usecase/state/RestoreCachedStatesUseCase.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/domain/usecase/state/RestoreCachedStatesUseCase.kt
@@ -30,6 +30,7 @@ class RestoreCachedStatesUseCase @Inject constructor(
     private val coreVersionExtractor: CoreVersionExtractor,
     private val retroArchConfigParser: RetroArchConfigParser,
     private val retroArchPathResolver: com.nendo.argosy.data.emulator.RetroArchPathResolver,
+    private val libretroStatePathResolver: com.nendo.argosy.data.emulator.LibretroStatePathResolver,
 ) {
     suspend operator fun invoke(
         gameId: Long,
@@ -84,6 +85,7 @@ class RestoreCachedStatesUseCase @Inject constructor(
                 retroArchPathResolver.resolveStateDirectories(req)
             }
             userStateOverride != null -> listOf(userStateOverride)
+            emulatorId == "builtin" -> listOf(libretroStatePathResolver.liveStateBaseDir(gameId).absolutePath)
             else -> StatePathRegistry.resolvePath(config, game.platformSlug)
         }
 

--- a/app/src/main/kotlin/com/nendo/argosy/domain/usecase/state/RestoreStateUseCase.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/domain/usecase/state/RestoreStateUseCase.kt
@@ -63,6 +63,7 @@ class RestoreStateUseCase @Inject constructor(
             emulatorId = emulatorId,
             coreName = currentCoreId,
             romPath = romPath,
+            gameId = cache.gameId,
         ) ?: return RestoreStateResult.Error("Could not determine target path")
 
         val success = stateCacheManager.restoreState(cacheId, targetPath)

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/CoreCrashController.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/CoreCrashController.kt
@@ -41,7 +41,7 @@ class CoreCrashController @Inject constructor(
     suspend fun runBootDetection() {
         val crash = crashDetector.detect() ?: return
         val game = gameDao.getById(crash.gameId) ?: return
-        val displayName = LibretroCoreRegistry.getCoreById(crash.coreId)?.displayName ?: crash.coreId
+        val displayName = LibretroCoreRegistry.displayNameFor(crash.coreId)
         history = coreManager.getCoreHistory(crash.coreId)
 
         val options = buildList {

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroActivity.kt
@@ -636,6 +636,10 @@ class LibretroActivity : ComponentActivity() {
                             Log.i(TAG, "[Startup] First frame rendered - emulation running successfully")
                             Log.d(TAG, "[Startup] gameId=$gameId, core=$coreName, hardcore=$hardcoreMode")
                             checkStateSupport()
+                            if (retroView.sramLoadFailed) {
+                                Log.w(TAG, "[Startup] SRAM failed to load (size mismatch); booting with a fresh save")
+                                inGameMessage = "Failed to load save, using new save instead"
+                            }
                             attemptAutoRestore()
                             netplay.triggerPendingNetplayJoin()
                         }

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroActivity.kt
@@ -203,6 +203,7 @@ class LibretroActivity : ComponentActivity() {
     private var activeMenuHandler: InputHandler? = null
 
     private var restoredSram: ByteArray? = null
+    private var casualSaveInHardcore: Boolean = false
     private var hardcoreMode by mutableStateOf(false)
     private var launchMode = LaunchMode.RESUME
     private var statesSupported = true
@@ -489,6 +490,7 @@ class LibretroActivity : ComponentActivity() {
             saveStateManager.restoreSaveForLaunchMode(launchMode)
         }
         restoredSram = restoreResult.sramData
+        casualSaveInHardcore = restoreResult.casualSaveInHardcore
         if (restoreResult.switchToHardcore) {
             hardcoreMode = true
         }
@@ -639,6 +641,8 @@ class LibretroActivity : ComponentActivity() {
                             if (retroView.sramLoadFailed) {
                                 Log.w(TAG, "[Startup] SRAM failed to load (size mismatch); booting with a fresh save")
                                 inGameMessage = "Failed to load save, using new save instead"
+                            } else if (casualSaveInHardcore) {
+                                inGameMessage = "Continuing casual save in hardcore"
                             }
                             attemptAutoRestore()
                             netplay.triggerPendingNetplayJoin()
@@ -1525,9 +1529,6 @@ class LibretroActivity : ComponentActivity() {
                     try {
                         withContext(kotlinx.coroutines.Dispatchers.IO + kotlinx.coroutines.NonCancellable) {
                             performAutoSaveState()
-                            // Flush live SRAM to disk before caching. cacheCurrentSessionForQuit
-                            // reads the .srm off disk, so caching first snapshots the pre-session
-                            // save and that stale cache overwrites the fresh one on next resume.
                             if (!isGuestJoinedSession) {
                                 saveStateManager.saveSram(retroView)
                             }

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroActivity.kt
@@ -1521,6 +1521,12 @@ class LibretroActivity : ComponentActivity() {
                     try {
                         withContext(kotlinx.coroutines.Dispatchers.IO + kotlinx.coroutines.NonCancellable) {
                             performAutoSaveState()
+                            // Flush live SRAM to disk before caching. cacheCurrentSessionForQuit
+                            // reads the .srm off disk, so caching first snapshots the pre-session
+                            // save and that stale cache overwrites the fresh one on next resume.
+                            if (!isGuestJoinedSession) {
+                                saveStateManager.saveSram(retroView)
+                            }
                             try {
                                 playSessionTracker.cacheCurrentSessionForQuit()
                             } catch (e: Exception) {
@@ -1530,9 +1536,6 @@ class LibretroActivity : ComponentActivity() {
                                 playSessionTracker.cacheCurrentSessionStatesForQuit()
                             } catch (e: Exception) {
                                 Log.w(TAG, "Pre-quit state cache failed", e)
-                            }
-                            if (!isGuestJoinedSession) {
-                                saveStateManager.saveSram(retroView)
                             }
                             coreDestroyed = true
                             retroView.destroyNative()

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroCoreRegistry.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroCoreRegistry.kt
@@ -95,7 +95,7 @@ object LibretroCoreRegistry {
             coreId = "vba_next",
             fileName = "vba_next_libretro_android.so",
             displayName = "VBA Next",
-            platforms = setOf("gb", "gbc", "gba"),
+            platforms = setOf("gba"),
             estimatedSizeBytes = 2_000_000L
         ),
 

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroCoreRegistry.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroCoreRegistry.kt
@@ -512,6 +512,9 @@ object LibretroCoreRegistry {
 
     fun getCoreById(coreId: String): CoreInfo? = cores.find { it.coreId == coreId }
 
+    /** Human-readable name for a core id, falling back to the raw id when the core is unknown. */
+    fun displayNameFor(coreId: String): String = getCoreById(coreId)?.displayName ?: coreId
+
     private val hardwareRenderedCores = setOf(
         "dolphin", "flycast", "mupen64plus_next_gles3", "mupen64plus_next_gles2",
         "parallel_n64", "ppsspp", "mednafen_psx_hw"

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroCoreRegistry.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroCoreRegistry.kt
@@ -91,6 +91,13 @@ object LibretroCoreRegistry {
             estimatedSizeBytes = 2_000_000L,
             requiresBios = listOf("gba_bios.bin")
         ),
+        CoreInfo(
+            coreId = "vba_next",
+            fileName = "vba_next_libretro_android.so",
+            displayName = "VBA Next",
+            platforms = setOf("gb", "gbc", "gba"),
+            estimatedSizeBytes = 2_000_000L
+        ),
 
         // Nintendo 64
         CoreInfo(

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroStateSlots.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroStateSlots.kt
@@ -1,0 +1,24 @@
+package com.nendo.argosy.libretro
+
+/**
+ * Canonical on-disk naming for built-in libretro save-state slots. Live states are flat
+ * ({statesDir}/rom.state.X) -- mirroring SRAM and external emulators -- with channels held
+ * only in the cache. This is the single source of truth for slot <-> filename, shared by
+ * SaveStateManager (live engine) and StateCacheManager (cache/restore).
+ */
+object LibretroStateSlots {
+    const val AUTO_SLOT = -1
+    const val RESUME_SLOT = -2
+    const val MAX_SLOT = 9
+    const val QUICK_SLOT_BASE = 100
+    const val QUICK_RING_SIZE = 10
+
+    fun fileName(romBaseName: String, slotNumber: Int): String = when (slotNumber) {
+        AUTO_SLOT -> "$romBaseName.state.auto"
+        RESUME_SLOT -> "$romBaseName.state.resume"
+        in QUICK_SLOT_BASE until QUICK_SLOT_BASE + QUICK_RING_SIZE ->
+            "$romBaseName.state.q${slotNumber - QUICK_SLOT_BASE}"
+        0 -> "$romBaseName.state"
+        else -> "$romBaseName.state$slotNumber"
+    }
+}

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/SaveStateManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/SaveStateManager.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.nendo.argosy.data.emulator.EmulatorRegistry
 import com.nendo.argosy.data.local.dao.GameDao
+import com.nendo.argosy.data.local.entity.GameEntity
 import com.nendo.argosy.data.repository.SaveCacheManager
 import com.swordfish.libretrodroid.GLRetroView
 import java.io.File
@@ -114,15 +115,21 @@ class SaveStateManager(
             return RestoreResult(bytes)
         }
 
+        // Resume paths read the game row once and thread it through to restoreResumeSave.
+        val game = if (launchMode == LaunchMode.RESUME || launchMode == LaunchMode.RESUME_HARDCORE) {
+            gameDao.getById(gameId)
+        } else {
+            null
+        }
+
         // An explicit save-management restore must win over the default resume pick. The restore
         // already wrote the chosen save to the live .srm and set activeSaveApplied (cleared on
         // session end), so load that as-is instead of re-deriving from the cache -- otherwise the
         // hardcore path (getLatestHardcoreSave) or the timestamp lookup can silently clobber the
         // user's choice with a different save.
-        if (launchMode == LaunchMode.RESUME || launchMode == LaunchMode.RESUME_HARDCORE) {
-            val game = gameDao.getById(gameId)
+        if (game?.activeSaveApplied == true) {
             val sramFile = getSramFile()
-            if (game?.activeSaveApplied == true && sramFile.exists()) {
+            if (sramFile.exists()) {
                 val bytes = sramFile.readBytes()
                 Log.i(TAG, "Honoring explicit restore (activeSaveApplied): on-disk .srm ${bytes.size} bytes")
                 return RestoreResult(bytes)
@@ -173,15 +180,14 @@ class SaveStateManager(
                     // starting fresh. hardcoreMode is already set from the launch mode, so the
                     // session stays hardcore and saves made from here get tagged hardcore.
                     Log.d(TAG, "No hardcore save; using active save for hardcore session")
-                    restoreResumeSave()
+                    restoreResumeSave(game)
                 }
             }
-            LaunchMode.RESUME -> restoreResumeSave()
+            LaunchMode.RESUME -> restoreResumeSave(game)
         }
     }
 
-    private suspend fun restoreResumeSave(): RestoreResult {
-        val game = gameDao.getById(gameId)
+    private suspend fun restoreResumeSave(game: GameEntity?): RestoreResult {
         val activeSaveTimestamp = game?.activeSaveTimestamp
         val activeChannel = game?.activeSaveChannel
 

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/SaveStateManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/SaveStateManager.kt
@@ -114,6 +114,21 @@ class SaveStateManager(
             return RestoreResult(bytes)
         }
 
+        // An explicit save-management restore must win over the default resume pick. The restore
+        // already wrote the chosen save to the live .srm and set activeSaveApplied (cleared on
+        // session end), so load that as-is instead of re-deriving from the cache -- otherwise the
+        // hardcore path (getLatestHardcoreSave) or the timestamp lookup can silently clobber the
+        // user's choice with a different save.
+        if (launchMode == LaunchMode.RESUME || launchMode == LaunchMode.RESUME_HARDCORE) {
+            val game = gameDao.getById(gameId)
+            val sramFile = getSramFile()
+            if (game?.activeSaveApplied == true && sramFile.exists()) {
+                val bytes = sramFile.readBytes()
+                Log.i(TAG, "Honoring explicit restore (activeSaveApplied): on-disk .srm ${bytes.size} bytes")
+                return RestoreResult(bytes)
+            }
+        }
+
         return when (launchMode) {
             LaunchMode.NEW_HARDCORE, LaunchMode.NEW_CASUAL -> {
                 Log.d(TAG, "New game mode - starting fresh (no save)")

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/SaveStateManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/SaveStateManager.kt
@@ -21,14 +21,13 @@ class SaveStateManager(
     private val gameDao: GameDao,
     private val saveCacheManager: SaveCacheManager,
     private val usesExternalMemcard: Boolean = false,
-    channelName: String? = null,
+    private val channelName: String? = null,
     private val isVariant: Boolean = false
 ) {
     private var lastSramHash: String? = null
     var hasQuickSave by mutableStateOf(false)
         private set
 
-    private val channelDir: File = resolveChannelDir(channelName)
     private val romBaseName: String = File(romPath).nameWithoutExtension
 
     data class RestoreResult(
@@ -46,18 +45,18 @@ class SaveStateManager(
 
     fun initializeFromExistingSave(existingSram: ByteArray?) {
         lastSramHash = existingSram?.let { hashBytes(it) }
-        migrateExistingFlatFiles()
-        channelDir.mkdirs()
+        migrateChannelStatesToFlat()
+        statesDir.mkdirs()
         hasQuickSave = quickRingEntries().isNotEmpty()
     }
 
     fun getSlotFile(slotNumber: Int): File {
         val fileName = buildSlotFileName(slotNumber)
-        return File(channelDir, fileName)
+        return File(statesDir, fileName)
     }
 
     fun getSlotScreenshotFile(slotNumber: Int): File {
-        return File(channelDir, "${buildSlotFileName(slotNumber)}.png")
+        return File(statesDir, "${buildSlotFileName(slotNumber)}.png")
     }
 
     fun getSramFile(): File {
@@ -154,8 +153,12 @@ class SaveStateManager(
                     }
                     RestoreResult(bytes)
                 } else {
-                    Log.w(TAG, "No hardcore save found, starting fresh")
-                    RestoreResult(null)
+                    // RetroAchievements permits SRAM battery saves in hardcore (only save
+                    // states are disallowed), so fall back to the active save rather than
+                    // starting fresh. hardcoreMode is already set from the launch mode, so the
+                    // session stays hardcore and saves made from here get tagged hardcore.
+                    Log.d(TAG, "No hardcore save; using active save for hardcore session")
+                    restoreResumeSave()
                 }
             }
             LaunchMode.RESUME -> restoreResumeSave()
@@ -260,7 +263,7 @@ class SaveStateManager(
 
     fun performSlotSave(slotNumber: Int, stateData: ByteArray, screenshot: Bitmap? = null): Boolean {
         return try {
-            channelDir.mkdirs()
+            statesDir.mkdirs()
             val stateFile = getSlotFile(slotNumber)
             stateFile.writeBytes(stateData)
 
@@ -352,37 +355,23 @@ class SaveStateManager(
         hasQuickSave = false
     }
 
-    private fun buildSlotFileName(slotNumber: Int): String {
-        return when (slotNumber) {
-            AUTO_SLOT -> "$romBaseName.state.auto"
-            RESUME_SLOT -> "$romBaseName.state.resume"
-            in QUICK_SLOT_BASE until QUICK_SLOT_BASE + QUICK_RING_SIZE -> "$romBaseName.state.q${slotNumber - QUICK_SLOT_BASE}"
-            0 -> "$romBaseName.state"
-            else -> "$romBaseName.state$slotNumber"
-        }
-    }
+    private fun buildSlotFileName(slotNumber: Int): String =
+        LibretroStateSlots.fileName(romBaseName, slotNumber)
 
-    private fun resolveChannelDir(channelName: String?): File {
-        val dirName = channelName ?: "default"
-        return File(statesDir, dirName)
-    }
-
-    private fun migrateExistingFlatFiles() {
-        val flatStateFile = File(statesDir, "$romBaseName.state")
-        if (flatStateFile.exists() && flatStateFile.parentFile == statesDir) {
-            val defaultDir = File(statesDir, "default")
-            defaultDir.mkdirs()
-
-            val filesToMigrate = statesDir.listFiles { file ->
-                file.isFile && file.name.startsWith("$romBaseName.state")
-            } ?: return
-
-            for (file in filesToMigrate) {
-                val target = File(defaultDir, file.name)
-                if (!target.exists()) {
-                    file.renameTo(target)
-                    Log.d(TAG, "Migrated ${file.name} to default/")
-                }
+    // Live states are now flat under statesDir (mirroring SRAM and external emulators);
+    // channels live only in the cache. One-shot: lift this game's active-channel states
+    // out of the legacy {statesDir}/{channel}/ subdir up to the flat statesDir. Named
+    // channels not migrated here are re-materialized from the cache on channel switch.
+    private fun migrateChannelStatesToFlat() {
+        val legacyChannelDir = File(statesDir, channelName ?: "default")
+        if (legacyChannelDir == statesDir || !legacyChannelDir.isDirectory) return
+        val files = legacyChannelDir.listFiles { file ->
+            file.isFile && file.name.startsWith("$romBaseName.state")
+        } ?: return
+        for (file in files) {
+            val target = File(statesDir, file.name)
+            if (!target.exists() && file.renameTo(target)) {
+                Log.d(TAG, "Migrated ${file.name} from ${legacyChannelDir.name}/ to flat")
             }
         }
     }
@@ -394,11 +383,11 @@ class SaveStateManager(
 
     companion object {
         private const val TAG = "SaveStateManager"
-        const val AUTO_SLOT = -1
-        const val RESUME_SLOT = -2
-        const val MAX_SLOT = 9
-        const val QUICK_SLOT_BASE = 100
-        const val QUICK_RING_SIZE = 10
+        const val AUTO_SLOT = LibretroStateSlots.AUTO_SLOT
+        const val RESUME_SLOT = LibretroStateSlots.RESUME_SLOT
+        const val MAX_SLOT = LibretroStateSlots.MAX_SLOT
+        const val QUICK_SLOT_BASE = LibretroStateSlots.QUICK_SLOT_BASE
+        const val QUICK_RING_SIZE = LibretroStateSlots.QUICK_RING_SIZE
         private const val SCREENSHOT_MAX_WIDTH = 480
     }
 }

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/SaveStateManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/SaveStateManager.kt
@@ -33,7 +33,8 @@ class SaveStateManager(
 
     data class RestoreResult(
         val sramData: ByteArray?,
-        val switchToHardcore: Boolean = false
+        val switchToHardcore: Boolean = false,
+        val casualSaveInHardcore: Boolean = false
     )
 
     data class SlotInfo(
@@ -94,6 +95,13 @@ class SaveStateManager(
         return slots
     }
 
+    /**
+     * Resolves the SRAM to load for [launchMode], writes it to the live .srm, and returns the bytes
+     * plus mode hints. Two non-obvious rules: an explicit save-management restore (activeSaveApplied)
+     * wins over the default resume pick; and RESUME_HARDCORE falls back to the active save when no
+     * hardcore save exists, because RetroAchievements forbids only save states in hardcore, not SRAM
+     * battery saves (that fallback is flagged casualSaveInHardcore so the UI can surface it).
+     */
     suspend fun restoreSaveForLaunchMode(launchMode: LaunchMode): RestoreResult {
         if (usesExternalMemcard) {
             Log.d(TAG, "External memcard (GCI folder) - skipping flat .srm restore")
@@ -115,18 +123,12 @@ class SaveStateManager(
             return RestoreResult(bytes)
         }
 
-        // Resume paths read the game row once and thread it through to restoreResumeSave.
         val game = if (launchMode == LaunchMode.RESUME || launchMode == LaunchMode.RESUME_HARDCORE) {
             gameDao.getById(gameId)
         } else {
             null
         }
 
-        // An explicit save-management restore must win over the default resume pick. The restore
-        // already wrote the chosen save to the live .srm and set activeSaveApplied (cleared on
-        // session end), so load that as-is instead of re-deriving from the cache -- otherwise the
-        // hardcore path (getLatestHardcoreSave) or the timestamp lookup can silently clobber the
-        // user's choice with a different save.
         if (game?.activeSaveApplied == true) {
             val sramFile = getSramFile()
             if (sramFile.exists()) {
@@ -175,12 +177,13 @@ class SaveStateManager(
                     }
                     RestoreResult(bytes)
                 } else {
-                    // RetroAchievements permits SRAM battery saves in hardcore (only save
-                    // states are disallowed), so fall back to the active save rather than
-                    // starting fresh. hardcoreMode is already set from the launch mode, so the
-                    // session stays hardcore and saves made from here get tagged hardcore.
                     Log.d(TAG, "No hardcore save; using active save for hardcore session")
-                    restoreResumeSave(game)
+                    val fallback = restoreResumeSave(game)
+                    if (fallback.sramData != null && !fallback.switchToHardcore) {
+                        fallback.copy(casualSaveInHardcore = true)
+                    } else {
+                        fallback
+                    }
                 }
             }
             LaunchMode.RESUME -> restoreResumeSave(game)
@@ -379,10 +382,12 @@ class SaveStateManager(
     private fun buildSlotFileName(slotNumber: Int): String =
         LibretroStateSlots.fileName(romBaseName, slotNumber)
 
-    // Live states are now flat under statesDir (mirroring SRAM and external emulators);
-    // channels live only in the cache. One-shot: lift this game's active-channel states
-    // out of the legacy {statesDir}/{channel}/ subdir up to the flat statesDir. Named
-    // channels not migrated here are re-materialized from the cache on channel switch.
+    /**
+     * One-shot migration: live states are now flat under statesDir (mirroring SRAM and external
+     * emulators), with channels living only in the cache. Lifts this game's active-channel states out
+     * of the legacy {statesDir}/{channel}/ subdir up to the flat statesDir; named channels not
+     * migrated here are re-materialized from the cache on channel switch.
+     */
     private fun migrateChannelStatesToFlat() {
         val legacyChannelDir = File(statesDir, channelName ?: "default")
         if (legacyChannelDir == statesDir || !legacyChannelDir.isDirectory) return

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/VideoSettingsManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/VideoSettingsManager.kt
@@ -137,7 +137,8 @@ class VideoSettingsManager(
         LibretroSettingDef.RewindBufferDuration -> currentRewindBufferDuration
         LibretroSettingDef.AutoSaveState,
         LibretroSettingDef.AutoRestoreState,
-        LibretroSettingDef.HwCoreSaveStates -> ""
+        LibretroSettingDef.HwCoreSaveStates,
+        LibretroSettingDef.DefaultToHardcore -> ""
     }
 
     fun getGlobalVideoSettingValue(setting: LibretroSettingDef): String = when (setting) {
@@ -162,7 +163,8 @@ class VideoSettingsManager(
         LibretroSettingDef.RewindBufferDuration -> globalSettings.rewindBufferDurationDisplay
         LibretroSettingDef.AutoSaveState,
         LibretroSettingDef.AutoRestoreState,
-        LibretroSettingDef.HwCoreSaveStates -> ""
+        LibretroSettingDef.HwCoreSaveStates,
+        LibretroSettingDef.DefaultToHardcore -> ""
     }
 
     private fun getGlobalFrameForPlatform(): String? {
@@ -241,7 +243,8 @@ class VideoSettingsManager(
                 LibretroSettingDef.RewindBufferDuration -> current.copy(rewindBufferDuration = null)
                 LibretroSettingDef.AutoSaveState,
                 LibretroSettingDef.AutoRestoreState,
-                LibretroSettingDef.HwCoreSaveStates -> current
+                LibretroSettingDef.HwCoreSaveStates,
+                LibretroSettingDef.DefaultToHardcore -> current
             }
             if (updated.hasAnyOverrides()) {
                 platformLibretroSettingsDao.upsert(updated)
@@ -397,7 +400,8 @@ class VideoSettingsManager(
             }
             LibretroSettingDef.AutoSaveState,
             LibretroSettingDef.AutoRestoreState,
-            LibretroSettingDef.HwCoreSaveStates -> {
+            LibretroSettingDef.HwCoreSaveStates,
+            LibretroSettingDef.DefaultToHardcore -> {
             }
         }
 
@@ -484,7 +488,8 @@ class VideoSettingsManager(
                 LibretroSettingDef.RewindBufferDuration -> current.copy(rewindBufferDuration = value.removeSuffix("s").toIntOrNull())
                 LibretroSettingDef.AutoSaveState,
                 LibretroSettingDef.AutoRestoreState,
-                LibretroSettingDef.HwCoreSaveStates -> current
+                LibretroSettingDef.HwCoreSaveStates,
+                LibretroSettingDef.DefaultToHardcore -> current
             }
 
             if (updated.hasAnyOverrides()) {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelModal.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelModal.kt
@@ -911,7 +911,7 @@ private fun DeleteConfirmationOverlay(channelName: String) {
             modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Text(
-            text = "This will remove it from local storage.",
+            text = "This will remove it from the server and local storage. This cannot be undone.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelSavesDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelSavesDelegate.kt
@@ -361,7 +361,16 @@ class SaveChannelSavesDelegate @Inject constructor(
                         )
                         val label = channelName ?: "Auto Save"
                         notificationManager.showSuccess("Using save slot: $label")
-                        _state.update { it.copy(isVisible = false, activeSaveCacheId = entry.localCacheId) }
+                        // Refresh the panel in place so the restored save shows as active,
+                        // rather than closing it. Server restores have a null cacheId, so the
+                        // active marker falls back to the timestamp recorded here.
+                        _state.update {
+                            it.copy(
+                                activeSaveTimestamp = entryTimestamp,
+                                activeSaveCacheId = entry.localCacheId
+                            )
+                        }
+                        refreshEntries()
                         onRestored()
                     }
                     is RestoreCachedSaveUseCase.Result.Error -> {
@@ -469,7 +478,6 @@ class SaveChannelSavesDelegate @Inject constructor(
             _state.update {
                 it.copy(
                     showRestoreConfirmation = false,
-                    isVisible = false,
                     activeChannel = targetChannel,
                     activeSaveTimestamp = targetTimestamp,
                     activeSaveCacheId = entry.localCacheId
@@ -491,6 +499,7 @@ class SaveChannelSavesDelegate @Inject constructor(
                         "Restored to $targetChannel"
                     } else "Save restored"
                     notificationManager.showSuccess(msg)
+                    refreshEntries()
                     onRestored()
                 }
                 is RestoreCachedSaveUseCase.Result.RestoredAndSynced -> {
@@ -500,6 +509,7 @@ class SaveChannelSavesDelegate @Inject constructor(
                         "Restored to $targetChannel and synced"
                     } else "Save restored and synced"
                     notificationManager.showSuccess(msg)
+                    refreshEntries()
                     onRestored()
                 }
                 is RestoreCachedSaveUseCase.Result.Error -> {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelSavesDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelSavesDelegate.kt
@@ -453,12 +453,13 @@ class SaveChannelSavesDelegate @Inject constructor(
                         skipAutoState = true
                     )
                     if (game?.localPath != null) {
-                        stateCacheManager.deleteAutoStateFromDisk(
+                        stateCacheManager.deleteAutoResumeStatesFromDisk(
                             emulatorId = emulatorId,
                             romPath = game.localPath,
                             platformSlug = game.platformSlug,
                             emulatorPackage = emulatorPackage,
-                            coreId = state.currentCoreId
+                            coreId = state.currentCoreId,
+                            gameId = currentGameId
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelSavesDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelSavesDelegate.kt
@@ -361,9 +361,6 @@ class SaveChannelSavesDelegate @Inject constructor(
                         )
                         val label = channelName ?: "Auto Save"
                         notificationManager.showSuccess("Using save slot: $label")
-                        // Refresh the panel in place so the restored save shows as active,
-                        // rather than closing it. Server restores have a null cacheId, so the
-                        // active marker falls back to the timestamp recorded here.
                         _state.update {
                             it.copy(
                                 activeSaveTimestamp = entryTimestamp,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelSavesDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelSavesDelegate.kt
@@ -760,7 +760,15 @@ class SaveChannelSavesDelegate @Inject constructor(
         val channelName = entry.channelName ?: return
 
         scope.launch {
-            entry.localCacheId?.let { saveCacheManager.deleteSave(it) }
+            // Delete every copy of the slot -- local cache AND server. Deleting only the local
+            // cache lets a server-only (or synced) save survive and re-sync back on refresh, so the
+            // delete silently no-ops. (Mirrors confirmDeleteLegacyChannel.)
+            val channelEntries = holder.rawEntries.filter { it.channelName == channelName }
+            val serverIds = channelEntries.mapNotNull { it.serverSaveId }
+            if (serverIds.isNotEmpty()) {
+                saveSyncRepository.deleteServerSaves(serverIds)
+            }
+            channelEntries.forEach { e -> e.localCacheId?.let { saveCacheManager.deleteSave(it) } }
 
             if (state.activeChannel == channelName) {
                 gameRepository.updateActiveSaveChannel(currentGameId, null)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelSavesDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelSavesDelegate.kt
@@ -751,6 +751,18 @@ class SaveChannelSavesDelegate @Inject constructor(
         }
     }
 
+    /**
+     * Delete every copy of a save channel -- local cache entries AND their server saves. Deleting
+     * only the local cache lets a server-only (or synced) save survive and re-sync back on refresh.
+     */
+    private suspend fun deleteChannelEverywhere(channelName: String) {
+        val entries = holder.rawEntries.filter { it.channelName == channelName }
+        entries.mapNotNull { it.serverSaveId }
+            .takeIf { it.isNotEmpty() }
+            ?.let { saveSyncRepository.deleteServerSaves(it) }
+        entries.forEach { entry -> entry.localCacheId?.let { saveCacheManager.deleteSave(it) } }
+    }
+
     fun confirmDeleteChannel(
         scope: CoroutineScope,
         onSaveStatusChanged: (SaveStatusEvent) -> Unit
@@ -760,15 +772,7 @@ class SaveChannelSavesDelegate @Inject constructor(
         val channelName = entry.channelName ?: return
 
         scope.launch {
-            // Delete every copy of the slot -- local cache AND server. Deleting only the local
-            // cache lets a server-only (or synced) save survive and re-sync back on refresh, so the
-            // delete silently no-ops. (Mirrors confirmDeleteLegacyChannel.)
-            val channelEntries = holder.rawEntries.filter { it.channelName == channelName }
-            val serverIds = channelEntries.mapNotNull { it.serverSaveId }
-            if (serverIds.isNotEmpty()) {
-                saveSyncRepository.deleteServerSaves(serverIds)
-            }
-            channelEntries.forEach { e -> e.localCacheId?.let { saveCacheManager.deleteSave(it) } }
+            deleteChannelEverywhere(channelName)
 
             if (state.activeChannel == channelName) {
                 gameRepository.updateActiveSaveChannel(currentGameId, null)
@@ -896,15 +900,7 @@ class SaveChannelSavesDelegate @Inject constructor(
         val channelName = state.deleteLegacyChannelName ?: return
 
         scope.launch {
-            val entries = holder.rawEntries.filter { it.channelName == channelName }
-
-            val serverIds = entries.mapNotNull { it.serverSaveId }
-            if (serverIds.isNotEmpty()) {
-                saveSyncRepository.deleteServerSaves(serverIds)
-            }
-            for (entry in entries) {
-                entry.localCacheId?.let { saveCacheManager.deleteSave(it) }
-            }
+            deleteChannelEverywhere(channelName)
 
             refreshEntries()
             _state.update {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/common/GameLaunchDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/common/GameLaunchDelegate.kt
@@ -112,7 +112,8 @@ class GameLaunchDelegate @Inject constructor(
     private val saveSyncRepository: SaveSyncRepository,
     private val saveCacheManager: SaveCacheManager,
     private val variantResolver: com.nendo.argosy.data.emulator.VariantResolver,
-    private val emulatorSaveConfigRepository: com.nendo.argosy.data.repository.EmulatorSaveConfigRepository
+    private val emulatorSaveConfigRepository: com.nendo.argosy.data.repository.EmulatorSaveConfigRepository,
+    private val retroAchievementsRepository: com.nendo.argosy.data.repository.RetroAchievementsRepository
 ) {
     companion object {
         private const val EMULATOR_KILL_DELAY_MS = 500L
@@ -123,6 +124,16 @@ class GameLaunchDelegate @Inject constructor(
         val save = saveCacheManager.getMostRecentInChannel(gameId, activeChannel)
         return save?.isHardcore == true
     }
+
+    /**
+     * "Default to Hardcore": a built-in game resumes in hardcore by default when the setting is on
+     * and RetroAchievements is signed in (hardcore is only meaningful signed in). Centralized here so
+     * every launch entry point -- home, library, game detail, dual-screen -- honors it uniformly.
+     */
+    private suspend fun shouldDefaultToHardcore(emulatorPackage: String?): Boolean =
+        emulatorPackage == EmulatorRegistry.BUILTIN_PACKAGE &&
+            preferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore &&
+            retroAchievementsRepository.isLoggedIn()
 
     private val _syncOverlayState = MutableStateFlow<SyncOverlayState?>(null)
     val syncOverlayState: StateFlow<SyncOverlayState?> = _syncOverlayState.asStateFlow()
@@ -350,6 +361,7 @@ class GameLaunchDelegate @Inject constructor(
                     hardcoreConflictChoice == HardcoreConflictChoice.KEEP_HARDCORE -> LaunchMode.RESUME_HARDCORE
                     overrideLaunchMode != null -> overrideLaunchMode
                     isActiveSaveHardcore(gameId) -> LaunchMode.RESUME_HARDCORE
+                    shouldDefaultToHardcore(emulatorPackage) -> LaunchMode.RESUME_HARDCORE
                     else -> null
                 }
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/common/GameLaunchDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/common/GameLaunchDelegate.kt
@@ -127,11 +127,18 @@ class GameLaunchDelegate @Inject constructor(
 
     /**
      * "Default to Hardcore": a built-in game resumes in hardcore by default when the setting is on
-     * and RetroAchievements is signed in (hardcore is only meaningful signed in). Centralized here so
-     * every launch entry point -- home, library, game detail, dual-screen -- honors it uniformly.
+     * and RetroAchievements is signed in. Centralized here so every launch entry point (home,
+     * library, game detail, dual-screen) honors it uniformly. Requires the game to actually have
+     * achievements: hardcore mode disables save states, rewind, and cheats regardless of whether an
+     * RA session resolves, so forcing it on an achievement-less game only removes features (and its
+     * hardcore-tagged save would then ratchet future resumes into hardcore).
      */
-    private suspend fun shouldDefaultToHardcore(emulatorPackage: String?): Boolean =
+    private suspend fun shouldDefaultToHardcore(
+        emulatorPackage: String?,
+        game: com.nendo.argosy.data.local.entity.GameEntity
+    ): Boolean =
         emulatorPackage == EmulatorRegistry.BUILTIN_PACKAGE &&
+            game.achievementCount > 0 &&
             preferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore &&
             retroAchievementsRepository.isLoggedIn()
 
@@ -361,7 +368,7 @@ class GameLaunchDelegate @Inject constructor(
                     hardcoreConflictChoice == HardcoreConflictChoice.KEEP_HARDCORE -> LaunchMode.RESUME_HARDCORE
                     overrideLaunchMode != null -> overrideLaunchMode
                     isActiveSaveHardcore(gameId) -> LaunchMode.RESUME_HARDCORE
-                    shouldDefaultToHardcore(emulatorPackage) -> LaunchMode.RESUME_HARDCORE
+                    shouldDefaultToHardcore(emulatorPackage, game) -> LaunchMode.RESUME_HARDCORE
                     else -> null
                 }
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/GameDetailViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/GameDetailViewModel.kt
@@ -838,22 +838,11 @@ class GameDetailViewModel @Inject constructor(
                 }
             }
 
-            // "Default to Hardcore": the modal path pre-focuses hardcore; this covers the direct
-            // launch (a built-in game with a save that skips the modal), which otherwise resumes casual.
-            val overrideLaunchMode = if (
-                currentGame.isBuiltInEmulator && playOptionsDelegate.shouldDefaultToHardcoreResume()
-            ) {
-                com.nendo.argosy.libretro.LaunchMode.RESUME_HARDCORE
-            } else {
-                null
-            }
-
             val callbacks = makeLaunchCallbacks()
             gameLaunchDelegate.launchGame(
                 scope = viewModelScope,
                 gameId = currentGameId,
                 discId = discId,
-                overrideLaunchMode = overrideLaunchMode,
                 onLaunch = callbacks.onLaunch,
                 onLaunchFailed = { callbacks.onLaunchFailed() }
             )

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/GameDetailViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/GameDetailViewModel.kt
@@ -838,11 +838,22 @@ class GameDetailViewModel @Inject constructor(
                 }
             }
 
+            // "Default to Hardcore": the modal path pre-focuses hardcore; this covers the direct
+            // launch (a built-in game with a save that skips the modal), which otherwise resumes casual.
+            val overrideLaunchMode = if (
+                currentGame.isBuiltInEmulator && playOptionsDelegate.shouldDefaultToHardcoreResume()
+            ) {
+                com.nendo.argosy.libretro.LaunchMode.RESUME_HARDCORE
+            } else {
+                null
+            }
+
             val callbacks = makeLaunchCallbacks()
             gameLaunchDelegate.launchGame(
                 scope = viewModelScope,
                 gameId = currentGameId,
                 discId = discId,
+                overrideLaunchMode = overrideLaunchMode,
                 onLaunch = callbacks.onLaunch,
                 onLaunchFailed = { callbacks.onLaunchFailed() }
             )

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
@@ -63,16 +63,18 @@ class PlayOptionsDelegate @Inject constructor(
         _state.value = PlayOptionsState()
     }
 
+    /**
+     * Opens the play-options modal. Save existence (Continue vs New) comes from the unified
+     * local+server view so a server-only cloud save still offers Continue, but the server fetch is
+     * skipped when offline to avoid the sync client's connect timeout.
+     */
     fun showPlayOptions(scope: CoroutineScope, gameId: Long, hasAchievements: Boolean) {
         scope.launch {
-            // Include server-only cloud saves, not just the local cache: a freshly synced RomM
-            // game has its save on the server only and must still offer Continue (otherwise the
-            // modal shows New Game, which would overwrite the cloud save).
-            val entries = getUnifiedSavesUseCase(gameId, expandHistory = false)
+            val isOnline = com.nendo.argosy.util.NetworkUtils.isOnline(context)
+            val entries = getUnifiedSavesUseCase(gameId, expandHistory = false, includeServer = isOnline)
             val hasCasualSaves = entries.any { !it.isHardcore }
             val hasHardcoreSave = entries.any { it.isHardcore }
             val isRALoggedIn = raRepository.isLoggedIn()
-            val isOnline = com.nendo.argosy.util.NetworkUtils.isOnline(context)
             val defaultToHardcore = isDefaultToHardcore()
 
             val newState = PlayOptionsState(
@@ -83,8 +85,6 @@ class PlayOptionsDelegate @Inject constructor(
                 isRALoggedIn = isRALoggedIn,
                 isOnline = isOnline
             )
-            // With "Default to Hardcore" on, pre-focus the Continue-in-Hardcore row so A launches
-            // hardcore (openModal falls back to the first row when that option isn't shown).
             openModal(newState, PlayOptionAction.ResumeHardcore.takeIf { defaultToHardcore })
         }
     }
@@ -123,7 +123,6 @@ class PlayOptionsDelegate @Inject constructor(
     fun confirmPlayOptionSelection(): PlayOptionAction? {
         val state = _state.value
         val action = visibleActions(state).getOrNull(state.playOptionsFocusIndex) ?: return null
-        // Hardcore is online-only.
         if (action == PlayOptionAction.NewHardcore && !state.isOnline) return null
         return action
     }
@@ -134,9 +133,9 @@ class PlayOptionsDelegate @Inject constructor(
         hasAchievements: Boolean
     ): Boolean {
         if (!isBuiltInEmulator || !hasAchievements) return false
-        // Gate on the cheap RA-login check before the networked unified-saves fetch.
         if (!raRepository.isLoggedIn()) return false
-        return getUnifiedSavesUseCase(gameId, expandHistory = false).isEmpty()
+        val isOnline = com.nendo.argosy.util.NetworkUtils.isOnline(context)
+        return getUnifiedSavesUseCase(gameId, expandHistory = false, includeServer = isOnline).isEmpty()
     }
 
     fun showFreshGameModeSelection(scope: CoroutineScope, gameId: Long) {
@@ -150,7 +149,6 @@ class PlayOptionsDelegate @Inject constructor(
                 isRALoggedIn = true,
                 isOnline = isOnline
             )
-            // "Default to Hardcore" pre-focuses New Hardcore (online-only) for a fresh game.
             openModal(newState, PlayOptionAction.NewHardcore.takeIf { isDefaultToHardcore() && isOnline })
         }
     }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
@@ -73,8 +73,7 @@ class PlayOptionsDelegate @Inject constructor(
             val hasHardcoreSave = entries.any { it.isHardcore }
             val isRALoggedIn = raRepository.isLoggedIn()
             val isOnline = com.nendo.argosy.util.NetworkUtils.isOnline(context)
-            val defaultToHardcore = userPreferencesRepository.getBuiltinEmulatorSettings()
-                .first().defaultToHardcore
+            val defaultToHardcore = isDefaultToHardcore()
 
             val newState = PlayOptionsState(
                 showPlayOptions = true,
@@ -142,18 +141,33 @@ class PlayOptionsDelegate @Inject constructor(
     fun showFreshGameModeSelection(scope: CoroutineScope, gameId: Long) {
         scope.launch {
             val isOnline = com.nendo.argosy.util.NetworkUtils.isOnline(context)
-            _state.update {
-                it.copy(
-                    showPlayOptions = true,
-                    playOptionsFocusIndex = 0,
-                    hasCasualSaves = false,
-                    hasHardcoreSave = false,
-                    hasRASupport = true,
-                    isRALoggedIn = true,
-                    isOnline = isOnline
-                )
+            val newState = PlayOptionsState(
+                showPlayOptions = true,
+                hasCasualSaves = false,
+                hasHardcoreSave = false,
+                hasRASupport = true,
+                isRALoggedIn = true,
+                isOnline = isOnline
+            )
+            // "Default to Hardcore" pre-focuses New Hardcore (online-only) for a fresh game.
+            val focusIndex = if (isDefaultToHardcore() && isOnline) {
+                visibleActions(newState).indexOf(PlayOptionAction.NewHardcore).coerceAtLeast(0)
+            } else {
+                0
             }
+            _state.value = newState.copy(playOptionsFocusIndex = focusIndex)
             soundManager.play(SoundType.OPEN_MODAL)
         }
     }
+
+    private suspend fun isDefaultToHardcore(): Boolean =
+        userPreferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore
+
+    /**
+     * Whether a built-in RESUME launch should default to hardcore. Used by the direct-launch path
+     * (which bypasses the modal). Requires the "Default to Hardcore" setting and a RetroAchievements
+     * login, since hardcore is only meaningful when signed in.
+     */
+    suspend fun shouldDefaultToHardcoreResume(): Boolean =
+        isDefaultToHardcore() && raRepository.isLoggedIn()
 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
@@ -5,8 +5,8 @@ import com.nendo.argosy.data.emulator.LaunchResult
 import com.nendo.argosy.data.preferences.UserPreferencesRepository
 import com.nendo.argosy.data.repository.GameRepository
 import com.nendo.argosy.data.repository.RetroAchievementsRepository
-import com.nendo.argosy.data.repository.SaveCacheManager
 import com.nendo.argosy.domain.usecase.game.LaunchGameUseCase
+import com.nendo.argosy.domain.usecase.save.GetUnifiedSavesUseCase
 import com.nendo.argosy.ui.input.SoundFeedbackManager
 import com.nendo.argosy.core.input.SoundType
 import com.nendo.argosy.ui.screens.gamedetail.LaunchEvent
@@ -47,7 +47,7 @@ data class PlayOptionsState(
 class PlayOptionsDelegate @Inject constructor(
     @ApplicationContext private val context: Context,
     private val gameRepository: GameRepository,
-    private val saveCacheManager: SaveCacheManager,
+    private val getUnifiedSavesUseCase: GetUnifiedSavesUseCase,
     private val raRepository: RetroAchievementsRepository,
     private val launchGameUseCase: LaunchGameUseCase,
     private val soundManager: SoundFeedbackManager,
@@ -65,9 +65,12 @@ class PlayOptionsDelegate @Inject constructor(
 
     fun showPlayOptions(scope: CoroutineScope, gameId: Long, hasAchievements: Boolean) {
         scope.launch {
-            val hasCasualSaves = saveCacheManager.getCachesForGameOnce(gameId)
-                .any { !it.isHardcore }
-            val hasHardcoreSave = saveCacheManager.hasHardcoreSave(gameId)
+            // Include server-only cloud saves, not just the local cache: a freshly synced RomM
+            // game has its save on the server only and must still offer Continue (otherwise the
+            // modal shows New Game, which would overwrite the cloud save).
+            val entries = getUnifiedSavesUseCase(gameId, expandHistory = false)
+            val hasCasualSaves = entries.any { !it.isHardcore }
+            val hasHardcoreSave = entries.any { it.isHardcore }
             val isRALoggedIn = raRepository.isLoggedIn()
             val isOnline = com.nendo.argosy.util.NetworkUtils.isOnline(context)
             val defaultToHardcore = userPreferencesRepository.getBuiltinEmulatorSettings()
@@ -131,7 +134,7 @@ class PlayOptionsDelegate @Inject constructor(
         hasAchievements: Boolean
     ): Boolean {
         if (!isBuiltInEmulator || !hasAchievements) return false
-        val hasSaves = saveCacheManager.getCachesForGameOnce(gameId).isNotEmpty()
+        val hasSaves = getUnifiedSavesUseCase(gameId, expandHistory = false).isNotEmpty()
         val isRALoggedIn = raRepository.isLoggedIn()
         return !hasSaves && isRALoggedIn
     }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
@@ -2,6 +2,7 @@ package com.nendo.argosy.ui.screens.gamedetail.delegates
 
 import android.content.Context
 import com.nendo.argosy.data.emulator.LaunchResult
+import com.nendo.argosy.data.preferences.UserPreferencesRepository
 import com.nendo.argosy.data.repository.GameRepository
 import com.nendo.argosy.data.repository.RetroAchievementsRepository
 import com.nendo.argosy.data.repository.SaveCacheManager
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -48,7 +50,8 @@ class PlayOptionsDelegate @Inject constructor(
     private val saveCacheManager: SaveCacheManager,
     private val raRepository: RetroAchievementsRepository,
     private val launchGameUseCase: LaunchGameUseCase,
-    private val soundManager: SoundFeedbackManager
+    private val soundManager: SoundFeedbackManager,
+    private val userPreferencesRepository: UserPreferencesRepository
 ) {
     private val _state = MutableStateFlow(PlayOptionsState())
     val state: StateFlow<PlayOptionsState> = _state.asStateFlow()
@@ -67,20 +70,32 @@ class PlayOptionsDelegate @Inject constructor(
             val hasHardcoreSave = saveCacheManager.hasHardcoreSave(gameId)
             val isRALoggedIn = raRepository.isLoggedIn()
             val isOnline = com.nendo.argosy.util.NetworkUtils.isOnline(context)
+            val defaultToHardcore = userPreferencesRepository.getBuiltinEmulatorSettings()
+                .first().defaultToHardcore
 
-            _state.update {
-                it.copy(
-                    showPlayOptions = true,
-                    playOptionsFocusIndex = 0,
-                    hasCasualSaves = hasCasualSaves,
-                    hasHardcoreSave = hasHardcoreSave,
-                    hasRASupport = hasAchievements,
-                    isRALoggedIn = isRALoggedIn,
-                    isOnline = isOnline
-                )
-            }
+            val newState = PlayOptionsState(
+                showPlayOptions = true,
+                playOptionsFocusIndex = 0,
+                hasCasualSaves = hasCasualSaves,
+                hasHardcoreSave = hasHardcoreSave,
+                hasRASupport = hasAchievements,
+                isRALoggedIn = isRALoggedIn,
+                isOnline = isOnline
+            )
+            _state.value = newState.copy(
+                playOptionsFocusIndex = defaultFocusIndex(newState, defaultToHardcore)
+            )
             soundManager.play(SoundType.OPEN_MODAL)
         }
+    }
+
+    /** With "Default to Hardcore" on, pre-focus the Continue-in-Hardcore row so A launches hardcore. */
+    private fun defaultFocusIndex(state: PlayOptionsState, defaultToHardcore: Boolean): Int {
+        if (!defaultToHardcore || !state.showResumeHardcore) return 0
+        var idx = 0
+        if (state.hasCasualSaves) idx++
+        if (state.hasCasualSaves && state.isOnline) idx++
+        return idx
     }
 
     fun dismissPlayOptions() {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
@@ -84,14 +84,8 @@ class PlayOptionsDelegate @Inject constructor(
                 isOnline = isOnline
             )
             // With "Default to Hardcore" on, pre-focus the Continue-in-Hardcore row so A launches
-            // hardcore (falls back to the first row when that option isn't shown).
-            val focusIndex = if (defaultToHardcore) {
-                visibleActions(newState).indexOf(PlayOptionAction.ResumeHardcore).coerceAtLeast(0)
-            } else {
-                0
-            }
-            _state.value = newState.copy(playOptionsFocusIndex = focusIndex)
-            soundManager.play(SoundType.OPEN_MODAL)
+            // hardcore (openModal falls back to the first row when that option isn't shown).
+            openModal(newState, PlayOptionAction.ResumeHardcore.takeIf { defaultToHardcore })
         }
     }
 
@@ -105,6 +99,13 @@ class PlayOptionsDelegate @Inject constructor(
         if (state.showResumeHardcore) add(PlayOptionAction.ResumeHardcore)
         add(PlayOptionAction.NewCasual)
         if (state.hardcoreAvailable) add(PlayOptionAction.NewHardcore)
+    }
+
+    /** Show the play-options modal, pre-focusing [preferred] if present (else the first row). */
+    private fun openModal(state: PlayOptionsState, preferred: PlayOptionAction?) {
+        val focusIndex = preferred?.let { visibleActions(state).indexOf(it).coerceAtLeast(0) } ?: 0
+        _state.value = state.copy(playOptionsFocusIndex = focusIndex)
+        soundManager.play(SoundType.OPEN_MODAL)
     }
 
     fun dismissPlayOptions() {
@@ -133,9 +134,9 @@ class PlayOptionsDelegate @Inject constructor(
         hasAchievements: Boolean
     ): Boolean {
         if (!isBuiltInEmulator || !hasAchievements) return false
-        val hasSaves = getUnifiedSavesUseCase(gameId, expandHistory = false).isNotEmpty()
-        val isRALoggedIn = raRepository.isLoggedIn()
-        return !hasSaves && isRALoggedIn
+        // Gate on the cheap RA-login check before the networked unified-saves fetch.
+        if (!raRepository.isLoggedIn()) return false
+        return getUnifiedSavesUseCase(gameId, expandHistory = false).isEmpty()
     }
 
     fun showFreshGameModeSelection(scope: CoroutineScope, gameId: Long) {
@@ -150,13 +151,7 @@ class PlayOptionsDelegate @Inject constructor(
                 isOnline = isOnline
             )
             // "Default to Hardcore" pre-focuses New Hardcore (online-only) for a fresh game.
-            val focusIndex = if (isDefaultToHardcore() && isOnline) {
-                visibleActions(newState).indexOf(PlayOptionAction.NewHardcore).coerceAtLeast(0)
-            } else {
-                0
-            }
-            _state.value = newState.copy(playOptionsFocusIndex = focusIndex)
-            soundManager.play(SoundType.OPEN_MODAL)
+            openModal(newState, PlayOptionAction.NewHardcore.takeIf { isDefaultToHardcore() && isOnline })
         }
     }
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
@@ -75,27 +75,34 @@ class PlayOptionsDelegate @Inject constructor(
 
             val newState = PlayOptionsState(
                 showPlayOptions = true,
-                playOptionsFocusIndex = 0,
                 hasCasualSaves = hasCasualSaves,
                 hasHardcoreSave = hasHardcoreSave,
                 hasRASupport = hasAchievements,
                 isRALoggedIn = isRALoggedIn,
                 isOnline = isOnline
             )
-            _state.value = newState.copy(
-                playOptionsFocusIndex = defaultFocusIndex(newState, defaultToHardcore)
-            )
+            // With "Default to Hardcore" on, pre-focus the Continue-in-Hardcore row so A launches
+            // hardcore (falls back to the first row when that option isn't shown).
+            val focusIndex = if (defaultToHardcore) {
+                visibleActions(newState).indexOf(PlayOptionAction.ResumeHardcore).coerceAtLeast(0)
+            } else {
+                0
+            }
+            _state.value = newState.copy(playOptionsFocusIndex = focusIndex)
             soundManager.play(SoundType.OPEN_MODAL)
         }
     }
 
-    /** With "Default to Hardcore" on, pre-focus the Continue-in-Hardcore row so A launches hardcore. */
-    private fun defaultFocusIndex(state: PlayOptionsState, defaultToHardcore: Boolean): Int {
-        if (!defaultToHardcore || !state.showResumeHardcore) return 0
-        var idx = 0
-        if (state.hasCasualSaves) idx++
-        if (state.hasCasualSaves && state.isOnline) idx++
-        return idx
+    /**
+     * The play options shown, in display order -- the single source of truth for the modal's row
+     * layout, its focus bounds, and confirm mapping. Must match [PlayOptionsModal]'s rendering.
+     */
+    private fun visibleActions(state: PlayOptionsState): List<PlayOptionAction> = buildList {
+        if (state.hasCasualSaves) add(PlayOptionAction.Resume)
+        if (state.hasCasualSaves && state.isOnline) add(PlayOptionAction.ResumeNoSync)
+        if (state.showResumeHardcore) add(PlayOptionAction.ResumeHardcore)
+        add(PlayOptionAction.NewCasual)
+        if (state.hardcoreAvailable) add(PlayOptionAction.NewHardcore)
     }
 
     fun dismissPlayOptions() {
@@ -105,42 +112,17 @@ class PlayOptionsDelegate @Inject constructor(
 
     fun movePlayOptionsFocus(delta: Int) {
         _state.update {
-            val state = it
-            var optionCount = 1
-
-            if (state.hasCasualSaves) optionCount++
-            if (state.hasCasualSaves && state.isOnline) optionCount++
-            if (state.showResumeHardcore) optionCount++
-            if (state.hasRASupport && state.isRALoggedIn) optionCount++
-
-            val maxIndex = (optionCount - 1).coerceAtLeast(0)
-            val newIndex = (it.playOptionsFocusIndex + delta).coerceIn(0, maxIndex)
-            it.copy(playOptionsFocusIndex = newIndex)
+            val maxIndex = (visibleActions(it).size - 1).coerceAtLeast(0)
+            it.copy(playOptionsFocusIndex = (it.playOptionsFocusIndex + delta).coerceIn(0, maxIndex))
         }
     }
 
     fun confirmPlayOptionSelection(): PlayOptionAction? {
         val state = _state.value
-        val focusIndex = state.playOptionsFocusIndex
-
-        var currentIdx = 0
-        val resumeIdx = if (state.hasCasualSaves) currentIdx++ else -1
-        val resumeNoSyncIdx = if (state.hasCasualSaves && state.isOnline) currentIdx++ else -1
-        val resumeHardcoreIdx = if (state.showResumeHardcore) currentIdx++ else -1
-        val newCasualIdx = currentIdx++
-        val newHardcoreIdx = if (state.hasRASupport && state.isRALoggedIn) currentIdx else -1
-
-        return when (focusIndex) {
-            resumeIdx -> PlayOptionAction.Resume
-            resumeNoSyncIdx -> PlayOptionAction.ResumeNoSync
-            resumeHardcoreIdx -> PlayOptionAction.ResumeHardcore
-            newCasualIdx -> PlayOptionAction.NewCasual
-            newHardcoreIdx -> {
-                if (!state.isOnline) return null
-                PlayOptionAction.NewHardcore
-            }
-            else -> null
-        }
+        val action = visibleActions(state).getOrNull(state.playOptionsFocusIndex) ?: return null
+        // Hardcore is online-only.
+        if (action == PlayOptionAction.NewHardcore && !state.isOnline) return null
+        return action
     }
 
     suspend fun shouldShowModeSelection(

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
@@ -30,7 +30,17 @@ data class PlayOptionsState(
     val hasRASupport: Boolean = false,
     val isRALoggedIn: Boolean = false,
     val isOnline: Boolean = false
-)
+) {
+    /** Hardcore requires a RetroAchievements login. */
+    val hardcoreAvailable: Boolean get() = hasRASupport && isRALoggedIn
+
+    /**
+     * Continue-in-hardcore is offered whenever hardcore is available and there is any resumable
+     * save. RESUME_HARDCORE loads the latest hardcore save if present, else falls back to the
+     * active SRAM -- so a casual save can be continued in a hardcore session.
+     */
+    val showResumeHardcore: Boolean get() = hardcoreAvailable && (hasCasualSaves || hasHardcoreSave)
+}
 
 class PlayOptionsDelegate @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -85,7 +95,7 @@ class PlayOptionsDelegate @Inject constructor(
 
             if (state.hasCasualSaves) optionCount++
             if (state.hasCasualSaves && state.isOnline) optionCount++
-            if (state.hasHardcoreSave) optionCount++
+            if (state.showResumeHardcore) optionCount++
             if (state.hasRASupport && state.isRALoggedIn) optionCount++
 
             val maxIndex = (optionCount - 1).coerceAtLeast(0)
@@ -101,7 +111,7 @@ class PlayOptionsDelegate @Inject constructor(
         var currentIdx = 0
         val resumeIdx = if (state.hasCasualSaves) currentIdx++ else -1
         val resumeNoSyncIdx = if (state.hasCasualSaves && state.isOnline) currentIdx++ else -1
-        val resumeHardcoreIdx = if (state.hasHardcoreSave) currentIdx++ else -1
+        val resumeHardcoreIdx = if (state.showResumeHardcore) currentIdx++ else -1
         val newCasualIdx = currentIdx++
         val newHardcoreIdx = if (state.hasRASupport && state.isRALoggedIn) currentIdx else -1
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
@@ -162,12 +162,4 @@ class PlayOptionsDelegate @Inject constructor(
 
     private suspend fun isDefaultToHardcore(): Boolean =
         userPreferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore
-
-    /**
-     * Whether a built-in RESUME launch should default to hardcore. Used by the direct-launch path
-     * (which bypasses the modal). Requires the "Default to Hardcore" setting and a RetroAchievements
-     * login, since hardcore is only meaningful when signed in.
-     */
-    suspend fun shouldDefaultToHardcoreResume(): Boolean =
-        isDefaultToHardcore() && raRepository.isLoggedIn()
 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/modals/PlayOptionsModal.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/modals/PlayOptionsModal.kt
@@ -81,12 +81,13 @@ fun PlayOptionsModal(
                 )
             }
 
-            if (hasHardcoreSave) {
+            if (showHardcoreOptions && (hasSaves || hasHardcoreSave)) {
                 val idx = currentIndex++
                 PlayOptionRow(
                     icon = Icons.Default.EmojiEvents,
                     iconTint = ALauncherColors.StarGold,
                     label = "Hardcore",
+                    subtext = if (hasHardcoreSave) null else "Continue this save in hardcore",
                     isFocused = focusIndex == idx,
                     onClick = { onAction(PlayOptionAction.ResumeHardcore) }
                 )

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/modals/PlayOptionsModal.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/modals/PlayOptionsModal.kt
@@ -81,7 +81,7 @@ fun PlayOptionsModal(
                 )
             }
 
-            if (showHardcoreOptions && (hasSaves || hasHardcoreSave)) {
+            if (showHardcoreOptions) {
                 val idx = currentIndex++
                 PlayOptionRow(
                     icon = Icons.Default.EmojiEvents,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsBuiltinRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsBuiltinRouter.kt
@@ -190,6 +190,13 @@ internal fun routeSetBuiltinHwCoreSaveStates(vm: SettingsViewModel, enabled: Boo
     }
 }
 
+internal fun routeSetBuiltinDefaultToHardcore(vm: SettingsViewModel, enabled: Boolean) {
+    vm._uiState.update { it.copy(builtinVideo = it.builtinVideo.copy(defaultToHardcore = enabled)) }
+    vm.viewModelScope.launch {
+        vm.libretroSettingsRepo.setBuiltinDefaultToHardcore(enabled)
+    }
+}
+
 internal fun routeSetBuiltinSavePath(vm: SettingsViewModel, newPath: String) {
     val oldPath = vm._uiState.value.builtinVideo.savePath
     initiateBuiltinPathMigration(vm, BuiltinPathType.SAVE, oldPath, newPath)
@@ -688,7 +695,8 @@ internal fun routeUpdatePlatformLibretroSetting(vm: SettingsViewModel, setting: 
             LibretroSettingDef.RewindBufferDuration -> current.copy(rewindBufferDuration = value?.removeSuffix("s")?.toIntOrNull())
             LibretroSettingDef.AutoSaveState,
             LibretroSettingDef.AutoRestoreState,
-            LibretroSettingDef.HwCoreSaveStates -> current
+            LibretroSettingDef.HwCoreSaveStates,
+            LibretroSettingDef.DefaultToHardcore -> current
         }
 
         if (updated.hasAnyOverrides()) {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsInitRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsInitRouter.kt
@@ -672,6 +672,7 @@ internal fun routeLoadSettings(vm: SettingsViewModel) {
                     autoSaveState = builtinSettings.autoSaveState,
                     autoRestoreState = builtinSettings.autoRestoreState,
                     hwCoreSaveStatesEnabled = builtinSettings.hwCoreSaveStatesEnabled,
+                    defaultToHardcore = builtinSettings.defaultToHardcore,
                     savePath = builtinSettings.customSavePath
                         ?: AppPaths.libretroSavesDir(vm.context.filesDir).absolutePath,
                     statePath = builtinSettings.customStatePath

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsModels.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsModels.kt
@@ -407,6 +407,7 @@ data class BuiltinVideoState(
     val autoSaveState: Boolean = true,
     val autoRestoreState: Boolean = true,
     val hwCoreSaveStatesEnabled: Boolean = false,
+    val defaultToHardcore: Boolean = false,
     val savePath: String = "",
     val statePath: String = "",
     val isCustomSavePath: Boolean = false,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
@@ -393,6 +393,7 @@ class SettingsViewModel @Inject constructor(
     fun setBuiltinAutoSaveState(enabled: Boolean) = routeSetBuiltinAutoSaveState(this, enabled)
     fun setBuiltinAutoRestoreState(enabled: Boolean) = routeSetBuiltinAutoRestoreState(this, enabled)
     fun setBuiltinHwCoreSaveStates(enabled: Boolean) = routeSetBuiltinHwCoreSaveStates(this, enabled)
+    fun setBuiltinDefaultToHardcore(enabled: Boolean) = routeSetBuiltinDefaultToHardcore(this, enabled)
     fun setBuiltinSavePath(path: String) = routeSetBuiltinSavePath(this, path)
     fun resetBuiltinSavePath() = routeResetBuiltinSavePath(this)
     fun setBuiltinStatePath(path: String) = routeSetBuiltinStatePath(this, path)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/libretro/LibretroSettingsAccessor.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/libretro/LibretroSettingsAccessor.kt
@@ -54,6 +54,7 @@ class GlobalLibretroSettingsAccessor(
         LibretroSettingDef.AutoSaveState -> state.autoSaveState.toString()
         LibretroSettingDef.AutoRestoreState -> state.autoRestoreState.toString()
         LibretroSettingDef.HwCoreSaveStates -> state.hwCoreSaveStatesEnabled.toString()
+        LibretroSettingDef.DefaultToHardcore -> state.defaultToHardcore.toString()
     }
 
     override fun hasOverride(setting: LibretroSettingDef): Boolean = false
@@ -78,6 +79,7 @@ class GlobalLibretroSettingsAccessor(
             LibretroSettingDef.AutoSaveState -> state.autoSaveState
             LibretroSettingDef.AutoRestoreState -> state.autoRestoreState
             LibretroSettingDef.HwCoreSaveStates -> state.hwCoreSaveStatesEnabled
+            LibretroSettingDef.DefaultToHardcore -> state.defaultToHardcore
             else -> return
         }
         onToggle(setting, !current)
@@ -151,6 +153,7 @@ class PlatformLibretroSettingsAccessor(
         LibretroSettingDef.AutoSaveState -> globalState.autoSaveState.toString()
         LibretroSettingDef.AutoRestoreState -> globalState.autoRestoreState.toString()
         LibretroSettingDef.HwCoreSaveStates -> globalState.hwCoreSaveStatesEnabled.toString()
+        LibretroSettingDef.DefaultToHardcore -> globalState.defaultToHardcore.toString()
     }
 
     override fun hasOverride(setting: LibretroSettingDef): Boolean {
@@ -209,6 +212,7 @@ class PlatformLibretroSettingsAccessor(
             LibretroSettingDef.AutoSaveState -> null
             LibretroSettingDef.AutoRestoreState -> null
             LibretroSettingDef.HwCoreSaveStates -> null
+            LibretroSettingDef.DefaultToHardcore -> null
         }
     }
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/BuiltinVideoSection.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/BuiltinVideoSection.kt
@@ -75,6 +75,7 @@ fun BuiltinVideoSection(
                         LibretroSettingDef.AutoSaveState -> viewModel.setBuiltinAutoSaveState(enabled)
                         LibretroSettingDef.AutoRestoreState -> viewModel.setBuiltinAutoRestoreState(enabled)
                         LibretroSettingDef.HwCoreSaveStates -> viewModel.setBuiltinHwCoreSaveStates(enabled)
+                        LibretroSettingDef.DefaultToHardcore -> viewModel.setBuiltinDefaultToHardcore(enabled)
                         else -> {}
                     }
                 },

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/input/BuiltinVideoSectionInput.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/input/BuiltinVideoSectionInput.kt
@@ -159,6 +159,10 @@ internal class BuiltinVideoSectionInput(
             viewModel.setBuiltinHwCoreSaveStates(!videoState.hwCoreSaveStatesEnabled)
             InputResult.handled(SoundType.TOGGLE)
         }
+        LibretroSettingDef.DefaultToHardcore -> {
+            viewModel.setBuiltinDefaultToHardcore(!videoState.defaultToHardcore)
+            InputResult.handled(SoundType.TOGGLE)
+        }
     }
 
     private fun confirmPlatform(

--- a/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
@@ -61,6 +61,7 @@ class GameLauncherTest {
     private lateinit var emulatorSaveConfigRepository: com.nendo.argosy.data.repository.EmulatorSaveConfigRepository
     private lateinit var saveHandlerRegistry: com.nendo.argosy.data.sync.platform.PlatformSaveHandlerRegistry
 
+    private lateinit var libretroStatePathResolver: LibretroStatePathResolver
     private lateinit var launcher: GameLauncher
 
     @Before
@@ -93,6 +94,9 @@ class GameLauncherTest {
         gameFileDao = mockk(relaxed = true)
         emulatorSaveConfigRepository = mockk(relaxed = true)
         saveHandlerRegistry = mockk(relaxed = true)
+        libretroStatePathResolver = mockk(relaxed = true)
+        coEvery { libretroStatePathResolver.liveStateBaseDir(any()) } returns
+            java.io.File("/data/data/com.nendo.argosy/files/libretro/states")
 
         every { userPreferencesRepository.userPreferences } returns flowOf(UserPreferences())
         every { userPreferencesRepository.getBuiltinCoreSelections() } returns flowOf(emptyMap())
@@ -119,7 +123,8 @@ class GameLauncherTest {
             coreSystemDataManager = coreSystemDataManager,
             gameFileDao = gameFileDao,
             emulatorSaveConfigRepository = emulatorSaveConfigRepository,
-            saveHandlerRegistry = saveHandlerRegistry
+            saveHandlerRegistry = saveHandlerRegistry,
+            libretroStatePathResolver = libretroStatePathResolver
         )
     }
 

--- a/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
@@ -124,7 +124,8 @@ class GameLauncherTest {
             gameFileDao = gameFileDao,
             emulatorSaveConfigRepository = emulatorSaveConfigRepository,
             saveHandlerRegistry = saveHandlerRegistry,
-            libretroStatePathResolver = libretroStatePathResolver
+            libretroStatePathResolver = libretroStatePathResolver,
+            notificationManager = mockk(relaxed = true)
         )
     }
 

--- a/app/src/test/kotlin/com/nendo/argosy/libretro/LibretroStateSlotsTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/libretro/LibretroStateSlotsTest.kt
@@ -1,0 +1,21 @@
+package com.nendo.argosy.libretro
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LibretroStateSlotsTest {
+
+    @Test
+    fun `slot numbers map to the canonical flat file names`() {
+        val rom = "Sonic Advance"
+        assertEquals("Sonic Advance.state.auto", LibretroStateSlots.fileName(rom, LibretroStateSlots.AUTO_SLOT))
+        assertEquals("Sonic Advance.state.resume", LibretroStateSlots.fileName(rom, LibretroStateSlots.RESUME_SLOT))
+        assertEquals("Sonic Advance.state", LibretroStateSlots.fileName(rom, 0))
+        assertEquals("Sonic Advance.state5", LibretroStateSlots.fileName(rom, 5))
+        assertEquals("Sonic Advance.state.q0", LibretroStateSlots.fileName(rom, LibretroStateSlots.QUICK_SLOT_BASE))
+        assertEquals(
+            "Sonic Advance.state.q9",
+            LibretroStateSlots.fileName(rom, LibretroStateSlots.QUICK_SLOT_BASE + LibretroStateSlots.QUICK_RING_SIZE - 1)
+        )
+    }
+}

--- a/app/src/test/kotlin/com/nendo/argosy/libretro/SaveStateManagerTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/libretro/SaveStateManagerTest.kt
@@ -1,0 +1,139 @@
+package com.nendo.argosy.libretro
+
+import com.nendo.argosy.data.local.dao.GameDao
+import com.nendo.argosy.data.local.entity.GameEntity
+import com.nendo.argosy.data.local.entity.SaveCacheEntity
+import com.nendo.argosy.data.model.GameSource
+import com.nendo.argosy.data.repository.SaveCacheManager
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.time.Instant
+
+class SaveStateManagerTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private fun manager(gameDao: GameDao, cache: SaveCacheManager): SaveStateManager {
+        val saves = tempFolder.newFolder("saves")
+        val states = tempFolder.newFolder("states")
+        return SaveStateManager(
+            savesDir = saves,
+            statesDir = states,
+            romPath = File(saves, "Sonic Advance.gba").absolutePath,
+            gameId = GAME_ID,
+            gameDao = gameDao,
+            saveCacheManager = cache
+        )
+    }
+
+    private fun game() = GameEntity(
+        id = GAME_ID,
+        title = "Sonic Advance",
+        sortTitle = "sonic advance",
+        platformId = 1L,
+        platformSlug = "gba",
+        rommId = null,
+        igdbId = null,
+        localPath = null,
+        source = GameSource.ROMM_SYNCED
+    )
+
+    private fun cacheEntity(hardcore: Boolean) = SaveCacheEntity(
+        gameId = GAME_ID,
+        emulatorId = "builtin",
+        cachedAt = Instant.ofEpochMilli(1000),
+        saveSize = 3,
+        cachePath = "cache/x.srm",
+        isHardcore = hardcore
+    )
+
+    // RetroAchievements permits SRAM in hardcore, so a hardcore resume must not start
+    // fresh just because no save carries the hardcore tag -- it should reuse the active save.
+    @Test
+    fun `RESUME_HARDCORE reuses the casual save when no hardcore save exists`() = runBlocking {
+        val gameDao = mockk<GameDao>()
+        val cache = mockk<SaveCacheManager>(relaxed = true)
+        val casual = cacheEntity(hardcore = false)
+        val casualBytes = byteArrayOf(1, 2, 3)
+        coEvery { cache.getLatestHardcoreSave(GAME_ID) } returns null
+        coEvery { gameDao.getById(GAME_ID) } returns game() // no active timestamp/channel -> most recent
+        coEvery { cache.getMostRecentSave(GAME_ID) } returns casual
+        coEvery { cache.getSaveBytesFromEntity(casual) } returns casualBytes
+
+        val result = manager(gameDao, cache).restoreSaveForLaunchMode(LaunchMode.RESUME_HARDCORE)
+
+        assertNotNull("hardcore should reuse the active SRAM instead of starting fresh", result.sramData)
+        assertArrayEquals(casualBytes, result.sramData)
+    }
+
+    @Test
+    fun `RESUME_HARDCORE still prefers an existing hardcore save`() = runBlocking {
+        val gameDao = mockk<GameDao>(relaxed = true)
+        val cache = mockk<SaveCacheManager>(relaxed = true)
+        val hardcore = cacheEntity(hardcore = true)
+        val hardcoreBytes = byteArrayOf(9, 9)
+        coEvery { cache.getLatestHardcoreSave(GAME_ID) } returns hardcore
+        coEvery { cache.isValidHardcoreSave(hardcore) } returns true
+        coEvery { cache.getSaveBytesFromEntity(hardcore) } returns hardcoreBytes
+
+        val result = manager(gameDao, cache).restoreSaveForLaunchMode(LaunchMode.RESUME_HARDCORE)
+
+        assertArrayEquals(hardcoreBytes, result.sramData)
+    }
+
+    // --- Flat live layout (refactor: channels are cache-only) ---
+
+    @Test
+    fun `getSlotFile is flat, never under a channel subdir`() {
+        val saves = tempFolder.newFolder("flat-saves")
+        val states = tempFolder.newFolder("flat-states")
+        val mgr = SaveStateManager(
+            savesDir = saves,
+            statesDir = states,
+            romPath = File(saves, "Sonic Advance.gba").absolutePath,
+            gameId = GAME_ID,
+            gameDao = mockk(relaxed = true),
+            saveCacheManager = mockk(relaxed = true),
+            channelName = "some-channel"
+        )
+        val auto = mgr.getSlotFile(SaveStateManager.AUTO_SLOT)
+        assertEquals(File(states, "Sonic Advance.state.auto"), auto)
+        assertEquals("state file must sit directly in statesDir, not a channel subdir", states, auto.parentFile)
+    }
+
+    @Test
+    fun `initialize lifts legacy channel states up to flat`() {
+        val saves = tempFolder.newFolder("mig-saves")
+        val states = tempFolder.newFolder("mig-states")
+        File(states, "default").mkdirs()
+        File(states, "default/Sonic Advance.state.auto").writeBytes(byteArrayOf(1, 2))
+        val mgr = SaveStateManager(
+            savesDir = saves,
+            statesDir = states,
+            romPath = File(saves, "Sonic Advance.gba").absolutePath,
+            gameId = GAME_ID,
+            gameDao = mockk(relaxed = true),
+            saveCacheManager = mockk(relaxed = true),
+            channelName = null
+        )
+        mgr.initializeFromExistingSave(null)
+        assertTrue(
+            "legacy default/ state should be migrated up to the flat states dir",
+            File(states, "Sonic Advance.state.auto").exists()
+        )
+    }
+
+    companion object {
+        private const val GAME_ID = 1L
+    }
+}

--- a/app/src/test/kotlin/com/nendo/argosy/libretro/SaveStateManagerTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/libretro/SaveStateManagerTest.kt
@@ -36,7 +36,7 @@ class SaveStateManagerTest {
         )
     }
 
-    private fun game() = GameEntity(
+    private fun game(activeSaveApplied: Boolean = false) = GameEntity(
         id = GAME_ID,
         title = "Sonic Advance",
         sortTitle = "sonic advance",
@@ -45,7 +45,8 @@ class SaveStateManagerTest {
         rommId = null,
         igdbId = null,
         localPath = null,
-        source = GameSource.ROMM_SYNCED
+        source = GameSource.ROMM_SYNCED,
+        activeSaveApplied = activeSaveApplied
     )
 
     private fun cacheEntity(hardcore: Boolean) = SaveCacheEntity(
@@ -89,6 +90,35 @@ class SaveStateManagerTest {
         val result = manager(gameDao, cache).restoreSaveForLaunchMode(LaunchMode.RESUME_HARDCORE)
 
         assertArrayEquals(hardcoreBytes, result.sramData)
+    }
+
+    @Test
+    fun `activeSaveApplied honors the on-disk SRAM over the default resume pick`() = runBlocking {
+        val saves = tempFolder.newFolder("applied-saves")
+        val states = tempFolder.newFolder("applied-states")
+        val restoredBytes = byteArrayOf(7, 7, 7)
+        File(saves, "Sonic Advance.srm").writeBytes(restoredBytes)
+
+        val gameDao = mockk<GameDao>()
+        val cache = mockk<SaveCacheManager>(relaxed = true)
+        coEvery { gameDao.getById(GAME_ID) } returns game(activeSaveApplied = true)
+        coEvery { cache.getLatestHardcoreSave(GAME_ID) } returns cacheEntity(hardcore = true)
+
+        val mgr = SaveStateManager(
+            savesDir = saves,
+            statesDir = states,
+            romPath = File(saves, "Sonic Advance.gba").absolutePath,
+            gameId = GAME_ID,
+            gameDao = gameDao,
+            saveCacheManager = cache
+        )
+        val result = mgr.restoreSaveForLaunchMode(LaunchMode.RESUME_HARDCORE)
+
+        assertArrayEquals(
+            "activeSaveApplied must load the on-disk .srm, not the cache's hardcore save",
+            restoredBytes,
+            result.sramData
+        )
     }
 
     // --- Flat live layout (refactor: channels are cache-only) ---

--- a/libretrodroid/src/main/java/com/swordfish/libretrodroid/GLRetroView.kt
+++ b/libretrodroid/src/main/java/com/swordfish/libretrodroid/GLRetroView.kt
@@ -551,11 +551,11 @@ class GLRetroView(
             data.gameFileBytes != null -> loadGameFromBytes(data.gameFileBytes!!)
             data.gameVirtualFiles.isNotEmpty() -> loadGameFromVirtualFiles(data.gameVirtualFiles)
         }
-        data.saveRAMState?.let {
+        data.saveRAMState?.let { sram ->
             // A false result means the on-disk SRAM couldn't be applied (e.g. it's larger than
             // the core's save memory -- a cross-core mismatch). Record it so the UI can warn
             // instead of silently booting with a fresh save.
-            if (!LibretroDroid.unserializeSRAM(data.saveRAMState)) {
+            if (!LibretroDroid.unserializeSRAM(sram)) {
                 sramLoadFailed = true
             }
             data.saveRAMState = null

--- a/libretrodroid/src/main/java/com/swordfish/libretrodroid/GLRetroView.kt
+++ b/libretrodroid/src/main/java/com/swordfish/libretrodroid/GLRetroView.kt
@@ -130,6 +130,11 @@ class GLRetroView(
     private val retroGLEventsSubject = MutableSharedFlow<GLRetroEvents>(1)
     private val retroGLIssuesErrors = MutableSharedFlow<Int>(1)
 
+    /** True if the on-disk SRAM couldn't be applied to the core at load (e.g. size mismatch). */
+    @Volatile
+    var sramLoadFailed: Boolean = false
+        private set
+
     private val rumbleEventsSubject = MutableSharedFlow<RumbleEvent>()
 
     private var lifecycle: Lifecycle? = null
@@ -547,7 +552,12 @@ class GLRetroView(
             data.gameVirtualFiles.isNotEmpty() -> loadGameFromVirtualFiles(data.gameVirtualFiles)
         }
         data.saveRAMState?.let {
-            LibretroDroid.unserializeSRAM(data.saveRAMState)
+            // A false result means the on-disk SRAM couldn't be applied (e.g. it's larger than
+            // the core's save memory -- a cross-core mismatch). Record it so the UI can warn
+            // instead of silently booting with a fresh save.
+            if (!LibretroDroid.unserializeSRAM(data.saveRAMState)) {
+                sramLoadFailed = true
+            }
             data.saveRAMState = null
         }
         LibretroDroid.onSurfaceCreated()


### PR DESCRIPTION
## Summary

This started as a refactor of the built-in libretro core's save-state layout and grew to fix a cluster of related save/state reliability problems, most notably that an explicitly restored save (including a cloud save) could be silently replaced by a different one on launch. Net effect: the built-in player now stores states in one predictable place, honors the save you restore, tells you when it can't load a save or core instead of failing quietly, and can run the VBA core that matches RetroArch `vba_next` cloud saves.

No database schema change; the state-layout change is disk-level only.

## What changed

### Save-state layout (the original refactor)
- **Flat live layout**: the built-in core now keeps one current SRAM + set of states flat under the state dir (mirroring SRAM and external emulators); channels are a cache/versioning concept only.
- **One source of truth for the live state dir**: `LibretroStatePathResolver`, used by launch, discovery, restore, and clear. This also fixes a latent bug where the cache side used `StatePathRegistry`'s unexpanded `{filesDir}` token for built-in.
- `LibretroStateSlots` centralizes slot ↔ filename naming.

### Save reliability
- **Flush SRAM to disk before caching on quit**, so the cache snapshots the finished session rather than a stale save.
- **Honor an explicit restore over the default resume pick**: a save-management restore writes the chosen save to the live `.srm` and sets `activeSaveApplied`, but the launch previously re-derived the SRAM from the cache (`getLatestHardcoreSave` for hardcore, a timestamp lookup for casual) and could load a *different* save. Continue / Continue-Hardcore now load the restored save. This is what made restored cloud saves finally stick.
- Restored SRAM is no longer overwritten by a lingering auto-resume state.
- **Bound autosave history on the server**: the RomM `autocleanup` pruning only fired when the active channel was null, not when it was the literal string `"autosave"` (which a restore sets), so the autosave slot's server-side history could grow unbounded. Both forms now enable `autocleanup` (keeps the newest 10).

### Server-only cloud saves (fresh RomM library)
- **Start Game offers Continue for a server-only save**: a freshly synced game whose save lives only on the server previously showed only New Game (which, on launch, would overwrite the cloud save). Start Game now considers server/cloud saves, not just the local cache, so it offers Continue. This applies to both the play-options modal and the fresh-game mode picker.
- **Delete removes the server copy too**: deleting a save slot now deletes the server save alongside the local cache. Previously it reported success but the server copy re-synced back, so the slot reappeared.

### Features
- **Continue-in-Hardcore**: the Start Game dialog now offers a hardcore "Continue" whenever hardcore is available and any save is resumable (not only when a hardcore-tagged save exists).
- **Global "Default to Hardcore" setting** (off by default): pre-selects the hardcore continue option so `A` launches hardcore.

### Failure surfacing (previously silent)
- Toast when the configured core can't run on the built-in player and it falls back (`Failed to load <core>, using <core> instead`).
- In-game message when a save can't be applied to the core, e.g. a size/format mismatch (`Failed to load save, using new save instead`) instead of silently booting fresh and overwriting the cloud save.
- Register **`vba_next`** as a built-in core (downloaded from the buildbot like the others), so `vba_next` cloud saves load into the matching core.

### UX / cleanup
- Built-in save-state toggles now read "Applies to casual games only".
- Save-management panel refreshes in place after a restore (and marks a server/cloud restore active) instead of closing.
- Post-review dedup: single `visibleActions()` for the play-options row order, a resolver overload so `GameLauncher` reuses inputs it already loaded, one game fetch on resume, and a shared `LibretroCoreRegistry.displayNameFor()`.

## Testing
- `./gradlew testDebugUnitTest`: all unit suites pass; added tests for the flat layout, channel→flat migration, slot naming, and hardcore-save handling.
- Verified on-device (Anbernic-class handheld, RomM-synced): fresh-save persists across quit→resume; an explicitly restored cloud save loads and round-trips; Continue-in-Hardcore continues a casual save in hardcore.
- Verified with a server-only cloud save (a freshly synced Genesis game): Start Game offers Continue, restoring loads the cloud save, and deleting a cloud slot removes it for good.

## Note on stability

I have ran this for about a day and tested GBA, SNES, and Genesis games and it works flawlessly. I encourage the maintainers to try this branch to verify my claims.
