### PR TITLE
settings: scope shader chains to selected platform

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/LibretroSettingsRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/LibretroSettingsRepository.kt
@@ -36,6 +36,12 @@ class LibretroSettingsRepository @Inject constructor(
     suspend fun upsert(settings: PlatformLibretroSettingsEntity): Long =
         platformLibretroSettingsDao.upsert(settings)
 
+    suspend fun setPlatformShaderChain(platformId: Long, shader: String, chainJson: String) {
+        val current = platformLibretroSettingsDao.getByPlatformId(platformId)
+            ?: PlatformLibretroSettingsEntity(platformId = platformId)
+        platformLibretroSettingsDao.upsert(current.copy(shader = shader, shaderChain = chainJson))
+    }
+
     suspend fun deleteByPlatformId(platformId: Long) =
         platformLibretroSettingsDao.deleteByPlatformId(platformId)
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsBuiltinRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsBuiltinRouter.kt
@@ -740,7 +740,7 @@ internal fun routeResetAllPlatformLibretroSettings(vm: SettingsViewModel) {
     vm.viewModelScope.launch {
         val current = vm.libretroSettingsRepo.getByPlatformId(platformContext.platformId) ?: return@launch
         val updated = current.copy(
-            shader = null, filter = null, aspectRatio = null, portraitPosition = null, rotation = null,
+            shader = null, shaderChain = null, filter = null, aspectRatio = null, portraitPosition = null, rotation = null,
             overscanCrop = null, frame = null, blackFrameInsertion = null, fastForwardEnabled = null, fastForwardSpeed = null,
             rewindEnabled = null, rewindSpeed = null, rewindBufferDuration = null,
             skipDuplicateFrames = null, lowLatencyAudio = null, audioVolume = null, vsync = null
@@ -996,7 +996,6 @@ internal fun routeDownloadCoreWithNotification(vm: SettingsViewModel, coreId: St
 }
 
 internal fun routeOpenShaderChainConfig(vm: SettingsViewModel) {
-    vm.shaderChainManager.loadChain(vm._uiState.value.builtinVideo.shaderChainJson)
     vm.loadPreviewGames()
     vm.navigateToSection(SettingsSection.SHADER_STACK)
 }
@@ -1046,16 +1045,51 @@ internal fun routeDownloadAndSelectFrame(vm: SettingsViewModel, frameId: String)
 internal fun routePersistShaderChain(vm: SettingsViewModel, config: ShaderChainConfig) {
     val json = config.toJson()
     val shaderMode = if (config.entries.isNotEmpty()) "Custom" else "None"
-    vm._uiState.update {
-        it.copy(builtinVideo = it.builtinVideo.copy(
-            shader = shaderMode,
-            shaderChainJson = json
-        ))
+    val settingsScope = routeResolveShaderChainSettingsScope(vm._uiState.value)
+    val platformId = settingsScope.platformId
+
+    if (platformId == null) {
+        vm._uiState.update {
+            it.copy(
+                builtinVideo = it.builtinVideo.copy(
+                    shader = shaderMode,
+                    shaderChainJson = json
+                )
+            )
+        }
+        vm.viewModelScope.launch {
+            vm.libretroSettingsRepo.setBuiltinShader(shaderMode)
+            vm.libretroSettingsRepo.setBuiltinShaderChain(json)
+        }
+    } else {
+        vm._uiState.update { state ->
+            val current = state.platformLibretro.platformSettings[platformId]
+                ?: PlatformLibretroSettingsEntity(platformId = platformId)
+            state.copy(
+                platformLibretro = state.platformLibretro.copy(
+                    platformSettings = state.platformLibretro.platformSettings +
+                        (platformId to current.copy(shader = shaderMode, shaderChain = json))
+                )
+            )
+        }
+        vm.viewModelScope.launch {
+            vm.libretroSettingsRepo.setPlatformShaderChain(platformId, shaderMode, json)
+        }
     }
-    vm.viewModelScope.launch {
-        vm.libretroSettingsRepo.setBuiltinShader(shaderMode)
-        vm.libretroSettingsRepo.setBuiltinShaderChain(json)
-    }
+}
+
+internal data class ShaderChainSettingsScope(
+    val platformId: Long?,
+    val chainJson: String
+)
+
+internal fun routeResolveShaderChainSettingsScope(state: SettingsUiState): ShaderChainSettingsScope {
+    val platformId = state.builtinVideo.currentPlatformContext?.platformId
+    val platformChain = platformId?.let { state.platformLibretro.platformSettings[it]?.shaderChain }
+    return ShaderChainSettingsScope(
+        platformId = platformId,
+        chainJson = platformChain ?: state.builtinVideo.shaderChainJson
+    )
 }
 
 internal suspend fun routeResolvePreviewBitmap(vm: SettingsViewModel): Bitmap? {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouter.kt
@@ -55,7 +55,9 @@ internal fun routeNavigateToSection(vm: SettingsViewModel, section: SettingsSect
         }
         SettingsSection.STEAM_SETTINGS -> vm.steamDelegate.loadSteamSettings(vm.context, vm.viewModelScope)
         SettingsSection.PERMISSIONS -> vm.permissionsDelegate.refreshPermissions()
-        SettingsSection.SHADER_STACK -> vm.shaderChainManager.loadChain(vm._uiState.value.builtinVideo.shaderChainJson)
+        SettingsSection.SHADER_STACK -> vm.shaderChainManager.loadChain(
+            routeResolveShaderChainSettingsScope(vm._uiState.value).chainJson
+        )
         SettingsSection.DRIVERS -> vm.driversDelegate.loadDrivers(vm.viewModelScope)
         else -> {}
     }

--- a/app/src/test/kotlin/com/nendo/argosy/data/repository/LibretroSettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/repository/LibretroSettingsRepositoryTest.kt
@@ -1,0 +1,41 @@
+package com.nendo.argosy.data.repository
+
+import com.nendo.argosy.data.local.dao.PlatformLibretroSettingsDao
+import com.nendo.argosy.data.local.entity.PlatformLibretroSettingsEntity
+import com.nendo.argosy.data.preferences.BuiltinEmulatorPreferencesRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LibretroSettingsRepositoryTest {
+    private val platformSettingsDao = mockk<PlatformLibretroSettingsDao>()
+    private val builtinPreferences = mockk<BuiltinEmulatorPreferencesRepository>(relaxed = true)
+    private val repository = LibretroSettingsRepository(platformSettingsDao, builtinPreferences)
+
+    @Test
+    fun `setPlatformShaderChain preserves other platform overrides without changing global settings`() = runTest {
+        val existing = PlatformLibretroSettingsEntity(
+            id = 7L,
+            platformId = 42L,
+            filter = "Nearest",
+            aspectRatio = "4:3",
+            rewindEnabled = false
+        )
+        val saved = slot<PlatformLibretroSettingsEntity>()
+        coEvery { platformSettingsDao.getByPlatformId(42L) } returns existing
+        coEvery { platformSettingsDao.upsert(capture(saved)) } returns 7L
+
+        repository.setPlatformShaderChain(42L, "Custom", """{"passes":[]}""")
+
+        assertEquals(
+            existing.copy(shader = "Custom", shaderChain = """{"passes":[]}"""),
+            saved.captured
+        )
+        coVerify(exactly = 0) { builtinPreferences.setBuiltinShader(any()) }
+        coVerify(exactly = 0) { builtinPreferences.setBuiltinShaderChain(any()) }
+    }
+}

--- a/app/src/test/kotlin/com/nendo/argosy/ui/screens/settings/ShaderChainSettingsScopeTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/ui/screens/settings/ShaderChainSettingsScopeTest.kt
@@ -1,0 +1,73 @@
+package com.nendo.argosy.ui.screens.settings
+
+import com.nendo.argosy.data.local.entity.PlatformLibretroSettingsEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ShaderChainSettingsScopeTest {
+    private val platform = PlatformContext(
+        platformId = 42L,
+        platformName = "Super Nintendo Entertainment System",
+        platformSlug = "snes"
+    )
+
+    @Test
+    fun `global context uses the global chain`() {
+        val state = SettingsUiState(
+            builtinVideo = BuiltinVideoState(
+                shaderChainJson = "global-chain",
+                availablePlatforms = listOf(platform)
+            ),
+            platformLibretro = PlatformLibretroState(
+                platformSettings = mapOf(
+                    42L to PlatformLibretroSettingsEntity(
+                        platformId = 42L,
+                        shaderChain = "platform-chain"
+                    )
+                )
+            )
+        )
+
+        val scope = routeResolveShaderChainSettingsScope(state)
+
+        assertNull(scope.platformId)
+        assertEquals("global-chain", scope.chainJson)
+    }
+
+    @Test
+    fun `platform context uses its own chain`() {
+        val state = platformState(shaderChain = "platform-chain")
+
+        val scope = routeResolveShaderChainSettingsScope(state)
+
+        assertEquals(42L, scope.platformId)
+        assertEquals("platform-chain", scope.chainJson)
+    }
+
+    @Test
+    fun `platform context inherits the global chain when it has no override`() {
+        val state = platformState(shaderChain = null)
+
+        val scope = routeResolveShaderChainSettingsScope(state)
+
+        assertEquals(42L, scope.platformId)
+        assertEquals("global-chain", scope.chainJson)
+    }
+
+    private fun platformState(shaderChain: String?): SettingsUiState = SettingsUiState(
+        builtinVideo = BuiltinVideoState(
+            shaderChainJson = "global-chain",
+            platformContextIndex = 1,
+            availablePlatforms = listOf(platform)
+        ),
+        platformLibretro = PlatformLibretroState(
+            platformSettings = mapOf(
+                42L to PlatformLibretroSettingsEntity(
+                    platformId = 42L,
+                    shaderChain = shaderChain
+                )
+            )
+        )
+    )
+}


### PR DESCRIPTION
## Summary
Make the shader-chain editor honor the active Global/platform context when loading and saving a chain.

The platform path now updates the selected platform's shader mode and chain together while preserving its other libretro overrides. The existing Global path remains unchanged.

Fixes #303.

## Behavior changes
- Configuring a custom shader chain in a platform context affects only that platform instead of overwriting Global.
- A platform without its own stored chain initially inherits the Global chain when the editor opens.
- **Reset all** now clears the platform's stored shader chain along with its shader mode.

## Hot paths
No launch, frame, sync, network, or blocking path changes.

Saving a chain already performed persistence from the settings screen. In platform context, that user-driven operation now writes one per-platform Room entity instead of writing the two Global preferences.

## Testing evidence
- Tested on an AYN Thor running Android 13 with a debug build based on 2.4.0-beta.2/current `main`.
- Left Global at `None`, selected SNES, configured `crt-lottes`, and confirmed Global plus an untouched platform remained at their defaults.
- Force-stopped and relaunched Argosy, then confirmed the platform override persisted without contaminating Global.
- A read-only database snapshot showed the sole shader override on SNES as `Custom` with the `crt-lottes` chain; unrelated platform overrides were preserved.
- `./gradlew testDebugUnitTest -PallAbis`
- `./gradlew lintDebug -PallAbis`
- `./gradlew assembleDebug`
- `python3 scripts/ci/agentic-smells.py --range 'origin/main...HEAD'`

## AI assistance
Implemented collaboratively with OpenAI Codex. Codex performed the code-path diagnosis, and the implementation and regression tests were authored collaboratively. I steered the design, ran local/CI-equivalent validation, and completed device installation and persistence inspection - then reproduced the bug, reviewed the behaviour, and performed the real hardware verification.

## Checklist
- [x] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
