### PR TITLE
settings: Move and upgrade DefaultToHardcore preference to 3-way cycle selection

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/core/emulator/LibretroSettingDef.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/core/emulator/LibretroSettingDef.kt
@@ -167,9 +167,9 @@ sealed class LibretroSettingDef(
     data object DefaultToHardcore : LibretroSettingDef(
         key = "defaultToHardcore",
         section = "saving",
-        title = "Default to Hardcore",
-        subtitle = "When launching a game, default to hardcore instead of casual",
-        type = SettingType.Switch
+        title = "RetroAchievements Mode",
+        subtitle = "Preferred mode when launching a game",
+        type = SettingType.Cycle(listOf("Ask", "Default to Casual", "Default to Hardcore"))
     )
 
     companion object {
@@ -193,8 +193,7 @@ sealed class LibretroSettingDef(
             AudioVolume,
             AutoSaveState,
             AutoRestoreState,
-            HwCoreSaveStates,
-            DefaultToHardcore
+            HwCoreSaveStates
         )
 
         val SECTIONS: Map<String, String> = mapOf(

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/BuiltinEmulatorPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/BuiltinEmulatorPreferencesRepository.kt
@@ -49,6 +49,7 @@ class BuiltinEmulatorPreferencesRepository @Inject constructor(
         val BUILTIN_AUTO_RESTORE_STATE_MODE = stringPreferencesKey("builtin_auto_restore_state_mode")
         val BUILTIN_HW_CORE_SAVE_STATES = booleanPreferencesKey("builtin_hw_core_save_states")
         val BUILTIN_DEFAULT_TO_HARDCORE = booleanPreferencesKey("builtin_default_to_hardcore")
+        val BUILTIN_DEFAULT_TO_HARDCORE_MODE = stringPreferencesKey("builtin_default_to_hardcore_mode")
         val BUILTIN_CUSTOM_SAVE_PATH = stringPreferencesKey("builtin_custom_save_path")
         val BUILTIN_CUSTOM_STATE_PATH = stringPreferencesKey("builtin_custom_state_path")
         val BUILTIN_MIGRATION_V1 = booleanPreferencesKey("builtin_migration_v2")
@@ -105,7 +106,8 @@ class BuiltinEmulatorPreferencesRepository @Inject constructor(
                 ?: (prefs[Keys.BUILTIN_AUTO_RESTORE_STATE_MODE] != "off"),
             autoRestoreStateMode = prefs[Keys.BUILTIN_AUTO_RESTORE_STATE_MODE] ?: "restore",
             hwCoreSaveStatesEnabled = prefs[Keys.BUILTIN_HW_CORE_SAVE_STATES] ?: false,
-            defaultToHardcore = prefs[Keys.BUILTIN_DEFAULT_TO_HARDCORE] ?: false,
+            defaultToHardcore = prefs[Keys.BUILTIN_DEFAULT_TO_HARDCORE_MODE]
+                ?: if (prefs[Keys.BUILTIN_DEFAULT_TO_HARDCORE] == true) "Default to Hardcore" else "Ask",
             customSavePath = prefs[Keys.BUILTIN_CUSTOM_SAVE_PATH],
             customStatePath = prefs[Keys.BUILTIN_CUSTOM_STATE_PATH],
             architectureOverride = prefs[Keys.BUILTIN_ARCHITECTURE_OVERRIDE],
@@ -285,8 +287,8 @@ class BuiltinEmulatorPreferencesRepository @Inject constructor(
         dataStore.edit { it[Keys.BUILTIN_HW_CORE_SAVE_STATES] = enabled }
     }
 
-    suspend fun setBuiltinDefaultToHardcore(enabled: Boolean) {
-        dataStore.edit { it[Keys.BUILTIN_DEFAULT_TO_HARDCORE] = enabled }
+    suspend fun setBuiltinDefaultToHardcore(mode: String) {
+        dataStore.edit { it[Keys.BUILTIN_DEFAULT_TO_HARDCORE_MODE] = mode }
     }
 
     suspend fun setBuiltinCustomSavePath(path: String?) {

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/BuiltinEmulatorPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/BuiltinEmulatorPreferencesRepository.kt
@@ -106,8 +106,12 @@ class BuiltinEmulatorPreferencesRepository @Inject constructor(
                 ?: (prefs[Keys.BUILTIN_AUTO_RESTORE_STATE_MODE] != "off"),
             autoRestoreStateMode = prefs[Keys.BUILTIN_AUTO_RESTORE_STATE_MODE] ?: "restore",
             hwCoreSaveStatesEnabled = prefs[Keys.BUILTIN_HW_CORE_SAVE_STATES] ?: false,
-            defaultToHardcore = prefs[Keys.BUILTIN_DEFAULT_TO_HARDCORE_MODE]
-                ?: if (prefs[Keys.BUILTIN_DEFAULT_TO_HARDCORE] == true) "Default to Hardcore" else "Ask",
+            defaultToHardcore = when (val saved = prefs[Keys.BUILTIN_DEFAULT_TO_HARDCORE_MODE]) {
+                "Default to Hardcore", "hardcore" -> "hardcore"
+                "Default to Casual", "casual" -> "casual"
+                "Ask", "ask" -> "ask"
+                else -> if (prefs[Keys.BUILTIN_DEFAULT_TO_HARDCORE] == true) "hardcore" else "ask"
+            },
             customSavePath = prefs[Keys.BUILTIN_CUSTOM_SAVE_PATH],
             customStatePath = prefs[Keys.BUILTIN_CUSTOM_STATE_PATH],
             architectureOverride = prefs[Keys.BUILTIN_ARCHITECTURE_OVERRIDE],
@@ -288,7 +292,13 @@ class BuiltinEmulatorPreferencesRepository @Inject constructor(
     }
 
     suspend fun setBuiltinDefaultToHardcore(mode: String) {
-        dataStore.edit { it[Keys.BUILTIN_DEFAULT_TO_HARDCORE_MODE] = mode }
+        val token = when (mode) {
+            "Default to Hardcore", "hardcore" -> "hardcore"
+            "Default to Casual", "casual" -> "casual"
+            "Ask", "ask" -> "ask"
+            else -> "ask"
+        }
+        dataStore.edit { it[Keys.BUILTIN_DEFAULT_TO_HARDCORE_MODE] = token }
     }
 
     suspend fun setBuiltinCustomSavePath(path: String?) {

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
@@ -461,7 +461,7 @@ data class BuiltinEmulatorSettings(
     val autoRestoreState: Boolean = true,
     val autoRestoreStateMode: String = "restore",
     val hwCoreSaveStatesEnabled: Boolean = false,
-    val defaultToHardcore: String = "Ask",
+    val defaultToHardcore: String = "ask",
     val customSavePath: String? = null,
     val customStatePath: String? = null,
     val architectureOverride: String? = null,

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
@@ -461,7 +461,7 @@ data class BuiltinEmulatorSettings(
     val autoRestoreState: Boolean = true,
     val autoRestoreStateMode: String = "restore",
     val hwCoreSaveStatesEnabled: Boolean = false,
-    val defaultToHardcore: Boolean = false,
+    val defaultToHardcore: String = "Ask",
     val customSavePath: String? = null,
     val customStatePath: String? = null,
     val architectureOverride: String? = null,

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/LibretroSettingsRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/LibretroSettingsRepository.kt
@@ -125,8 +125,8 @@ class LibretroSettingsRepository @Inject constructor(
     suspend fun setBuiltinHwCoreSaveStates(enabled: Boolean) =
         builtinPrefs.setBuiltinHwCoreSaveStates(enabled)
 
-    suspend fun setBuiltinDefaultToHardcore(enabled: Boolean) =
-        builtinPrefs.setBuiltinDefaultToHardcore(enabled)
+    suspend fun setBuiltinDefaultToHardcore(mode: String) =
+        builtinPrefs.setBuiltinDefaultToHardcore(mode)
 
     suspend fun setBuiltinCustomSavePath(path: String?) =
         builtinPrefs.setBuiltinCustomSavePath(path)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/common/GameLaunchDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/common/GameLaunchDelegate.kt
@@ -139,7 +139,7 @@ class GameLaunchDelegate @Inject constructor(
     ): Boolean =
         emulatorPackage == EmulatorRegistry.BUILTIN_PACKAGE &&
             game.achievementCount > 0 &&
-            preferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore &&
+            preferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore == "Default to Hardcore" &&
             retroAchievementsRepository.isLoggedIn()
 
     private val _syncOverlayState = MutableStateFlow<SyncOverlayState?>(null)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/common/GameLaunchDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/common/GameLaunchDelegate.kt
@@ -139,7 +139,7 @@ class GameLaunchDelegate @Inject constructor(
     ): Boolean =
         emulatorPackage == EmulatorRegistry.BUILTIN_PACKAGE &&
             game.achievementCount > 0 &&
-            preferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore == "Default to Hardcore" &&
+            preferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore == "hardcore" &&
             retroAchievementsRepository.isLoggedIn()
 
     private val _syncOverlayState = MutableStateFlow<SyncOverlayState?>(null)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
@@ -135,7 +135,7 @@ class PlayOptionsDelegate @Inject constructor(
         if (!isBuiltInEmulator || !hasAchievements) return false
         if (!raRepository.isLoggedIn()) return false
         val pref = userPreferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore
-        if (pref != "Ask") return false
+        if (pref != "ask") return false
         val isOnline = com.nendo.argosy.util.NetworkUtils.isOnline(context)
         return getUnifiedSavesUseCase(gameId, expandHistory = false, includeServer = isOnline).isEmpty()
     }
@@ -156,5 +156,5 @@ class PlayOptionsDelegate @Inject constructor(
     }
 
     private suspend fun isDefaultToHardcore(): Boolean =
-        userPreferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore == "Default to Hardcore"
+        userPreferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore == "hardcore"
 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PlayOptionsDelegate.kt
@@ -134,6 +134,8 @@ class PlayOptionsDelegate @Inject constructor(
     ): Boolean {
         if (!isBuiltInEmulator || !hasAchievements) return false
         if (!raRepository.isLoggedIn()) return false
+        val pref = userPreferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore
+        if (pref != "Ask") return false
         val isOnline = com.nendo.argosy.util.NetworkUtils.isOnline(context)
         return getUnifiedSavesUseCase(gameId, expandHistory = false, includeServer = isOnline).isEmpty()
     }
@@ -154,5 +156,5 @@ class PlayOptionsDelegate @Inject constructor(
     }
 
     private suspend fun isDefaultToHardcore(): Boolean =
-        userPreferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore
+        userPreferencesRepository.getBuiltinEmulatorSettings().first().defaultToHardcore == "Default to Hardcore"
 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsBuiltinRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsBuiltinRouter.kt
@@ -192,10 +192,15 @@ internal fun routeSetBuiltinHwCoreSaveStates(vm: SettingsViewModel, enabled: Boo
     }
 }
 
-internal fun routeSetBuiltinDefaultToHardcore(vm: SettingsViewModel, enabled: Boolean) {
-    vm._uiState.update { it.copy(builtinVideo = it.builtinVideo.copy(defaultToHardcore = enabled)) }
+internal fun routeSetBuiltinDefaultToHardcore(vm: SettingsViewModel, mode: String) {
+    vm._uiState.update {
+        it.copy(
+            builtinVideo = it.builtinVideo.copy(defaultToHardcore = mode),
+            retroAchievements = it.retroAchievements.copy(defaultToHardcore = mode)
+        )
+    }
     vm.viewModelScope.launch {
-        vm.libretroSettingsRepo.setBuiltinDefaultToHardcore(enabled)
+        vm.libretroSettingsRepo.setBuiltinDefaultToHardcore(mode)
     }
 }
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsBuiltinRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsBuiltinRouter.kt
@@ -193,14 +193,11 @@ internal fun routeSetBuiltinHwCoreSaveStates(vm: SettingsViewModel, enabled: Boo
 }
 
 internal fun routeSetBuiltinDefaultToHardcore(vm: SettingsViewModel, mode: String) {
+    vm.raDelegate.setDefaultToHardcore(vm.viewModelScope, mode)
     vm._uiState.update {
         it.copy(
-            builtinVideo = it.builtinVideo.copy(defaultToHardcore = mode),
-            retroAchievements = it.retroAchievements.copy(defaultToHardcore = mode)
+            builtinVideo = it.builtinVideo.copy(defaultToHardcore = mode)
         )
-    }
-    vm.viewModelScope.launch {
-        vm.libretroSettingsRepo.setBuiltinDefaultToHardcore(mode)
     }
 }
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
@@ -175,7 +175,6 @@ internal fun routeConfirm(vm: SettingsViewModel): InputResult {
                 }
             } else {
                 if (ra.isLoggedIn) {
-                    val pushIndex = if (ra.proxyEnabled) 4 else 3
                     when (state.focusedIndex) {
                         0 -> vm.logoutFromRA()
                         1 -> {
@@ -187,7 +186,6 @@ internal fun routeConfirm(vm: SettingsViewModel): InputResult {
                         4 -> if (ra.proxyEnabled && ra.canPushToRetroArch) vm.pushRACredentialsToRetroArch()
                     }
                 } else {
-                    val pushIndex = -1
                     when (state.focusedIndex) {
                         0 -> vm.showRALoginForm()
                         1 -> vm.setRAProxyEnabled(!ra.proxyEnabled)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
@@ -174,15 +174,25 @@ internal fun routeConfirm(vm: SettingsViewModel): InputResult {
                     3 -> vm.hideRALoginForm()
                 }
             } else {
-                val pushIndex = if (ra.isLoggedIn && ra.canPushToRetroArch) {
-                    if (ra.proxyEnabled) RA_PROXY_FIELD_INDEX + 1 else RA_PROXY_TOGGLE_INDEX + 1
-                } else -1
-                when {
-                    state.focusedIndex == 0 ->
-                        if (ra.isLoggedIn) vm.logoutFromRA() else vm.showRALoginForm()
-                    state.focusedIndex == pushIndex -> vm.pushRACredentialsToRetroArch()
-                    state.focusedIndex == RA_PROXY_TOGGLE_INDEX -> vm.setRAProxyEnabled(!ra.proxyEnabled)
-                    state.focusedIndex == RA_PROXY_FIELD_INDEX -> vm.raDelegate.setFocusField(RA_PROXY_FIELD_INDEX)
+                if (ra.isLoggedIn) {
+                    val pushIndex = if (ra.proxyEnabled) 4 else 3
+                    when (state.focusedIndex) {
+                        0 -> vm.logoutFromRA()
+                        1 -> {
+                            vm.cycleRADefaultMode(1)
+                            return InputResult.handled(SoundType.SELECT)
+                        }
+                        2 -> vm.setRAProxyEnabled(!ra.proxyEnabled)
+                        3 -> if (ra.proxyEnabled) vm.raDelegate.setFocusField(3) else if (ra.canPushToRetroArch) vm.pushRACredentialsToRetroArch()
+                        4 -> if (ra.proxyEnabled && ra.canPushToRetroArch) vm.pushRACredentialsToRetroArch()
+                    }
+                } else {
+                    val pushIndex = -1
+                    when (state.focusedIndex) {
+                        0 -> vm.showRALoginForm()
+                        1 -> vm.setRAProxyEnabled(!ra.proxyEnabled)
+                        2 -> if (ra.proxyEnabled) vm.raDelegate.setFocusField(2)
+                    }
                 }
             }
             InputResult.HANDLED
@@ -898,7 +908,7 @@ private fun computeMaxFocusIndex(
     SettingsSection.RETRO_ACHIEVEMENTS -> when {
         state.retroAchievements.showLoginForm -> 3
         state.retroAchievements.isLoggedIn -> {
-            val lastBeforePush = if (state.retroAchievements.proxyEnabled) RA_PROXY_FIELD_INDEX else RA_PROXY_TOGGLE_INDEX
+            val lastBeforePush = if (state.retroAchievements.proxyEnabled) 3 else 2
             if (state.retroAchievements.canPushToRetroArch) lastBeforePush + 1 else lastBeforePush
         }
         state.retroAchievements.proxyEnabled -> RA_PROXY_FIELD_INDEX

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouter.kt
@@ -798,7 +798,8 @@ internal fun routeSetRAProxyEnabled(vm: SettingsViewModel, enabled: Boolean) {
     vm.raDelegate.setProxyEnabled(vm.viewModelScope, enabled)
     if (!enabled) {
         vm._uiState.update {
-            if (it.focusedIndex > RA_PROXY_TOGGLE_INDEX) it.copy(focusedIndex = RA_PROXY_TOGGLE_INDEX) else it
+            val proxyToggleIndex = if (it.retroAchievements.isLoggedIn) 2 else 1
+            if (it.focusedIndex > proxyToggleIndex) it.copy(focusedIndex = proxyToggleIndex) else it
         }
     }
 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsModels.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsModels.kt
@@ -424,7 +424,7 @@ data class BuiltinVideoState(
     val autoSaveState: Boolean = true,
     val autoRestoreState: Boolean = true,
     val hwCoreSaveStatesEnabled: Boolean = false,
-    val defaultToHardcore: String = "Ask",
+    val defaultToHardcore: String = "ask",
     val savePath: String = "",
     val statePath: String = "",
     val isCustomSavePath: Boolean = false,
@@ -884,7 +884,7 @@ data class RASettingsState(
     val proxyEnabled: Boolean = false,
     val proxyAddress: String = "",
     val canPushToRetroArch: Boolean = false,
-    val defaultToHardcore: String = "Ask"
+    val defaultToHardcore: String = "ask"
 )
 
 data class BiosFirmwareItem(

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsModels.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsModels.kt
@@ -424,7 +424,7 @@ data class BuiltinVideoState(
     val autoSaveState: Boolean = true,
     val autoRestoreState: Boolean = true,
     val hwCoreSaveStatesEnabled: Boolean = false,
-    val defaultToHardcore: Boolean = false,
+    val defaultToHardcore: String = "Ask",
     val savePath: String = "",
     val statePath: String = "",
     val isCustomSavePath: Boolean = false,
@@ -883,7 +883,8 @@ data class RASettingsState(
     val pendingAchievementsCount: Int = 0,
     val proxyEnabled: Boolean = false,
     val proxyAddress: String = "",
-    val canPushToRetroArch: Boolean = false
+    val canPushToRetroArch: Boolean = false,
+    val defaultToHardcore: String = "Ask"
 )
 
 data class BiosFirmwareItem(

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
@@ -399,7 +399,14 @@ class SettingsViewModel @Inject constructor(
     fun setBuiltinAutoSaveState(enabled: Boolean) = routeSetBuiltinAutoSaveState(this, enabled)
     fun setBuiltinAutoRestoreState(enabled: Boolean) = routeSetBuiltinAutoRestoreState(this, enabled)
     fun setBuiltinHwCoreSaveStates(enabled: Boolean) = routeSetBuiltinHwCoreSaveStates(this, enabled)
-    fun setBuiltinDefaultToHardcore(enabled: Boolean) = routeSetBuiltinDefaultToHardcore(this, enabled)
+    fun setBuiltinDefaultToHardcore(mode: String) = routeSetBuiltinDefaultToHardcore(this, mode)
+    fun cycleRADefaultMode(direction: Int) {
+        val options = listOf("Ask", "Default to Casual", "Default to Hardcore")
+        val current = _uiState.value.retroAchievements.defaultToHardcore
+        val currentIndex = options.indexOf(current).coerceAtLeast(0)
+        val nextIndex = (currentIndex + direction + options.size) % options.size
+        setBuiltinDefaultToHardcore(options[nextIndex])
+    }
     fun setBuiltinSavePath(path: String) = routeSetBuiltinSavePath(this, path)
     fun resetBuiltinSavePath() = routeResetBuiltinSavePath(this)
     fun setBuiltinStatePath(path: String) = routeSetBuiltinStatePath(this, path)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
@@ -401,7 +401,7 @@ class SettingsViewModel @Inject constructor(
     fun setBuiltinHwCoreSaveStates(enabled: Boolean) = routeSetBuiltinHwCoreSaveStates(this, enabled)
     fun setBuiltinDefaultToHardcore(mode: String) = routeSetBuiltinDefaultToHardcore(this, mode)
     fun cycleRADefaultMode(direction: Int) {
-        val options = listOf("Ask", "Default to Casual", "Default to Hardcore")
+        val options = listOf("ask", "casual", "hardcore")
         val current = _uiState.value.retroAchievements.defaultToHardcore
         val currentIndex = options.indexOf(current).coerceAtLeast(0)
         val nextIndex = (currentIndex + direction + options.size) % options.size

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/RASettingsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/RASettingsDelegate.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.nendo.argosy.data.preferences.UserPreferencesRepository
 import com.nendo.argosy.data.repository.RALoginResult
 import com.nendo.argosy.data.repository.RetroAchievementsRepository
+import com.nendo.argosy.data.repository.LibretroSettingsRepository
 import com.nendo.argosy.ui.screens.settings.RASettingsState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,7 +19,8 @@ private const val TAG = "RASettingsDelegate"
 
 class RASettingsDelegate @Inject constructor(
     private val raRepository: RetroAchievementsRepository,
-    private val prefsRepository: UserPreferencesRepository
+    private val prefsRepository: UserPreferencesRepository,
+    private val libretroSettingsRepo: LibretroSettingsRepository
 ) {
     private val _state = MutableStateFlow(RASettingsState())
     val state: StateFlow<RASettingsState> = _state.asStateFlow()
@@ -100,6 +102,11 @@ class RASettingsDelegate @Inject constructor(
     fun setProxyAddress(scope: CoroutineScope, address: String) {
         _state.update { it.copy(proxyAddress = address) }
         scope.launch { prefsRepository.setRAProxy(_state.value.proxyEnabled, address) }
+    }
+
+    fun setDefaultToHardcore(scope: CoroutineScope, mode: String) {
+        _state.update { it.copy(defaultToHardcore = mode) }
+        scope.launch { libretroSettingsRepo.setBuiltinDefaultToHardcore(mode) }
     }
 
     fun login(scope: CoroutineScope, onFocusReset: () -> Unit) {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/RASettingsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/RASettingsDelegate.kt
@@ -31,6 +31,7 @@ class RASettingsDelegate @Inject constructor(
         scope.launch {
             val credentials = raRepository.getCredentials()
             val prefs = prefsRepository.userPreferences.first()
+            val builtinPrefs = prefsRepository.getBuiltinEmulatorSettings().first()
             val canPush = raRepository.hasWritableRetroArchConfig()
             _state.update {
                 it.copy(
@@ -38,7 +39,8 @@ class RASettingsDelegate @Inject constructor(
                     username = credentials?.username,
                     proxyEnabled = prefs.raProxyEnabled,
                     proxyAddress = prefs.raProxyAddress,
-                    canPushToRetroArch = canPush
+                    canPushToRetroArch = canPush,
+                    defaultToHardcore = builtinPrefs.defaultToHardcore
                 )
             }
         }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/libretro/LibretroSettingsAccessor.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/libretro/LibretroSettingsAccessor.kt
@@ -79,7 +79,6 @@ class GlobalLibretroSettingsAccessor(
             LibretroSettingDef.AutoSaveState -> state.autoSaveState
             LibretroSettingDef.AutoRestoreState -> state.autoRestoreState
             LibretroSettingDef.HwCoreSaveStates -> state.hwCoreSaveStatesEnabled
-            LibretroSettingDef.DefaultToHardcore -> state.defaultToHardcore
             else -> return
         }
         onToggle(setting, !current)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/BuiltinVideoSection.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/BuiltinVideoSection.kt
@@ -77,7 +77,6 @@ fun BuiltinVideoSection(
                         LibretroSettingDef.AutoSaveState -> viewModel.setBuiltinAutoSaveState(enabled)
                         LibretroSettingDef.AutoRestoreState -> viewModel.setBuiltinAutoRestoreState(enabled)
                         LibretroSettingDef.HwCoreSaveStates -> viewModel.setBuiltinHwCoreSaveStates(enabled)
-                        LibretroSettingDef.DefaultToHardcore -> viewModel.setBuiltinDefaultToHardcore(enabled)
                         else -> {}
                     }
                 },

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/RASettingsSection.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/RASettingsSection.kt
@@ -186,21 +186,27 @@ private fun RALoggedInContent(
 
         item {
             val cycleOptions = listOf("Ask", "Default to Casual", "Default to Hardcore")
+            val tokenOptions = listOf("ask", "casual", "hardcore")
+            val currentLabel = when (raState.defaultToHardcore) {
+                "hardcore" -> "Default to Hardcore"
+                "casual" -> "Default to Casual"
+                else -> "Ask"
+            }
             CyclePreference(
                 title = "Play Mode Preference",
-                value = raState.defaultToHardcore,
+                value = currentLabel,
                 isFocused = focusedIndex == 1,
                 onClick = { viewModel.cycleRADefaultMode(1) },
                 onPrev = { viewModel.cycleRADefaultMode(-1) },
                 options = cycleOptions,
                 onSelect = { index ->
-                    val current = cycleOptions.indexOf(raState.defaultToHardcore).coerceAtLeast(0)
-                    viewModel.cycleRADefaultMode(index - current)
+                    val nextToken = tokenOptions.getOrNull(index) ?: "ask"
+                    viewModel.setBuiltinDefaultToHardcore(nextToken)
                 },
                 subtitle = when (raState.defaultToHardcore) {
-                    "Ask" -> "Prompt on launch to choose between Casual and Hardcore"
-                    "Default to Casual" -> "Allows save states, cheats, and rewind. Earn softcore achievements."
-                    "Default to Hardcore" -> "Disables save states, cheats, and rewind. Earn hardcore achievements."
+                    "ask" -> "Prompt on launch to choose between Casual and Hardcore"
+                    "casual" -> "Allows save states, cheats, and rewind. Earn softcore achievements."
+                    "hardcore" -> "Disables save states, cheats, and rewind. Earn hardcore achievements."
                     else -> "Preferred mode when launching a game"
                 }
             )

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/RASettingsSection.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/RASettingsSection.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.nendo.argosy.ui.components.ActionPreference
+import com.nendo.argosy.ui.components.CyclePreference
 import com.nendo.argosy.ui.components.FocusedScroll
 import com.nendo.argosy.ui.components.SwitchPreference
 import com.nendo.argosy.ui.screens.settings.RA_PROXY_FIELD_INDEX
@@ -183,7 +184,29 @@ private fun RALoggedInContent(
             )
         }
 
-        raProxyItems(raState, focusedIndex, viewModel)
+        item {
+            val cycleOptions = listOf("Ask", "Default to Casual", "Default to Hardcore")
+            CyclePreference(
+                title = "Play Mode Preference",
+                value = raState.defaultToHardcore,
+                isFocused = focusedIndex == 1,
+                onClick = { viewModel.cycleRADefaultMode(1) },
+                onPrev = { viewModel.cycleRADefaultMode(-1) },
+                options = cycleOptions,
+                onSelect = { index ->
+                    val current = cycleOptions.indexOf(raState.defaultToHardcore).coerceAtLeast(0)
+                    viewModel.cycleRADefaultMode(index - current)
+                },
+                subtitle = when (raState.defaultToHardcore) {
+                    "Ask" -> "Prompt on launch to choose between Casual and Hardcore"
+                    "Default to Casual" -> "Allows save states, cheats, and rewind. Earn softcore achievements."
+                    "Default to Hardcore" -> "Disables save states, cheats, and rewind. Earn hardcore achievements."
+                    else -> "Preferred mode when launching a game"
+                }
+            )
+        }
+
+        raProxyItems(raState, focusedIndex, viewModel, proxyToggleIndex = 2, proxyFieldIndex = 3)
 
         if (raState.canPushToRetroArch) {
             item {
@@ -191,7 +214,7 @@ private fun RALoggedInContent(
                 SectionHeader("RETROARCH")
             }
             item {
-                val pushIndex = if (raState.proxyEnabled) RA_PROXY_FIELD_INDEX + 1 else RA_PROXY_TOGGLE_INDEX + 1
+                val pushIndex = if (raState.proxyEnabled) 4 else 3
                 ActionPreference(
                     icon = Icons.Default.Sync,
                     title = "Push to RetroArch",
@@ -263,14 +286,16 @@ private fun RALoggedOutContent(
             )
         }
 
-        raProxyItems(raState, focusedIndex, viewModel)
+        raProxyItems(raState, focusedIndex, viewModel, proxyToggleIndex = 1, proxyFieldIndex = 2)
     }
 }
 
 private fun LazyListScope.raProxyItems(
     raState: RASettingsState,
     focusedIndex: Int,
-    viewModel: SettingsViewModel
+    viewModel: SettingsViewModel,
+    proxyToggleIndex: Int,
+    proxyFieldIndex: Int
 ) {
     item {
         Spacer(modifier = Modifier.height(Dimens.spacingMd))
@@ -281,7 +306,7 @@ private fun LazyListScope.raProxyItems(
             title = "RetroAchievements proxy",
             subtitle = "Route achievements through a local RAOfflineProxy",
             isEnabled = raState.proxyEnabled,
-            isFocused = focusedIndex == RA_PROXY_TOGGLE_INDEX,
+            isFocused = focusedIndex == proxyToggleIndex,
             onToggle = { viewModel.setRAProxyEnabled(it) }
         )
     }
@@ -290,7 +315,7 @@ private fun LazyListScope.raProxyItems(
             val inputShape = RoundedCornerShape(Dimens.radiusMd)
             val focusRequester = remember { FocusRequester() }
             LaunchedEffect(raState.focusField) {
-                if (raState.focusField == RA_PROXY_FIELD_INDEX) {
+                if (raState.focusField == proxyFieldIndex) {
                     focusRequester.requestFocus()
                     viewModel.clearRAFocusField()
                 }
@@ -307,7 +332,7 @@ private fun LazyListScope.raProxyItems(
                     .fillMaxWidth()
                     .focusRequester(focusRequester)
                     .then(
-                        if (focusedIndex == RA_PROXY_FIELD_INDEX)
+                        if (focusedIndex == proxyFieldIndex)
                             Modifier.background(LocalArgosyTheme.current.focusAccent.copy(alpha = 0.15f), inputShape)
                         else Modifier
                     )

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/input/BuiltinVideoSectionInput.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/input/BuiltinVideoSectionInput.kt
@@ -166,10 +166,7 @@ internal class BuiltinVideoSectionInput(
             viewModel.setBuiltinHwCoreSaveStates(!videoState.hwCoreSaveStatesEnabled)
             InputResult.handled(SoundType.TOGGLE)
         }
-        LibretroSettingDef.DefaultToHardcore -> {
-            viewModel.setBuiltinDefaultToHardcore(!videoState.defaultToHardcore)
-            InputResult.handled(SoundType.TOGGLE)
-        }
+        LibretroSettingDef.DefaultToHardcore -> InputResult.HANDLED
     }
 
     private fun confirmPlatform(


### PR DESCRIPTION
## Summary
Adjusts the existing "Default to Hardcore" preference to a 3-way cycle selection ("Ask", "Default to Casual", "Default to Hardcore") and relocates the preference to the RetroAchievements settings section.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c187d59d-39f7-4d54-9c8e-6a5f4a0241b4" />

## Related Issue

## Changes
- Removed the switch setting `DefaultToHardcore` from `LibretroSettingDef.ALL` so it no longer populates the Built-in Emulator settings.
- Re-implemented `DefaultToHardcore` as a `SettingType.Cycle` containing options `Ask`, `Default to Casual`, and `Default to Hardcore`.
- Relocated the preference to the **Settings > RetroAchievements** screen, displaying it when logged in as a `CyclePreference` with descriptive subtext per option. I could be way off, but this is where I went looking for it...
- Added a new string Datastore key `"builtin_default_to_hardcore_mode"` to avoid runtime crashes from changing types on the old boolean key. Added type-fallback logic to gracefully migrate existing users.
- Updated `PlayOptionsDelegate.shouldShowModeSelection` to bypass the launch-time mode selection dialog when a specific launch preference (`Default to Hardcore` or. `Default to Casual`) is selected.
- Updated `GameLaunchDelegate.shouldDefaultToHardcore` to read the new string preference and dynamically resolve the hardcore mode state.
- Redefined RetroAchievements settings focus indexes and confirmed action routing to dynamically accommodate the new setting cycle item.

## Testing
- Successfully compiled the project locally
- Deployed/installed the debug APK to a physical test device
- Verified Settings UI navigation: D-pad cycles correctly between all three options with accurate status subtext updating in real-time.
- Verified launch behavior:
  - When preference is `"Ask"`: Launching a game with achievements prompts the user to select Casual/Hardcore.
  - When preference is `"Default to Casual"`: Bypasses the prompt and launches directly in Casual mode.
  - When preference is `"Default to Hardcore"`: Bypasses the prompt and launches directly in Hardcore mode.

## Checklist
- [x] Code compiles without errors
- [x] Tests pass locally
- [x] Lint checks pass
- [x] Self-reviewed the code
