### PR TITLE
ui: keep restored list focus stationary

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/ui/components/SectionScroll.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/components/SectionScroll.kt
@@ -5,9 +5,26 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import kotlin.math.abs
+
+internal enum class FocusedScrollBehavior {
+    KEEP,
+    SNAP,
+    ANIMATE
+}
+
+internal fun focusedScrollBehavior(
+    isInitialPass: Boolean,
+    isTargetFullyVisible: Boolean,
+    jumped: Boolean = false
+): FocusedScrollBehavior = when {
+    isInitialPass && isTargetFullyVisible -> FocusedScrollBehavior.KEEP
+    isInitialPass || jumped -> FocusedScrollBehavior.SNAP
+    else -> FocusedScrollBehavior.ANIMATE
+}
 
 data class ListSection(
     val name: String? = null,
@@ -22,7 +39,11 @@ fun FocusedScroll(
     listState: LazyListState,
     focusedIndex: Int
 ) {
+    var isInitialPass by remember(listState) { mutableStateOf(true) }
+
     LaunchedEffect(focusedIndex) {
+        val initialPass = isInitialPass
+        isInitialPass = false
         val layoutInfo = listState.layoutInfo
         val visibleItems = layoutInfo.visibleItemsInfo
 
@@ -36,17 +57,32 @@ fun FocusedScroll(
 
         val viewportHeight = layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset
         val targetItem = visibleItems.find { it.index == focusedIndex }
+        val isTargetFullyVisible = targetItem != null &&
+            targetItem.offset >= layoutInfo.viewportStartOffset &&
+            targetItem.offset + targetItem.size <= layoutInfo.viewportEndOffset
+        val behavior = focusedScrollBehavior(initialPass, isTargetFullyVisible)
+        if (behavior == FocusedScrollBehavior.KEEP) {
+            return@LaunchedEffect
+        }
         val itemHeight = targetItem?.size ?: visibleItems.maxOfOrNull { it.size } ?: 80
         val lastListIndex = layoutInfo.totalItemsCount - 1
 
+        suspend fun scroll(index: Int, offset: Int) {
+            if (behavior == FocusedScrollBehavior.SNAP) {
+                listState.scrollToItem(index, offset)
+            } else {
+                listState.animateScrollToItem(index, offset)
+            }
+        }
+
         if (focusedIndex >= lastListIndex) {
             val bottomAlignOffset = if (targetItem != null) itemHeight - viewportHeight else 0
-            listState.animateScrollToItem(lastListIndex, bottomAlignOffset)
+            scroll(lastListIndex, bottomAlignOffset)
             return@LaunchedEffect
         }
 
         val centerOffset = (viewportHeight - itemHeight) / 2
-        listState.animateScrollToItem(focusedIndex, -centerOffset)
+        scroll(focusedIndex, -centerOffset)
     }
 }
 
@@ -58,8 +94,11 @@ fun SectionFocusedScroll(
     sections: List<ListSection>
 ) {
     var previousFocusIndex by remember { mutableIntStateOf(focusedIndex) }
+    var isInitialPass by remember(listState) { mutableStateOf(true) }
 
     LaunchedEffect(focusedIndex) {
+        val initialPass = isInitialPass
+        isInitialPass = false
         val jumped = abs(focusedIndex - previousFocusIndex) > 1
         previousFocusIndex = focusedIndex
 
@@ -72,11 +111,18 @@ fun SectionFocusedScroll(
         val viewportHeight = layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset
         val listIndex = focusToListIndex(focusedIndex)
         val targetItem = visibleItems.find { it.index == listIndex }
+        val isTargetFullyVisible = targetItem != null &&
+            targetItem.offset >= layoutInfo.viewportStartOffset &&
+            targetItem.offset + targetItem.size <= layoutInfo.viewportEndOffset
+        val behavior = focusedScrollBehavior(initialPass, isTargetFullyVisible, jumped)
+        if (behavior == FocusedScrollBehavior.KEEP) {
+            return@LaunchedEffect
+        }
         val itemHeight = targetItem?.size ?: visibleItems.maxOfOrNull { it.size } ?: 80
         val lastListIndex = layoutInfo.totalItemsCount - 1
 
         suspend fun scroll(index: Int, offset: Int) {
-            if (jumped) {
+            if (behavior == FocusedScrollBehavior.SNAP) {
                 listState.scrollToItem(index, offset)
             } else {
                 listState.animateScrollToItem(index, offset)

--- a/app/src/test/kotlin/com/nendo/argosy/ui/components/SectionScrollTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/ui/components/SectionScrollTest.kt
@@ -1,0 +1,42 @@
+package com.nendo.argosy.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SectionScrollTest {
+    @Test
+    fun `initially visible focus remains stationary`() {
+        assertEquals(
+            FocusedScrollBehavior.KEEP,
+            focusedScrollBehavior(isInitialPass = true, isTargetFullyVisible = true)
+        )
+    }
+
+    @Test
+    fun `initially clipped focus snaps fully into view`() {
+        assertEquals(
+            FocusedScrollBehavior.SNAP,
+            focusedScrollBehavior(isInitialPass = true, isTargetFullyVisible = false)
+        )
+    }
+
+    @Test
+    fun `ordinary focus movement remains animated`() {
+        assertEquals(
+            FocusedScrollBehavior.ANIMATE,
+            focusedScrollBehavior(isInitialPass = false, isTargetFullyVisible = true)
+        )
+    }
+
+    @Test
+    fun `large focus jumps remain immediate`() {
+        assertEquals(
+            FocusedScrollBehavior.SNAP,
+            focusedScrollBehavior(
+                isInitialPass = false,
+                isTargetFullyVisible = false,
+                jumped = true
+            )
+        )
+    }
+}


### PR DESCRIPTION
Closes #307

## Summary
The shared focus-scroll helpers always recentered restored focus when a settings list mounted. If the footer spacer was collapsing at the same time, the changing viewport made that animation move the row up and then back down.

This keeps a fully visible restored target stationary, snaps an initially clipped or off-screen target into view, and preserves the existing animation for subsequent focus movement.

## Behavior changes
- Returning to a list keeps an already-visible restored focus row stationary while surrounding layout changes.
- An initially clipped or off-screen focused row still snaps into view.
- Ordinary D-pad focus movement remains animated, and large section jumps remain immediate.

## Hot paths
No I/O, network, database, or blocking work is added. This is UI-only state used by the existing per-focus scroll effect: one remembered initial-pass flag and viewport geometry checks.

## Testing evidence
Reproduced and verified on an AYN Thor running Android 13. Frame analysis of device recordings measured about 25 px of row travel when returning from Controls and about 68 px from Core Options before the change; afterward, the Controls row had zero movement and the Core Options row center remained stationary through the footer transition.

I personally exercised both return paths and ordinary list navigation on the device, and validated that the resulting motion, look, feel, and overall UX are polished in real use. The hardware APK included #306 solely so the intended restored-selection path could be exercised; this PR is independent and contains only the shared scroll behavior change. The behavior decision is covered by focused regression tests, and the full unit-test and lint gate was also run with all ABIs enabled.

## AI assistance
Implemented collaboratively with OpenAI Codex. Codex performed the code-path diagnosis and frame-capture analysis, and the implementation and regression tests were authored collaboratively. I steered the design and scope, personally reviewed, understand, and approve every line being submitted, reproduced the bug, reviewed the resulting behavior, and performed the real-hardware verification on an AYN Thor—including the navigation feel, motion, and overall UX polish. Codex ran the local and CI-equivalent validation, built and installed the debug APK, and inspected and analyzed the relevant navigation paths.

## Checklist
- [x] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
