### PR TITLE
Fix variable-size persisted save-state restore

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/LibretroActivity.kt
@@ -1865,10 +1865,13 @@ class LibretroActivity : ComponentActivity() {
         if (isGuestJoinedSession) return
         val resumeFile = saveStateManager.getSlotFile(SaveStateManager.RESUME_SLOT)
         if (resumeFile.exists()) {
-            if (!hardcoreMode && statesSupported &&
-                saveStateManager.performSlotLoad(retroView, SaveStateManager.RESUME_SLOT)
-            ) {
-                inGameMessage = "Resumed"
+            if (!hardcoreMode && statesSupported) {
+                if (saveStateManager.performSlotLoad(retroView, SaveStateManager.RESUME_SLOT)) {
+                    inGameMessage = "Resumed"
+                } else {
+                    inGameMessage = "Failed to restore state"
+                    Log.w(TAG, "Failed to restore one-shot resume state")
+                }
             }
             resumeFile.delete()
             return
@@ -1886,6 +1889,9 @@ class LibretroActivity : ComponentActivity() {
         if (saveStateManager.performSlotLoad(retroView, SaveStateManager.AUTO_SLOT)) {
             inGameMessage = "State restored"
             Log.d(TAG, "Auto-restored state from auto slot")
+        } else {
+            inGameMessage = "Failed to restore state"
+            Log.w(TAG, "Failed to auto-restore state from auto slot")
         }
     }
 
@@ -2361,7 +2367,7 @@ class LibretroActivity : ComponentActivity() {
                 if (coreDestroyed || !::retroView.isInitialized) return@runOnUiThread
                 lifecycleScope.launch(Dispatchers.IO) {
                     val ok = try { saveStateManager.performQuickLoad(retroView) } catch (_: Exception) { false }
-                    notifyQuickAction(ok, "State loaded", "No quick save yet")
+                    notifyQuickAction(ok, "State loaded", "Failed to load state")
                 }
             }
         }

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/SaveStateManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/SaveStateManager.kt
@@ -309,7 +309,10 @@ class SaveStateManager(
             val stateFile = getSlotFile(slotNumber)
             if (stateFile.exists()) {
                 val stateData = stateFile.readBytes()
-                retroView.unserializeState(stateData)
+                if (!retroView.unserializePersistedState(stateData)) {
+                    Log.e(TAG, "Core rejected state from slot $slotNumber (${stateData.size} bytes)")
+                    return false
+                }
                 Log.d(TAG, "Loaded state from slot $slotNumber (${stateData.size} bytes)")
                 true
             } else {

--- a/app/src/test/kotlin/com/nendo/argosy/libretro/HotkeyDispatcherTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/libretro/HotkeyDispatcherTest.kt
@@ -15,12 +15,13 @@ class HotkeyDispatcherTest {
         netplayInSession: Boolean,
         netplayRole: NetplayMenuRole?,
         hardcore: Boolean = false,
+        quickLoadSucceeds: Boolean = true,
         toastSink: MutableList<String> = mutableListOf(),
         saveStateManager: SaveStateManager = mockk(relaxed = true),
         retroView: GLRetroView = mockk(relaxed = true)
     ): HotkeyDispatcher {
         every { saveStateManager.performQuickSave(any(), any()) } returns true
-        every { saveStateManager.performQuickLoad(any()) } returns true
+        every { saveStateManager.performQuickLoad(any()) } returns quickLoadSucceeds
         every { retroView.serializeState() } returns ByteArray(8)
         every { retroView.captureRawFrame() } returns null
         return HotkeyDispatcher(
@@ -106,6 +107,21 @@ class HotkeyDispatcherTest {
         dispatcher.dispatch(config(HotkeyAction.QUICK_LOAD))
         verify(exactly = 0) { saveStateManager.performQuickLoad(any()) }
         assertEquals(listOf("Save states disabled during netplay"), toasts)
+    }
+
+    @Test
+    fun quickLoad_core_rejection_reports_failure() {
+        val toasts = mutableListOf<String>()
+        val dispatcher = build(
+            netplayInSession = false,
+            netplayRole = null,
+            quickLoadSucceeds = false,
+            toastSink = toasts
+        )
+
+        dispatcher.dispatch(config(HotkeyAction.QUICK_LOAD))
+
+        assertEquals(listOf("Failed to load state"), toasts)
     }
 
     @Test

--- a/app/src/test/kotlin/com/nendo/argosy/libretro/SaveStateManagerTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/libretro/SaveStateManagerTest.kt
@@ -5,11 +5,15 @@ import com.nendo.argosy.data.local.entity.GameEntity
 import com.nendo.argosy.data.local.entity.SaveCacheEntity
 import com.nendo.argosy.data.model.GameSource
 import com.nendo.argosy.data.repository.SaveCacheManager
+import com.swordfish.libretrodroid.GLRetroView
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -161,6 +165,61 @@ class SaveStateManagerTest {
             "legacy default/ state should be migrated up to the flat states dir",
             File(states, "Sonic Advance.state.auto").exists()
         )
+    }
+
+    @Test
+    fun `performSlotLoad returns true when core accepts persisted state`() {
+        val mgr = manager(mockk(relaxed = true), mockk(relaxed = true))
+        val state = byteArrayOf(1, 2, 3, 4)
+        mgr.getSlotFile(1).writeBytes(state)
+        val retroView = mockk<GLRetroView>()
+        every { retroView.unserializePersistedState(match { it.contentEquals(state) }) } returns true
+
+        assertTrue(mgr.performSlotLoad(retroView, 1))
+        verify(exactly = 1) {
+            retroView.unserializePersistedState(match { it.contentEquals(state) })
+        }
+    }
+
+    @Test
+    fun `performSlotLoad returns false when core rejects persisted state`() {
+        val mgr = manager(mockk(relaxed = true), mockk(relaxed = true))
+        val state = byteArrayOf(5, 6, 7)
+        mgr.getSlotFile(2).writeBytes(state)
+        val retroView = mockk<GLRetroView>()
+        every { retroView.unserializePersistedState(any()) } returns false
+
+        assertFalse(mgr.performSlotLoad(retroView, 2))
+        verify(exactly = 1) { retroView.unserializePersistedState(any()) }
+    }
+
+    @Test
+    fun `performSlotLoad returns false for missing state without calling core`() {
+        val mgr = manager(mockk(relaxed = true), mockk(relaxed = true))
+        val retroView = mockk<GLRetroView>(relaxed = true)
+
+        assertFalse(mgr.performSlotLoad(retroView, 3))
+        verify(exactly = 0) { retroView.unserializePersistedState(any()) }
+    }
+
+    @Test
+    fun `performSlotLoad returns false when state cannot be read`() {
+        val mgr = manager(mockk(relaxed = true), mockk(relaxed = true))
+        mgr.getSlotFile(4).mkdirs()
+        val retroView = mockk<GLRetroView>(relaxed = true)
+
+        assertFalse(mgr.performSlotLoad(retroView, 4))
+        verify(exactly = 0) { retroView.unserializePersistedState(any()) }
+    }
+
+    @Test
+    fun `performQuickLoad propagates core rejection`() {
+        val mgr = manager(mockk(relaxed = true), mockk(relaxed = true))
+        mgr.getSlotFile(SaveStateManager.QUICK_SLOT_BASE).writeBytes(byteArrayOf(8, 9))
+        val retroView = mockk<GLRetroView>()
+        every { retroView.unserializePersistedState(any()) } returns false
+
+        assertFalse(mgr.performQuickLoad(retroView))
     }
 
     companion object {

--- a/libretrodroid/src/androidTest/kotlin/com/swordfish/libretrodroid/StateLoadPolicyNativeTest.kt
+++ b/libretrodroid/src/androidTest/kotlin/com/swordfish/libretrodroid/StateLoadPolicyNativeTest.kt
@@ -1,0 +1,24 @@
+/*
+ *     Copyright (C) 2026  Argosy
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ */
+
+package com.swordfish.libretrodroid
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StateLoadPolicyNativeTest {
+
+    @Test
+    fun runNativeStateLoadPolicyTests() {
+        assertEquals(7, LibretroDroid.runStateLoadPolicyTests())
+    }
+}

--- a/libretrodroid/src/androidTest/kotlin/com/swordfish/libretrodroid/StateLoadPolicyNativeTest.kt
+++ b/libretrodroid/src/androidTest/kotlin/com/swordfish/libretrodroid/StateLoadPolicyNativeTest.kt
@@ -19,6 +19,7 @@ class StateLoadPolicyNativeTest {
 
     @Test
     fun runNativeStateLoadPolicyTests() {
-        assertEquals(7, LibretroDroid.runStateLoadPolicyTests())
+        val passed = LibretroDroid.runStateLoadPolicyTests()
+        assertEquals("All native state-load policy tests should pass", 7, passed)
     }
 }

--- a/libretrodroid/src/main/cpp/CMakeLists.txt
+++ b/libretrodroid/src/main/cpp/CMakeLists.txt
@@ -77,6 +77,10 @@ add_library(libretrodroid SHARED
         libretrodroidjni.cpp
         libretrodroid.h
         libretrodroid.cpp
+        stateloadpolicy.h
+        stateloadpolicy.cpp
+        stateloadpolicy_test.h
+        stateloadpolicy_test.cpp
         log.h
         core.h
         core.cpp

--- a/libretrodroid/src/main/cpp/libretrodroid.cpp
+++ b/libretrodroid/src/main/cpp/libretrodroid.cpp
@@ -175,17 +175,63 @@ void LibretroDroid::setControllerType(unsigned int port, unsigned int type) {
 }
 
 bool LibretroDroid::unserializeState(int8_t *data, size_t size) {
-    size_t expectedSize = core->retro_serialize_size();
-    if (expectedSize == 0) {
+    return unserializeStateWithPolicy(data, size, StateLoadPolicy::StrictSize);
+}
+
+bool LibretroDroid::unserializePersistedState(int8_t *data, size_t size) {
+    return unserializeStateWithPolicy(data, size, StateLoadPolicy::CoreValidated);
+}
+
+bool LibretroDroid::unserializeStateWithPolicy(
+    int8_t *data,
+    size_t size,
+    StateLoadPolicy policy
+) {
+    const size_t currentSize = core->retro_serialize_size();
+    if (currentSize == 0) {
         LOGE("unserializeState: core reports no serialization support");
         return false;
     }
-    if (size != expectedSize) {
-        LOGE("unserializeState: size mismatch (got %zu, expected %zu)", size, expectedSize);
+    if (size == 0) {
+        LOGE("unserializeState: refusing empty state");
         return false;
     }
-    bool result = core->retro_unserialize(data, size);
-    if (result && video && video->isHWAccelerated()) {
+    if (size != currentSize) {
+        if (policy == StateLoadPolicy::StrictSize) {
+            LOGE(
+                "unserializeState: size mismatch (got %zu, current %zu); strict load rejected",
+                size,
+                currentSize
+            );
+            return false;
+        }
+        LOGW(
+            "unserializeState: persisted state size differs from current core size "
+            "(got %zu, current %zu); attempting core load",
+            size,
+            currentSize
+        );
+    }
+
+    const bool result = attemptStateLoad(
+        data,
+        size,
+        currentSize,
+        policy,
+        [this](const void* stateData, size_t stateSize) {
+            return core->retro_unserialize(stateData, stateSize);
+        }
+    );
+    if (!result) {
+        LOGE(
+            "unserializeState: core rejected state (got %zu, current %zu)",
+            size,
+            currentSize
+        );
+        return false;
+    }
+
+    if (video && video->isHWAccelerated()) {
         auto contextReset = Environment::getInstance().getHwContextReset();
         if (contextReset) {
             video->bindHWContext();
@@ -193,7 +239,7 @@ bool LibretroDroid::unserializeState(int8_t *data, size_t size) {
             video->bindMainContext();
         }
     }
-    return result;
+    return true;
 }
 
 JNIEXPORT jboolean JNICALL LibretroDroid::unserializeSRAM(int8_t* data, size_t size) {

--- a/libretrodroid/src/main/cpp/libretrodroid.h
+++ b/libretrodroid/src/main/cpp/libretrodroid.h
@@ -48,6 +48,7 @@
 #include "renderers/es3/imagerendereres3.h"
 #include "utils/rect.h"
 #include "rewindbuffer.h"
+#include "stateloadpolicy.h"
 
 namespace libretrodroid {
 
@@ -73,6 +74,7 @@ public:
     std::pair<int8_t*, size_t> serializeState();
     size_t getSerializeSize();
     bool unserializeState(int8_t *data, size_t size);
+    bool unserializePersistedState(int8_t *data, size_t size);
 
     std::pair<int8_t *, size_t> serializeSRAM();
     jboolean unserializeSRAM(int8_t *data, size_t size);
@@ -183,6 +185,7 @@ public:
     uintptr_t handleGetCurrentFrameBuffer();
 
 private:
+    bool unserializeStateWithPolicy(int8_t *data, size_t size, StateLoadPolicy policy);
     void updateAudioSampleRateMultiplier();
     float findDefaultAspectRatio(const retro_system_av_info &system_av_info);
     void afterGameLoad();

--- a/libretrodroid/src/main/cpp/libretrodroidjni.cpp
+++ b/libretrodroid/src/main/cpp/libretrodroidjni.cpp
@@ -44,6 +44,7 @@
 #include "renderers/es3/imagerendereres3.h"
 #include "utils/jnistring.h"
 #include "achievements_test.h"
+#include "stateloadpolicy_test.h"
 #include <rc_hash.h>
 
 namespace libretrodroid {
@@ -181,17 +182,19 @@ JNIEXPORT void JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_setControl
     LibretroDroid::getInstance().setControllerType(port, type);
 }
 
-JNIEXPORT jboolean JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_unserializeState(
+static jboolean unserializeStateFromJava(
     JNIEnv* env,
-    jclass obj,
-    jbyteArray state
+    jbyteArray state,
+    bool persisted
 ) {
     try {
         jboolean isCopy = JNI_FALSE;
         jbyte* data = env->GetByteArrayElements(state, &isCopy);
         jsize size = env->GetArrayLength(state);
 
-        bool result = LibretroDroid::getInstance().unserializeState(data, size);
+        const bool result = persisted
+            ? LibretroDroid::getInstance().unserializePersistedState(data, size)
+            : LibretroDroid::getInstance().unserializeState(data, size);
         env->ReleaseByteArrayElements(state, data, JNI_ABORT);
 
         return result ? JNI_TRUE : JNI_FALSE;
@@ -201,6 +204,22 @@ JNIEXPORT jboolean JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_unseri
         JavaUtils::throwRetroException(env, ERROR_SERIALIZATION);
         return JNI_FALSE;
     }
+}
+
+JNIEXPORT jboolean JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_unserializeState(
+    JNIEnv* env,
+    jclass obj,
+    jbyteArray state
+) {
+    return unserializeStateFromJava(env, state, false);
+}
+
+JNIEXPORT jboolean JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_unserializePersistedState(
+    JNIEnv* env,
+    jclass obj,
+    jbyteArray state
+) {
+    return unserializeStateFromJava(env, state, true);
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_serializeState(
@@ -978,6 +997,13 @@ JNIEXPORT jint JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_runAchieve
     }
 
     return static_cast<jint>(passed);
+}
+
+JNIEXPORT jint JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_runStateLoadPolicyTests(
+    JNIEnv* env,
+    jclass obj
+) {
+    return static_cast<jint>(test::runStateLoadPolicyTests());
 }
 
 JNIEXPORT jstring JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_computeRomHash(

--- a/libretrodroid/src/main/cpp/libretrodroidjni.h
+++ b/libretrodroid/src/main/cpp/libretrodroidjni.h
@@ -25,6 +25,7 @@ extern "C" {
 JNIEXPORT void JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_reset(JNIEnv* env, jclass obj);
 JNIEXPORT jbyteArray JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_serializeState(JNIEnv* env, jclass obj);
 JNIEXPORT jboolean JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_unserializeState(JNIEnv* env, jclass obj, jbyteArray data);
+JNIEXPORT jboolean JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_unserializePersistedState(JNIEnv* env, jclass obj, jbyteArray data);
 JNIEXPORT jlong JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_getSerializeSize(JNIEnv* env, jclass obj);
 JNIEXPORT jbyteArray JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_serializeSRAM(JNIEnv* env, jclass obj);
 JNIEXPORT jboolean JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_unserializeSRAM(JNIEnv* env, jclass obj, jbyteArray data);

--- a/libretrodroid/src/main/cpp/stateloadpolicy.cpp
+++ b/libretrodroid/src/main/cpp/stateloadpolicy.cpp
@@ -1,0 +1,30 @@
+/*
+ *     Copyright (C) 2026  Argosy
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ */
+
+#include "stateloadpolicy.h"
+
+namespace libretrodroid {
+
+bool attemptStateLoad(
+    const void* data,
+    size_t stateSize,
+    size_t currentSerializeSize,
+    StateLoadPolicy policy,
+    const StateUnserializer& unserialize
+) {
+    if (!data || stateSize == 0 || currentSerializeSize == 0) {
+        return false;
+    }
+    if (stateSize != currentSerializeSize && policy == StateLoadPolicy::StrictSize) {
+        return false;
+    }
+    return unserialize(data, stateSize);
+}
+
+} // namespace libretrodroid

--- a/libretrodroid/src/main/cpp/stateloadpolicy.h
+++ b/libretrodroid/src/main/cpp/stateloadpolicy.h
@@ -1,0 +1,37 @@
+/*
+ *     Copyright (C) 2026  Argosy
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ */
+
+#ifndef LIBRETRODROID_STATELOADPOLICY_H
+#define LIBRETRODROID_STATELOADPOLICY_H
+
+#include <cstddef>
+#include <functional>
+
+namespace libretrodroid {
+
+enum class StateLoadPolicy {
+    // Runtime and peer-provided snapshots must match the active core contract.
+    StrictSize,
+    // Persisted states may have a valid historical size; let the core decide.
+    CoreValidated
+};
+
+using StateUnserializer = std::function<bool(const void*, size_t)>;
+
+bool attemptStateLoad(
+    const void* data,
+    size_t stateSize,
+    size_t currentSerializeSize,
+    StateLoadPolicy policy,
+    const StateUnserializer& unserialize
+);
+
+} // namespace libretrodroid
+
+#endif // LIBRETRODROID_STATELOADPOLICY_H

--- a/libretrodroid/src/main/cpp/stateloadpolicy_test.cpp
+++ b/libretrodroid/src/main/cpp/stateloadpolicy_test.cpp
@@ -1,0 +1,70 @@
+/*
+ *     Copyright (C) 2026  Argosy
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ */
+
+#include "stateloadpolicy_test.h"
+
+#include <cstdint>
+
+#include "stateloadpolicy.h"
+
+namespace libretrodroid::test {
+
+int runStateLoadPolicyTests() {
+    int passed = 0;
+    uint8_t data = 0x42;
+    bool called = false;
+
+    auto acceptingCore = [&called](const void*, size_t) {
+        called = true;
+        return true;
+    };
+    auto rejectingCore = [&called](const void*, size_t) {
+        called = true;
+        return false;
+    };
+
+    called = false;
+    if (attemptStateLoad(&data, 8, 8, StateLoadPolicy::StrictSize, acceptingCore) && called) {
+        ++passed;
+    }
+
+    called = false;
+    if (!attemptStateLoad(&data, 7, 8, StateLoadPolicy::StrictSize, acceptingCore) && !called) {
+        ++passed;
+    }
+
+    called = false;
+    if (attemptStateLoad(&data, 7, 8, StateLoadPolicy::CoreValidated, acceptingCore) && called) {
+        ++passed;
+    }
+
+    called = false;
+    if (!attemptStateLoad(&data, 7, 8, StateLoadPolicy::CoreValidated, rejectingCore) && called) {
+        ++passed;
+    }
+
+    called = false;
+    if (!attemptStateLoad(&data, 8, 0, StateLoadPolicy::CoreValidated, acceptingCore) && !called) {
+        ++passed;
+    }
+
+    called = false;
+    if (!attemptStateLoad(&data, 0, 8, StateLoadPolicy::CoreValidated, acceptingCore) && !called) {
+        ++passed;
+    }
+
+    called = false;
+    if (!attemptStateLoad(nullptr, 8, 8, StateLoadPolicy::CoreValidated, acceptingCore) && !called) {
+        ++passed;
+    }
+
+    return passed;
+}
+
+} // namespace libretrodroid::test

--- a/libretrodroid/src/main/cpp/stateloadpolicy_test.h
+++ b/libretrodroid/src/main/cpp/stateloadpolicy_test.h
@@ -1,0 +1,19 @@
+/*
+ *     Copyright (C) 2026  Argosy
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ */
+
+#ifndef LIBRETRODROID_STATELOADPOLICY_TEST_H
+#define LIBRETRODROID_STATELOADPOLICY_TEST_H
+
+namespace libretrodroid::test {
+
+int runStateLoadPolicyTests();
+
+} // namespace libretrodroid::test
+
+#endif // LIBRETRODROID_STATELOADPOLICY_TEST_H

--- a/libretrodroid/src/main/java/com/swordfish/libretrodroid/GLRetroView.kt
+++ b/libretrodroid/src/main/java/com/swordfish/libretrodroid/GLRetroView.kt
@@ -241,6 +241,10 @@ class GLRetroView(
         LibretroDroid.unserializeState(data)
     }
 
+    fun unserializePersistedState(data: ByteArray): Boolean = runOnGLThread {
+        LibretroDroid.unserializePersistedState(data)
+    }
+
     fun serializeSRAM(): ByteArray = runOnGLThread {
         LibretroDroid.serializeSRAM()
     }

--- a/libretrodroid/src/main/java/com/swordfish/libretrodroid/LibretroDroid.java
+++ b/libretrodroid/src/main/java/com/swordfish/libretrodroid/LibretroDroid.java
@@ -133,6 +133,7 @@ public class LibretroDroid {
 
     public static native byte[] serializeState();
     public static native boolean unserializeState(byte[] state);
+    public static native boolean unserializePersistedState(byte[] state);
     public static native long getSerializeSize();
 
     public static native byte[] captureRawFrame();
@@ -190,6 +191,12 @@ public class LibretroDroid {
      * @return Number of tests that passed
      */
     public static native int runAchievementTests();
+
+    /**
+     * Run native save-state load policy tests.
+     * @return Number of tests that passed
+     */
+    public static native int runStateLoadPolicyTests();
 
     /**
      * Compute the RetroAchievements hash for a ROM file.


### PR DESCRIPTION
## Summary

Fix persisted libretro save-state restoration when a core's current `retro_serialize_size()` differs from the valid historical state size.

## Related Issue

Fixes #292

## Root cause

`LibretroDroid::unserializeState()` rejected any buffer whose size did not exactly equal the core's current advertised serialization size. mGBA's serialized size changes after deferred save-hardware setup: the reproduced state is 397,888 bytes, while a fresh launch initially advertises 528,448 bytes. mGBA can deserialize the smaller state, but the frontend gate prevented the call. `SaveStateManager` also ignored the native Boolean result, falsely reporting success.

## Changes

- keep strict size validation for runtime and netplay snapshots
- add a separate core-validated path for disk-persisted states
- propagate native/core rejection through `SaveStateManager` and failure UI
- add Kotlin and native policy coverage

## Testing

- `./gradlew testDebugUnitTest -PallAbis` (899 tests)
- `./gradlew lintDebug -PallAbis`
- `./gradlew assembleDebug -PallAbis`
- `./gradlew :libretrodroid:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.swordfish.libretrodroid.StateLoadPolicyNativeTest` (Retroid Pocket Flip2 / Android 13)
- live mGBA Bookworm handoff:
  - produced a 397,888-byte auto-state
  - fresh core reported 528,448 bytes
  - mGBA logged loading save data and RTC data
  - Argosy reported auto-restore only after core acceptance

## Checklist

- [x] Code compiles without errors
- [x] Tests pass locally
- [x] Lint checks pass
- [x] Self-reviewed the code
