### PR TITLE
Fix dual-screen quick-load availability after auto-restore

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/DualScreenManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/DualScreenManager.kt
@@ -47,6 +47,7 @@ import com.nendo.argosy.ui.screens.common.GameLaunchDelegate
 import com.nendo.argosy.hardware.FocusAccessibilityService
 import com.nendo.argosy.hardware.FocusDirectorActivity
 import com.nendo.argosy.hardware.SecondaryHomeActivity
+import com.nendo.argosy.hardware.withLiveQuickActionState
 import com.nendo.argosy.util.DisplayAffinityHelper
 import com.nendo.argosy.util.SecondaryDisplayType
 import kotlinx.coroutines.CoroutineScope
@@ -204,7 +205,7 @@ class DualScreenManager(
         }
 
     fun updateCompanionHasQuickSave(hasQuickSave: Boolean) {
-        _swappedCompanionState.value = _swappedCompanionState.value.copy(hasQuickSave = hasQuickSave)
+        _swappedCompanionState.update { it.copy(hasQuickSave = hasQuickSave) }
         companionHost?.onHasQuickSaveChanged(hasQuickSave)
     }
 
@@ -436,6 +437,8 @@ class DualScreenManager(
     )
     val swappedCompanionState: StateFlow<com.nendo.argosy.hardware.CompanionInGameState> =
         _swappedCompanionState
+    val companionHasQuickSave: Boolean
+        get() = _swappedCompanionState.value.hasQuickSave
 
     var swappedSessionTimer: com.nendo.argosy.hardware.CompanionSessionTimer? = null
         private set
@@ -990,22 +993,27 @@ class DualScreenManager(
             scope.launch(Dispatchers.IO) {
                 val game = gameDao.getById(gameId) ?: return@launch
                 val platform = platformRepository.getById(game.platformId)
-                _swappedCompanionState.value = com.nendo.argosy.hardware.CompanionInGameState(
-                    gameId = gameId,
-                    title = game.title,
-                    coverPath = game.coverPath,
-                    platformName = platform?.getDisplayName() ?: game.platformSlug,
-                    developer = game.developer,
-                    releaseYear = game.releaseYear,
-                    playTimeMinutes = game.playTimeMinutes,
-                    playCount = game.playCount,
-                    achievementCount = game.achievementCount,
-                    earnedAchievementCount = game.earnedAchievementCount,
-                    sessionStartTimeMillis = sessionStateStore.getSessionStartTimeMillis(),
-                    channelName = channelName,
-                    isHardcore = isHardcore,
-                    isLoaded = true
-                )
+                _swappedCompanionState.update { liveState ->
+                    com.nendo.argosy.hardware.CompanionInGameState(
+                        gameId = gameId,
+                        title = game.title,
+                        coverPath = game.coverPath,
+                        platformName = platform?.getDisplayName() ?: game.platformSlug,
+                        developer = game.developer,
+                        releaseYear = game.releaseYear,
+                        playTimeMinutes = game.playTimeMinutes,
+                        playCount = game.playCount,
+                        achievementCount = game.achievementCount,
+                        earnedAchievementCount = game.earnedAchievementCount,
+                        sessionStartTimeMillis = sessionStateStore.getSessionStartTimeMillis(),
+                        channelName = channelName,
+                        isHardcore = isHardcore,
+                        isLoaded = true
+                    ).withLiveQuickActionState(
+                        quickActionsAvailable = sessionQuickActions != null,
+                        hasQuickSave = liveState.hasQuickSave
+                    )
+                }
             }
             companionHost?.onSessionStarted(gameId, isHardcore, channelName)
         } else {

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/CompanionPanel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/CompanionPanel.kt
@@ -32,6 +32,19 @@ data class CompanionInGameState(
     val hasQuickSave: Boolean = false
 )
 
+/**
+ * Applies live quick-action state after asynchronously loaded game metadata arrives.
+ * These flags can change while the metadata is being loaded, so the metadata snapshot
+ * must not replace them with their defaults.
+ */
+internal fun CompanionInGameState.withLiveQuickActionState(
+    quickActionsAvailable: Boolean,
+    hasQuickSave: Boolean
+): CompanionInGameState = copy(
+    quickActionsAvailable = quickActionsAvailable,
+    hasQuickSave = hasQuickSave
+)
+
 class CompanionSessionTimer {
     private var screenOnDuration: Duration = Duration.ZERO
     private var lastScreenOnTime: Instant? = null

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeActivity.kt
@@ -789,8 +789,9 @@ class SecondaryHomeActivity :
 
     private fun loadCompanionGameData(gameId: Long) {
         lifecycleScope.launch {
-            companionInGameState = stateManager.loadCompanionGameData(gameId).copy(
-                quickActionsAvailable = dsm.sessionQuickActions != null
+            companionInGameState = stateManager.loadCompanionGameData(gameId).withLiveQuickActionState(
+                quickActionsAvailable = dsm.sessionQuickActions != null,
+                hasQuickSave = dsm.companionHasQuickSave
             )
         }
     }

--- a/app/src/test/kotlin/com/nendo/argosy/hardware/CompanionInGameStateTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/hardware/CompanionInGameStateTest.kt
@@ -1,0 +1,27 @@
+package com.nendo.argosy.hardware
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompanionInGameStateTest {
+
+    @Test
+    fun `metadata refresh preserves live quick save availability`() {
+        val metadata = CompanionInGameState(
+            gameId = 1L,
+            title = "EarthBound",
+            isLoaded = true
+        )
+        val merged = metadata.withLiveQuickActionState(
+            quickActionsAvailable = true,
+            hasQuickSave = true
+        )
+
+        assertEquals(1L, merged.gameId)
+        assertEquals("EarthBound", merged.title)
+        assertTrue(merged.isLoaded)
+        assertTrue(merged.quickActionsAvailable)
+        assertTrue(merged.hasQuickSave)
+    }
+}


### PR DESCRIPTION
## Summary

- preserve live companion quick-action flags when asynchronous game metadata arrives
- apply the same merge for both physical-companion and swapped-screen paths
- update quick-save availability atomically and add regression coverage for the metadata merge

Fixes #294

## Testing

- `./gradlew testDebugUnitTest lintDebug assembleDebug -PallAbis`
- AYN Thor (Android 13), built-in mGBA: created `Bookworm.state.q0`, quit normally, and relaunched with auto-load enabled
- confirmed the auto-state restored from slot `-1` and companion **Load State** was immediately enabled
- confirmed the companion action loaded quick-state slot `100` successfully after its confirmation tap
