### PR TITLE
ui: restore built-in emulator parent focus

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsBuiltinRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsBuiltinRouter.kt
@@ -15,6 +15,7 @@ import com.nendo.argosy.ui.input.HapticPattern
 import com.nendo.argosy.core.notification.NotificationType
 import com.nendo.argosy.core.notification.showError
 import com.nendo.argosy.core.emulator.LibretroSettingDef
+import com.nendo.argosy.ui.screens.settings.sections.BuiltinEmulatorItem
 import com.nendo.argosy.util.AppPaths
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
@@ -78,7 +79,11 @@ internal fun routeSetBuiltinArchitecture(vm: SettingsViewModel, value: String) {
 }
 
 internal fun routeSetBuiltinLibretroEnabled(vm: SettingsViewModel, enabled: Boolean) {
-    val newToggleIndex = if (enabled) 3 else 0
+    val newToggleIndex = if (enabled) {
+        BuiltinEmulatorItem.CONTROLS.focusIndex
+    } else {
+        BuiltinEmulatorItem.ENABLE.focusIndex
+    }
     vm._uiState.update { state ->
         val adjustedParentIndex = when {
             enabled && state.parentFocusIndex >= 2 -> state.parentFocusIndex + 1

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
@@ -12,6 +12,7 @@ import com.nendo.argosy.ui.screens.settings.sections.AmbientLedItem
 import com.nendo.argosy.ui.screens.settings.sections.ambientLedItemAtFocusIndex
 import com.nendo.argosy.ui.screens.settings.sections.ambientLedMaxFocusIndex
 import com.nendo.argosy.ui.screens.settings.sections.BiosItem
+import com.nendo.argosy.ui.screens.settings.sections.BuiltinEmulatorItem
 import com.nendo.argosy.ui.screens.settings.sections.PlatformDetailItem
 import com.nendo.argosy.ui.screens.settings.sections.platformDetailItemAtFocusIndex
 import com.nendo.argosy.ui.screens.settings.sections.platformDetailMaxFocusIndex
@@ -860,6 +861,24 @@ private fun routeFramePickerConfirm(vm: SettingsViewModel, state: SettingsUiStat
     return InputResult.HANDLED
 }
 
+internal fun builtinEmulatorParentItem(section: SettingsSection): BuiltinEmulatorItem? = when (section) {
+    SettingsSection.BUILTIN_VIDEO -> BuiltinEmulatorItem.VIDEO
+    SettingsSection.BUILTIN_CONTROLS -> BuiltinEmulatorItem.CONTROLS
+    SettingsSection.CORE_MANAGEMENT -> BuiltinEmulatorItem.CORE_MANAGEMENT
+    SettingsSection.CORE_OPTIONS -> BuiltinEmulatorItem.CORE_OPTIONS
+    else -> null
+}
+
+private fun routeReturnToBuiltinEmulator(vm: SettingsViewModel, childSection: SettingsSection) {
+    val parentItem = requireNotNull(builtinEmulatorParentItem(childSection))
+    vm._uiState.update {
+        it.copy(
+            currentSection = SettingsSection.BUILTIN_EMULATOR,
+            focusedIndex = parentItem.focusIndex
+        )
+    }
+}
+
 internal fun routeNavigateBack(vm: SettingsViewModel): Boolean {
     val state = vm._uiState.value
     return when {
@@ -963,7 +982,7 @@ internal fun routeNavigateBack(vm: SettingsViewModel): Boolean {
                     platformDetail = it.platformDetail.copy(builtinEnteredFromPlatform = false)
                 ) }
             } else {
-                vm._uiState.update { it.copy(currentSection = SettingsSection.BUILTIN_EMULATOR, focusedIndex = 1) }
+                routeReturnToBuiltinEmulator(vm, state.currentSection)
             }; true
         }
         state.currentSection == SettingsSection.BUILTIN_CONTROLS -> {
@@ -974,11 +993,11 @@ internal fun routeNavigateBack(vm: SettingsViewModel): Boolean {
                     platformDetail = it.platformDetail.copy(builtinEnteredFromPlatform = false)
                 ) }
             } else {
-                vm._uiState.update { it.copy(currentSection = SettingsSection.BUILTIN_EMULATOR, focusedIndex = 2) }
+                routeReturnToBuiltinEmulator(vm, state.currentSection)
             }; true
         }
         state.currentSection == SettingsSection.CORE_MANAGEMENT -> {
-            vm._uiState.update { it.copy(currentSection = SettingsSection.BUILTIN_EMULATOR, focusedIndex = 3) }; true
+            routeReturnToBuiltinEmulator(vm, state.currentSection); true
         }
         state.currentSection == SettingsSection.CORE_OPTIONS -> {
             if (state.platformDetail.builtinEnteredFromPlatform) {
@@ -988,7 +1007,7 @@ internal fun routeNavigateBack(vm: SettingsViewModel): Boolean {
                     platformDetail = it.platformDetail.copy(builtinEnteredFromPlatform = false)
                 ) }
             } else {
-                vm._uiState.update { it.copy(currentSection = SettingsSection.BUILTIN_EMULATOR, focusedIndex = 4) }
+                routeReturnToBuiltinEmulator(vm, state.currentSection)
             }; true
         }
         state.currentSection == SettingsSection.PLATFORM_DETAIL && state.platformDetail.showRemoveConfirm -> {
@@ -1090,7 +1109,11 @@ private fun computeMaxFocusIndex(
     SettingsSection.PLATFORMS -> emulatorsMaxFocusIndex(
         state.emulators.platforms.size
     )
-    SettingsSection.BUILTIN_EMULATOR -> if (state.emulators.builtinLibretroEnabled) 6 else 0
+    SettingsSection.BUILTIN_EMULATOR -> if (state.emulators.builtinLibretroEnabled) {
+        BuiltinEmulatorItem.TWO_COLUMN.focusIndex
+    } else {
+        BuiltinEmulatorItem.ENABLE.focusIndex
+    }
     SettingsSection.PLATFORM_DETAIL -> platformDetailMaxFocusIndex(state)
     SettingsSection.BUILTIN_VIDEO -> builtinVideoMaxFocusIndex(state.builtinVideo, state.platformLibretro.platformSettings)
     SettingsSection.BUILTIN_CONTROLS -> builtinControlsMaxFocusIndex(state.builtinControls)
@@ -1165,17 +1188,19 @@ private fun routePlatformDetailConfirm(vm: SettingsViewModel, state: SettingsUiS
 
 private fun routeBuiltinEmulatorConfirm(vm: SettingsViewModel, state: SettingsUiState): InputResult {
     val builtinEnabled = state.emulators.builtinLibretroEnabled
-    when (state.focusedIndex) {
-        0 -> vm.setBuiltinLibretroEnabled(!builtinEnabled)
-        1 -> if (builtinEnabled) {
+    when (BuiltinEmulatorItem.entries.getOrNull(state.focusedIndex)) {
+        BuiltinEmulatorItem.ENABLE -> vm.setBuiltinLibretroEnabled(!builtinEnabled)
+        BuiltinEmulatorItem.ARCHITECTURE -> if (builtinEnabled) {
             vm.requestEnumPicker(BUILTIN_ARCHITECTURE_PICKER_KEY)
             return InputResult.handled(SoundType.OPEN_MODAL)
         }
-        2 -> if (builtinEnabled) vm.navigateToBuiltinVideo()
-        3 -> if (builtinEnabled) vm.navigateToBuiltinControls()
-        4 -> if (builtinEnabled) vm.navigateToCoreManagement()
-        5 -> if (builtinEnabled) vm.navigateToCoreOptions()
-        6 -> if (builtinEnabled) vm.setIngameMenuTwoColumn(!state.emulators.ingameMenuTwoColumn)
+        BuiltinEmulatorItem.VIDEO -> if (builtinEnabled) vm.navigateToBuiltinVideo()
+        BuiltinEmulatorItem.CONTROLS -> if (builtinEnabled) vm.navigateToBuiltinControls()
+        BuiltinEmulatorItem.CORE_MANAGEMENT -> if (builtinEnabled) vm.navigateToCoreManagement()
+        BuiltinEmulatorItem.CORE_OPTIONS -> if (builtinEnabled) vm.navigateToCoreOptions()
+        BuiltinEmulatorItem.TWO_COLUMN ->
+            if (builtinEnabled) vm.setIngameMenuTwoColumn(!state.emulators.ingameMenuTwoColumn)
+        null -> {}
     }
     return InputResult.HANDLED
 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/BuiltinEmulatorSection.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/BuiltinEmulatorSection.kt
@@ -18,6 +18,18 @@ import com.nendo.argosy.ui.screens.settings.SettingsUiState
 import com.nendo.argosy.ui.screens.settings.SettingsViewModel
 import com.nendo.argosy.ui.theme.Dimens
 
+internal enum class BuiltinEmulatorItem {
+    ENABLE,
+    ARCHITECTURE,
+    VIDEO,
+    CONTROLS,
+    CORE_MANAGEMENT,
+    CORE_OPTIONS,
+    TWO_COLUMN;
+
+    val focusIndex: Int get() = ordinal
+}
+
 @Composable
 fun BuiltinEmulatorSection(
     uiState: SettingsUiState,
@@ -39,7 +51,7 @@ fun BuiltinEmulatorSection(
                 title = "Enable Built-in Emulator",
                 subtitle = "Use LibRetro cores for supported platforms",
                 isEnabled = builtinEnabled,
-                isFocused = uiState.focusedIndex == 0,
+                isFocused = uiState.focusedIndex == BuiltinEmulatorItem.ENABLE.focusIndex,
                 onToggle = { viewModel.setBuiltinLibretroEnabled(it) }
             )
         }
@@ -49,7 +61,7 @@ fun BuiltinEmulatorSection(
                 CyclePreference(
                     title = "Architecture",
                     value = emulators.architectureDisplay,
-                    isFocused = uiState.focusedIndex == 1,
+                    isFocused = uiState.focusedIndex == BuiltinEmulatorItem.ARCHITECTURE.focusIndex,
                     onClick = { viewModel.cycleBuiltinArchitecture(1) },
                     onPrev = { viewModel.cycleBuiltinArchitecture(-1) },
                     options = architectureOptions,
@@ -64,7 +76,7 @@ fun BuiltinEmulatorSection(
                 ActionPreference(
                     title = "A/V & Performance",
                     subtitle = "Shaders, display, performance, saving",
-                    isFocused = uiState.focusedIndex == 2,
+                    isFocused = uiState.focusedIndex == BuiltinEmulatorItem.VIDEO.focusIndex,
                     onClick = { viewModel.navigateToBuiltinVideo() }
                 )
             }
@@ -72,7 +84,7 @@ fun BuiltinEmulatorSection(
                 ActionPreference(
                     title = "Controls",
                     subtitle = "Rumble, input mapping, hotkeys",
-                    isFocused = uiState.focusedIndex == 3,
+                    isFocused = uiState.focusedIndex == BuiltinEmulatorItem.CONTROLS.focusIndex,
                     onClick = { viewModel.navigateToBuiltinControls() }
                 )
             }
@@ -81,7 +93,7 @@ fun BuiltinEmulatorSection(
                 ActionPreference(
                     title = "Manage Cores",
                     subtitle = "${emulators.installedCoreCount} of ${emulators.totalCoreCount} cores installed",
-                    isFocused = uiState.focusedIndex == 4,
+                    isFocused = uiState.focusedIndex == BuiltinEmulatorItem.CORE_MANAGEMENT.focusIndex,
                     onClick = { viewModel.navigateToCoreManagement() },
                     badge = if (updatesAvailable > 0) "$updatesAvailable update${if (updatesAvailable > 1) "s" else ""}" else null
                 )
@@ -90,7 +102,7 @@ fun BuiltinEmulatorSection(
                 ActionPreference(
                     title = "Core Options",
                     subtitle = "Per-core settings and overrides",
-                    isFocused = uiState.focusedIndex == 5,
+                    isFocused = uiState.focusedIndex == BuiltinEmulatorItem.CORE_OPTIONS.focusIndex,
                     onClick = { viewModel.navigateToCoreOptions() }
                 )
             }
@@ -103,7 +115,7 @@ fun BuiltinEmulatorSection(
                         "In-game menu uses a single column"
                     },
                     isEnabled = emulators.ingameMenuTwoColumn,
-                    isFocused = uiState.focusedIndex == 6,
+                    isFocused = uiState.focusedIndex == BuiltinEmulatorItem.TWO_COLUMN.focusIndex,
                     onToggle = { viewModel.setIngameMenuTwoColumn(it) }
                 )
             }

--- a/app/src/test/kotlin/com/nendo/argosy/ui/screens/settings/BuiltinEmulatorNavigationTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/ui/screens/settings/BuiltinEmulatorNavigationTest.kt
@@ -1,0 +1,33 @@
+package com.nendo.argosy.ui.screens.settings
+
+import com.nendo.argosy.ui.screens.settings.sections.BuiltinEmulatorItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BuiltinEmulatorNavigationTest {
+    @Test
+    fun `child sections return to their originating built-in emulator rows`() {
+        assertEquals(
+            BuiltinEmulatorItem.VIDEO,
+            builtinEmulatorParentItem(SettingsSection.BUILTIN_VIDEO)
+        )
+        assertEquals(
+            BuiltinEmulatorItem.CONTROLS,
+            builtinEmulatorParentItem(SettingsSection.BUILTIN_CONTROLS)
+        )
+        assertEquals(
+            BuiltinEmulatorItem.CORE_MANAGEMENT,
+            builtinEmulatorParentItem(SettingsSection.CORE_MANAGEMENT)
+        )
+        assertEquals(
+            BuiltinEmulatorItem.CORE_OPTIONS,
+            builtinEmulatorParentItem(SettingsSection.CORE_OPTIONS)
+        )
+    }
+
+    @Test
+    fun `unrelated sections have no built-in emulator parent row`() {
+        assertNull(builtinEmulatorParentItem(SettingsSection.MAIN))
+    }
+}


### PR DESCRIPTION
Closes #305

## Summary
The Built-in Emulator menu's child-screen return routes still used numeric positions from before the Architecture row was added. This replaces those stale positions with a semantic menu-item model shared by rendering, confirmation, focus bounds, toggle adjustment, and Back navigation. A regression test defends the child-to-originating-row mapping.

## Behavior changes
- Returning from A/V & Performance selects A/V & Performance.
- Returning from Controls selects Controls.
- Returning from Manage Cores selects Manage Cores.
- Returning from Core Options selects Core Options.
- Platform-specific entry and return paths are unchanged.

## Hot paths
No I/O, network, database, or blocking work is added. The change only resolves semantic menu items during settings rendering and controller navigation.

## Testing evidence
- Installed the debug APK on an AYN Thor running Android 13.
- Entered and returned from all four Built-in Emulator child screens with the controller; each returned to its originating row.
- Ran the focused navigation regression test, the full debug unit suite, debug lint/APK assembly, and the exact all-ABI unit/lint gate.
- Ran the repository agentic-smell check against the staged patch; clean.

## AI assistance
Implemented collaboratively with OpenAI Codex. Codex performed the code-path diagnosis, and the implementation and regression tests were authored collaboratively. I steered the design and scope, personally reviewed and approved every line, reproduced the bug, reviewed the resulting behaviour, and performed the real-hardware verification on an AYN Thor. Codex ran the local and CI-equivalent validation, built and installed the debug APK, and inspected the relevant navigation paths.

## Checklist
- [x] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
