### PR TITLE
input: let auxiliary controls yield to hotkeys

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/InputPresets.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/InputPresets.kt
@@ -27,7 +27,13 @@ data class MappingPlatform(
     val id: String,
     val displayName: String,
     val buttons: List<Int>,
-    val buttonLabels: Map<Int, String> = emptyMap()
+    val buttonLabels: Map<Int, String> = emptyMap(),
+    /**
+     * Buttons that retain gameplay priority over a single-button hotkey. Controls that only
+     * duplicate another input route or affect presentation can remain exposed in [buttons]
+     * without shadowing an explicitly configured hotkey.
+     */
+    val hotkeyBlockingButtons: Set<Int> = buttons.toSet()
 )
 
 object MappingPlatforms {
@@ -203,7 +209,13 @@ object MappingPlatforms {
             RetroButton.R2 to "Turbo R",
             RetroButton.L3 to "Darken Solar Sensor",
             RetroButton.R3 to "Brighten Solar Sensor"
-        )
+        ),
+        hotkeyBlockingButtons = setOf(
+            RetroButton.A, RetroButton.B,
+            RetroButton.L, RetroButton.R,
+            RetroButton.L3, RetroButton.R3,
+            RetroButton.START, RetroButton.SELECT
+        ) + DPAD
     )
 
     val N64 = MappingPlatform(
@@ -223,7 +235,12 @@ object MappingPlatforms {
             RetroButton.R2 to "C Buttons (hold)",
             RetroButton.A to "C-Right (C mode)",
             RetroButton.X to "C-Up (C mode)"
-        )
+        ),
+        hotkeyBlockingButtons = setOf(
+            RetroButton.B, RetroButton.Y,
+            RetroButton.L, RetroButton.R, RetroButton.L2,
+            RetroButton.START
+        ) + DPAD
     )
 
     val PSX = MappingPlatform(
@@ -420,7 +437,13 @@ object MappingPlatforms {
             RetroButton.R2 to "Swap Screens",
             RetroButton.L3 to "Close Lid",
             RetroButton.R3 to "Touch Joystick"
-        )
+        ),
+        hotkeyBlockingButtons = setOf(
+            RetroButton.A, RetroButton.B, RetroButton.X, RetroButton.Y,
+            RetroButton.L, RetroButton.R, RetroButton.L2,
+            RetroButton.L3, RetroButton.R3,
+            RetroButton.START, RetroButton.SELECT
+        ) + DPAD
     )
 
     val GAMECUBE = MappingPlatform(
@@ -705,7 +728,7 @@ object InputPresets {
      */
     fun keyMapsToConsoleButton(keyCode: Int, platformSlug: String): Boolean {
         val retroButton = DEFAULT_MAPPING[keyCode] ?: return false
-        return retroButton in MappingPlatforms.profileForSlug(platformSlug).buttons
+        return retroButton in MappingPlatforms.profileForSlug(platformSlug).hotkeyBlockingButtons
     }
 
     fun getPresetNamesForCycling(): List<String> = PRESETS.map { it.name }

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/InputPresets.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/InputPresets.kt
@@ -722,9 +722,9 @@ object InputPresets {
     }
 
     /**
-     * Whether this platform's console controller uses [keyCode] as a real button under the
-     * default mapping. A single-key hotkey on such a button is shadowed by the console button
-     * on that platform, so the editor warns rather than binding something that silently won't fire.
+     * Whether the default mapping sends [keyCode] to a gameplay-priority button on this platform.
+     * The hotkey editor has no per-controller mapping context, so its warning reflects this
+     * default-layout signal; runtime priority uses each controller's resolved mapping.
      */
     fun keyMapsToConsoleButton(keyCode: Int, platformSlug: String): Boolean {
         val retroButton = DEFAULT_MAPPING[keyCode] ?: return false

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/HotkeyManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/HotkeyManager.kt
@@ -21,7 +21,7 @@ class HotkeyManager(
     private var triggeredConfig: HotkeyConfig? = null
     private var limitToPlayer1 = true
     private var player1ControllerId: String? = null
-    private var platformMappedButtons: Set<Int> = emptySet()
+    private var platformMappedButtonsByController: Map<String, Set<Int>> = emptyMap()
     private var dispatchCallback: ((HotkeyConfig) -> Unit)? = null
 
     private var pendingHoldJob: Job? = null
@@ -70,8 +70,8 @@ class HotkeyManager(
         player1ControllerId = controllerId
     }
 
-    fun setPlatformMappedButtons(buttons: Set<Int>) {
-        platformMappedButtons = buttons
+    fun setPlatformMappedButtons(buttonsByController: Map<String, Set<Int>>) {
+        platformMappedButtonsByController = buttonsByController
     }
 
     /**
@@ -101,7 +101,9 @@ class HotkeyManager(
             if (hotkey.keyCodes.isEmpty()) return@filter false
             if (!pressedKeys.containsAll(hotkey.keyCodes)) return@filter false
             if (alreadyPressed.containsAll(hotkey.keyCodes)) return@filter false
-            if (hotkey.keyCodes.size == 1 && hotkey.keyCodes.first() in platformMappedButtons) return@filter false
+            if (hotkey.keyCodes.size == 1 && isPlatformMappedButton(hotkey.keyCodes.first(), controllerId)) {
+                return@filter false
+            }
             true
         }
 
@@ -121,6 +123,12 @@ class HotkeyManager(
             }
             else -> null
         }
+    }
+
+    private fun isPlatformMappedButton(keyCode: Int, controllerId: String?): Boolean {
+        val controllerButtons = controllerId?.let(platformMappedButtonsByController::get)
+        return controllerButtons?.contains(keyCode)
+            ?: platformMappedButtonsByController.values.any { keyCode in it }
     }
 
     private fun startPending(holdHotkey: HotkeyConfig, instantHotkey: HotkeyConfig?) {

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/InputConfigCoordinator.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/InputConfigCoordinator.kt
@@ -58,20 +58,11 @@ class InputConfigCoordinator(
             inputMapper.setExtendedMappings(mappings)
             inputMapper.setPortResolver { device -> portResolver.getPort(device) }
 
-            val hotkeyBlockingButtons = MappingPlatforms.profileForSlug(platformSlug).hotkeyBlockingButtons
-            val platformKeyCodes = mappings.values.firstOrNull()
-                ?.filter { (_, retroButton) -> retroButton in hotkeyBlockingButtons }
-                ?.keys
-                ?.filterIsInstance<InputSource.Button>()
-                ?.map { it.keyCode }
-                ?.toSet()
-                ?: emptySet()
-
             inputConfigRepository.initializeDefaultHotkeys()
             val hotkeys = inputConfigRepository.getEnabledHotkeys()
             hotkeyManager.setHotkeys(resolveScopedHotkeys(hotkeys))
             hotkeyList = inputConfigRepository.getHotkeys()
-            hotkeyManager.setPlatformMappedButtons(platformKeyCodes)
+            hotkeyManager.setPlatformMappedButtons(platformMappedButtons(mappings))
             hotkeyManager.setLimitToPlayer1(limitHotkeysToPlayer1)
 
             if (controllerOrder.isNotEmpty()) {
@@ -107,6 +98,7 @@ class InputConfigCoordinator(
             mappings[controller.controllerId] = mapping
         }
         inputMapper.setExtendedMappings(mappings)
+        hotkeyManager.setPlatformMappedButtons(platformMappedButtons(mappings))
     }
 
     suspend fun refreshHotkeys() {
@@ -122,6 +114,19 @@ class InputConfigCoordinator(
             coreId = coreId,
             parseCombo = inputConfigRepository::parseHotkeyCombo
         )
+
+    private fun platformMappedButtons(
+        mappings: Map<String, Map<InputSource, Int>>
+    ): Map<String, Set<Int>> {
+        val blockingButtons = MappingPlatforms.profileForSlug(platformSlug).hotkeyBlockingButtons
+        return mappings.mapValues { (_, mapping) ->
+            mapping
+                .filter { (_, retroButton) -> retroButton in blockingButtons }
+                .keys
+                .filterIsInstance<InputSource.Button>()
+                .mapTo(mutableSetOf()) { it.keyCode }
+        }
+    }
 
     companion object {
         private const val TAG = "InputConfigCoordinator"

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/InputConfigCoordinator.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/InputConfigCoordinator.kt
@@ -58,10 +58,9 @@ class InputConfigCoordinator(
             inputMapper.setExtendedMappings(mappings)
             inputMapper.setPortResolver { device -> portResolver.getPort(device) }
 
-            val platformIndex = MappingPlatforms.indexForPlatformSlug(platformSlug)
-            val platformButtons = MappingPlatforms.getByIndex(platformIndex).buttons.toSet()
+            val hotkeyBlockingButtons = MappingPlatforms.profileForSlug(platformSlug).hotkeyBlockingButtons
             val platformKeyCodes = mappings.values.firstOrNull()
-                ?.filter { (_, retroButton) -> retroButton in platformButtons }
+                ?.filter { (_, retroButton) -> retroButton in hotkeyBlockingButtons }
                 ?.keys
                 ?.filterIsInstance<InputSource.Button>()
                 ?.map { it.keyCode }

--- a/app/src/test/kotlin/com/nendo/argosy/data/repository/MappingPlatformsTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/repository/MappingPlatformsTest.kt
@@ -1,5 +1,6 @@
 package com.nendo.argosy.data.repository
 
+import android.view.KeyEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -23,6 +24,62 @@ class MappingPlatformsTest {
     fun `platform ids are unique`() {
         val ids = MappingPlatforms.ALL.map { it.id }
         assertEquals(ids.size, ids.toSet().size)
+    }
+
+    @Test
+    fun `hotkey blocking buttons are exposed by their platform`() {
+        MappingPlatforms.ALL.forEach { platform ->
+            assertTrue(
+                "${platform.id} blocks a button it does not expose",
+                platform.buttons.containsAll(platform.hotkeyBlockingButtons)
+            )
+        }
+    }
+
+    @Test
+    fun `gba duplicate turbo controls yield to configured hotkeys`() {
+        val gba = MappingPlatforms.profileForSlug("gba")
+
+        listOf(RetroButton.X, RetroButton.Y, RetroButton.L2, RetroButton.R2).forEach { button ->
+            assertTrue(button in gba.buttons)
+            assertFalse(button in gba.hotkeyBlockingButtons)
+        }
+        assertFalse(InputPresets.keyMapsToConsoleButton(KeyEvent.KEYCODE_BUTTON_L2, "gba"))
+        assertFalse(InputPresets.keyMapsToConsoleButton(KeyEvent.KEYCODE_BUTTON_R2, "gba"))
+        assertTrue(RetroButton.L3 in gba.hotkeyBlockingButtons)
+        assertTrue(RetroButton.R3 in gba.hotkeyBlockingButtons)
+    }
+
+    @Test
+    fun `n64 alternate C button route yields while Z retains priority`() {
+        val n64 = MappingPlatforms.profileForSlug("n64")
+
+        listOf(RetroButton.A, RetroButton.X, RetroButton.R2).forEach { button ->
+            assertTrue(button in n64.buttons)
+            assertFalse(button in n64.hotkeyBlockingButtons)
+        }
+        assertFalse(InputPresets.keyMapsToConsoleButton(KeyEvent.KEYCODE_BUTTON_R2, "n64"))
+        assertTrue(InputPresets.keyMapsToConsoleButton(KeyEvent.KEYCODE_BUTTON_L2, "n64"))
+    }
+
+    @Test
+    fun `ds screen swap yields while microphone retains priority`() {
+        val ds = MappingPlatforms.profileForSlug("nds")
+
+        assertTrue(RetroButton.R2 in ds.buttons)
+        assertFalse(RetroButton.R2 in ds.hotkeyBlockingButtons)
+        assertFalse(InputPresets.keyMapsToConsoleButton(KeyEvent.KEYCODE_BUTTON_R2, "nds"))
+        assertTrue(InputPresets.keyMapsToConsoleButton(KeyEvent.KEYCODE_BUTTON_L2, "nds"))
+    }
+
+    @Test
+    fun `native trigger controls retain gameplay priority`() {
+        val psx = MappingPlatforms.profileForSlug("psx")
+
+        assertTrue(RetroButton.L2 in psx.hotkeyBlockingButtons)
+        assertTrue(RetroButton.R2 in psx.hotkeyBlockingButtons)
+        assertTrue(InputPresets.keyMapsToConsoleButton(KeyEvent.KEYCODE_BUTTON_L2, "psx"))
+        assertTrue(InputPresets.keyMapsToConsoleButton(KeyEvent.KEYCODE_BUTTON_R2, "psx"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/nendo/argosy/libretro/HotkeyManagerTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/libretro/HotkeyManagerTest.kt
@@ -1,0 +1,55 @@
+package com.nendo.argosy.libretro
+
+import android.view.KeyEvent
+import com.nendo.argosy.data.local.entity.HotkeyAction
+import com.nendo.argosy.data.local.entity.HotkeyEntity
+import com.nendo.argosy.data.repository.InputConfigRepository
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HotkeyManagerTest {
+
+    private fun manager(keyCode: Int): HotkeyManager =
+        HotkeyManager(mockk<InputConfigRepository>(relaxed = true)).apply {
+            setHotkeys(
+                listOf(
+                    HotkeyEntity(
+                        action = HotkeyAction.FAST_FORWARD,
+                        buttonComboJson = "[$keyCode]"
+                    )
+                )
+            )
+        }
+
+    @Test
+    fun `platform button priority follows the event controller mapping`() {
+        val keyCode = KeyEvent.KEYCODE_BUTTON_R2
+        val manager = manager(keyCode)
+        manager.setPlatformMappedButtons(
+            mapOf(
+                "gameplay-pad" to setOf(keyCode),
+                "hotkey-pad" to emptySet()
+            )
+        )
+
+        assertNull(manager.onKeyDown(keyCode, "gameplay-pad"))
+        manager.onKeyUp(keyCode)
+        assertEquals(HotkeyAction.FAST_FORWARD, manager.onKeyDown(keyCode, "hotkey-pad")?.action)
+    }
+
+    @Test
+    fun `updated controller mapping replaces hotkey priority`() {
+        val keyCode = KeyEvent.KEYCODE_BUTTON_R2
+        val manager = manager(keyCode)
+        manager.setPlatformMappedButtons(mapOf("pad" to emptySet()))
+
+        assertEquals(HotkeyAction.FAST_FORWARD, manager.onKeyDown(keyCode, "pad")?.action)
+        manager.onKeyUp(keyCode)
+
+        manager.setPlatformMappedButtons(mapOf("pad" to setOf(keyCode)))
+
+        assertNull(manager.onKeyDown(keyCode, "pad"))
+    }
+}


### PR DESCRIPTION
Closes #296.

## Summary

- distinguish gameplay-critical platform buttons from auxiliary controls that may yield to a configured single-button hotkey
- exempt GBA's duplicate turbo controls, N64's alternate C-button route, and Nintendo DS screen swap while preserving gameplay priority for native controls
- evaluate gameplay priority from each event controller's resolved mapping and refresh it alongside live mapping changes
- use the same platform priority policy for runtime dispatch and the remapping UI's default-layout warning
- cover the platform policy, controller isolation, and mapping replacement with regression tests

## Rationale

The per-console profile expansion exposed several controls that duplicate another input route or affect presentation. Treating every exposed control as gameplay-critical caused the default `L2` Rewind and `R2` Fast Forward hotkeys to be shadowed on GBA.

The default remains conservative: every platform button blocks a single-button hotkey unless the platform profile explicitly marks that auxiliary route as non-blocking. Native inputs such as PlayStation triggers, N64 Z, DS microphone, and GBA solar-sensor controls retain gameplay priority. If a conflicting hotkey is cleared or moved, the auxiliary platform mapping still receives the button normally.

## Validation

- `./gradlew testDebugUnitTest --tests com.nendo.argosy.data.repository.MappingPlatformsTest --tests com.nendo.argosy.libretro.HotkeyManagerTest`
- `./gradlew testDebugUnitTest lintDebug assembleDebug -PallAbis`
- AYN Thor hardware test with the updated arm64 debug APK and Bookworm (GBA): default R2 Fast Forward and L2 Rewind both work
