### PR TITLE
fix: align core selection with effective emulator

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/DualScreenManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/DualScreenManager.kt
@@ -81,7 +81,7 @@ class DualScreenManager(
     private val saveCacheManager: SaveCacheManager,
     private val getUnifiedSavesUseCase: GetUnifiedSavesUseCase,
     private val restoreCachedSaveUseCase: RestoreCachedSaveUseCase,
-    private val emulatorResolver: EmulatorResolver,
+    internal val emulatorResolver: EmulatorResolver,
     private val fetchAchievementsUseCase: FetchAchievementsUseCase,
     internal val displayAffinityHelper: DisplayAffinityHelper,
     internal val sessionStateStore: SessionStateStore,
@@ -2181,7 +2181,7 @@ class DualScreenManager(
             displayAffinityHelper = displayAffinityHelper,
             downloadFileStatusRepository = downloadFileStatusRepository,
             sessionStateStore = sessionStateStore,
-            preferencesRepository = preferencesRepository,
+            emulatorResolver = emulatorResolver,
             context = appContext
         )
         vm.loadGame(gameId)

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/EmulatorRegistry.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/EmulatorRegistry.kt
@@ -293,6 +293,11 @@ data class RetroArchCore(
     val displayName: String
 )
 
+data class ResolvedCoreSelection(
+    val availableCores: List<RetroArchCore>,
+    val selectedCore: RetroArchCore?
+)
+
 data class ExtensionOption(
     val extension: String,
     val label: String
@@ -1395,6 +1400,34 @@ object EmulatorRegistry {
         } else {
             getSelectableCores(platformId, false).firstOrNull()
         }
+
+    fun resolveCoreSelection(
+        platformId: String,
+        isBuiltIn: Boolean,
+        storedCoreId: String?
+    ): ResolvedCoreSelection = resolveCoreSelection(
+        platformId = platformId,
+        isBuiltIn = isBuiltIn,
+        storedCoreIds = listOf(storedCoreId)
+    )
+
+    fun resolveCoreSelection(
+        platformId: String,
+        isBuiltIn: Boolean,
+        storedCoreIds: Iterable<String?>
+    ): ResolvedCoreSelection {
+        val availableCores = getSelectableCores(platformId, isBuiltIn)
+        val selectedCore = storedCoreIds.asSequence()
+            .filterNotNull()
+            .filter { it.isNotBlank() }
+            .mapNotNull { storedCoreId ->
+                availableCores.firstOrNull { it.id == storedCoreId }
+                    ?: availableCores.firstOrNull { it.id.startsWith(storedCoreId) }
+            }
+            .firstOrNull()
+            ?: getDefaultSelectableCore(platformId, isBuiltIn)
+        return ResolvedCoreSelection(availableCores, selectedCore)
+    }
 
     private val retroArchSaveDirByCore: Map<String, String> = mapOf(
         "snes9x2010" to "Snes9x 2010",

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/EmulatorResolver.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/EmulatorResolver.kt
@@ -2,6 +2,7 @@ package com.nendo.argosy.data.emulator
 
 import com.nendo.argosy.data.local.dao.EmulatorConfigDao
 import com.nendo.argosy.data.local.entity.EmulatorConfigEntity
+import com.nendo.argosy.data.platform.PlatformDefinitions
 import com.nendo.argosy.data.platform.InstalledAppResolver
 import com.nendo.argosy.data.preferences.UserPreferencesRepository
 import com.nendo.argosy.libretro.LibretroCoreManager
@@ -29,39 +30,67 @@ class EmulatorResolver @Inject constructor(
         }
     }
 
-    suspend fun getEmulatorPackageForGame(gameId: Long, platformId: Long, platformSlug: String): String? {
-        if (emulatorDetector.installedEmulators.value.isEmpty()) {
-            emulatorDetector.detectEmulators()
-        }
-
-        val builtinEnabled = userPreferencesRepository.userPreferences.first().builtinLibretroEnabled
-
-        var installedPackages = emulatorDetector.installedEmulators.value
-            .map { it.def.packageName }
-            .toSet()
-
+    suspend fun getEmulatorForGame(
+        gameId: Long,
+        platformId: Long,
+        platformSlug: String
+    ): EmulatorDef? {
         val gameOverride = emulatorConfigDao.getByGameId(gameId)
         val platformDefault = emulatorConfigDao.getDefaultForPlatform(platformId)
+        return resolveEmulator(platformSlug, gameOverride, platformDefault)
+    }
 
-        val configuredPackage = gameOverride?.packageName ?: platformDefault?.packageName
-        if (configuredPackage != null && configuredPackage !in installedPackages) {
-            emulatorDetector.detectEmulators()
-            installedPackages = emulatorDetector.installedEmulators.value
-                .map { it.def.packageName }
-                .toSet()
-        }
+    suspend fun getEmulatorForPlatform(platformId: Long, platformSlug: String): EmulatorDef? {
+        val platformDefault = emulatorConfigDao.getDefaultForPlatform(platformId)
+        return resolveEmulator(platformSlug, platformDefault)
+    }
 
-        gameOverride.acceptableLaunchPackage(platformSlug, installedPackages, builtinEnabled)?.let { return it }
-        platformDefault.acceptableLaunchPackage(platformSlug, installedPackages, builtinEnabled)?.let { return it }
-
-        val adHocPackage = gameOverride.adHocPackageOrNull() ?: platformDefault.adHocPackageOrNull()
-        if (adHocPackage != null) return adHocPackage
-
-        return emulatorDetector.getPreferredEmulator(platformSlug, builtinEnabled)?.def?.packageName
+    suspend fun getEmulatorPackageForGame(gameId: Long, platformId: Long, platformSlug: String): String? {
+        return getEmulatorForGame(gameId, platformId, platformSlug)?.packageName
     }
 
     suspend fun getEmulatorIdForGame(gameId: Long, platformId: Long, platformSlug: String): String? {
-        return getEmulatorPackageForGame(gameId, platformId, platformSlug)?.let { resolveEmulatorId(it) }
+        return getEmulatorForGame(gameId, platformId, platformSlug)?.id
+    }
+
+    suspend fun resolveCoreSelectionForGame(
+        gameId: Long,
+        platformId: Long,
+        platformSlug: String,
+        emulator: EmulatorDef
+    ): ResolvedCoreSelection? {
+        if (!emulator.launchConfig.isCoreSelectable) return null
+        val gameOverride = emulatorConfigDao.getByGameId(gameId)
+        val platformDefault = emulatorConfigDao.getDefaultForPlatform(platformId)
+        val legacyCore = if (emulator.launchConfig is LaunchConfig.BuiltIn) {
+            userPreferencesRepository.getBuiltinCoreSelections().first()[platformSlug]
+        } else {
+            null
+        }
+        return EmulatorRegistry.resolveCoreSelection(
+            platformId = platformSlug,
+            isBuiltIn = emulator.launchConfig is LaunchConfig.BuiltIn,
+            storedCoreIds = listOf(gameOverride?.coreName, platformDefault?.coreName, legacyCore)
+        )
+    }
+
+    suspend fun resolveCoreSelectionForPlatform(
+        platformId: Long,
+        platformSlug: String,
+        emulator: EmulatorDef
+    ): ResolvedCoreSelection? {
+        if (!emulator.launchConfig.isCoreSelectable) return null
+        val platformDefault = emulatorConfigDao.getDefaultForPlatform(platformId)
+        val legacyCore = if (emulator.launchConfig is LaunchConfig.BuiltIn) {
+            userPreferencesRepository.getBuiltinCoreSelections().first()[platformSlug]
+        } else {
+            null
+        }
+        return EmulatorRegistry.resolveCoreSelection(
+            platformId = platformSlug,
+            isBuiltIn = emulator.launchConfig is LaunchConfig.BuiltIn,
+            storedCoreIds = listOf(platformDefault?.coreName, legacyCore)
+        )
     }
 
     fun getInstalledForPlatform(platformSlug: String): List<InstalledEmulator> {
@@ -72,24 +101,63 @@ class EmulatorResolver @Inject constructor(
         return emulatorDetector.getPreferredEmulator(platformSlug)
     }
 
-    private fun EmulatorConfigEntity?.acceptableLaunchPackage(
+    private suspend fun resolveEmulator(
+        platformSlug: String,
+        vararg configs: EmulatorConfigEntity?
+    ): EmulatorDef? {
+        ensureDetected()
+
+        val builtinEnabled = userPreferencesRepository.userPreferences.first().builtinLibretroEnabled
+        var installedPackages = emulatorDetector.installedEmulators.value
+            .map { it.def.packageName }
+            .toSet()
+
+        val configuredPackages = configs.mapNotNull { it?.packageName }
+        if (configuredPackages.any { it !in installedPackages }) {
+            emulatorDetector.detectEmulators()
+            installedPackages = emulatorDetector.installedEmulators.value
+                .map { it.def.packageName }
+                .toSet()
+        }
+
+        configs.forEach { config ->
+            resolveConfiguredEmulator(
+                config = config,
+                platformSlug = platformSlug,
+                installedPackages = installedPackages,
+                builtinEnabled = builtinEnabled
+            )?.let { return it }
+        }
+
+        val allowBuiltin = builtinEnabled && libretroCoreMgr.isPlatformSupported(platformSlug)
+        return emulatorDetector.getPreferredEmulator(platformSlug, allowBuiltin)?.def
+    }
+
+    private fun resolveConfiguredEmulator(
+        config: EmulatorConfigEntity?,
         platformSlug: String,
         installedPackages: Set<String>,
         builtinEnabled: Boolean
-    ): String? {
-        val pkg = this?.packageName ?: return null
-        if (pkg !in installedPackages) return null
-        if (pkg == EmulatorRegistry.BUILTIN_PACKAGE &&
-            (!builtinEnabled || !libretroCoreMgr.isPlatformSupported(platformSlug))) {
+    ): EmulatorDef? {
+        val packageName = config?.packageName ?: return null
+        if (packageName in installedPackages) {
+            val emulator = emulatorDetector.getByPackage(packageName) ?: return null
+            val canonicalPlatform = PlatformDefinitions.getCanonicalSlug(platformSlug)
+            if (canonicalPlatform !in emulator.supportedPlatforms) return null
+            if (packageName == EmulatorRegistry.BUILTIN_PACKAGE &&
+                (!builtinEnabled || !libretroCoreMgr.isPlatformSupported(platformSlug))) {
+                return null
+            }
+            return emulator
+        }
+        if (EmulatorRegistry.isKnownPackage(packageName) ||
+            !installedAppResolver.isAppInstalled(packageName)) {
             return null
         }
-        return pkg
-    }
-
-    private fun EmulatorConfigEntity?.adHocPackageOrNull(): String? {
-        val pkg = this?.packageName ?: return null
-        if (EmulatorRegistry.isKnownPackage(pkg)) return null
-        if (!installedAppResolver.isAppInstalled(pkg)) return null
-        return pkg
+        return EmulatorRegistry.synthesizeAdHocEmulatorDef(
+            packageName = packageName,
+            displayName = config.displayName ?: packageName,
+            platformSlug = platformSlug
+        )
     }
 }

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/GameLauncher.kt
@@ -78,9 +78,8 @@ class GameLauncher @Inject constructor(
     private val emulatorConfigDao: EmulatorConfigDao,
     private val emulatorLaunchArgsDao: EmulatorLaunchArgsDao,
     private val variantResolver: VariantResolver,
-    private val installedAppResolver: com.nendo.argosy.data.platform.InstalledAppResolver,
+    private val emulatorResolver: EmulatorResolver,
     private val platformLibretroSettingsDao: com.nendo.argosy.data.local.dao.PlatformLibretroSettingsDao,
-    private val emulatorDetector: EmulatorDetector,
     private val m3uManager: M3uManager,
     private val libretroCoreMgr: LibretroCoreManager,
     private val biosRepository: BiosRepository,
@@ -651,65 +650,7 @@ class GameLauncher @Inject constructor(
     }
 
     private suspend fun resolveEmulator(game: GameEntity): EmulatorDef? {
-        if (emulatorDetector.installedEmulators.value.isEmpty()) {
-            emulatorDetector.detectEmulators()
-        }
-
-        val builtinEnabled = userPreferencesRepository.userPreferences.first().builtinLibretroEnabled
-
-        var installedPackages = emulatorDetector.installedEmulators.value
-            .map { it.def.packageName }
-            .toSet()
-
-        val gameOverride = emulatorConfigDao.getByGameId(game.id)
-        val platformDefault = emulatorConfigDao.getDefaultForPlatform(game.platformId)
-
-        val configuredPackage = gameOverride?.packageName ?: platformDefault?.packageName
-        if (configuredPackage != null && configuredPackage !in installedPackages) {
-            Logger.debug(TAG, "Configured emulator $configuredPackage not in cache, re-detecting...")
-            emulatorDetector.detectEmulators()
-            installedPackages = emulatorDetector.installedEmulators.value
-                .map { it.def.packageName }
-                .toSet()
-        }
-
-        val isBuiltinPackage: (String?) -> Boolean = { pkg ->
-            pkg == EmulatorRegistry.BUILTIN_PACKAGE
-        }
-
-        if (gameOverride?.packageName != null && gameOverride.packageName in installedPackages) {
-            val skipBuiltin = isBuiltinPackage(gameOverride.packageName) &&
-                (!builtinEnabled || !libretroCoreMgr.isPlatformSupported(game.platformSlug))
-            if (!skipBuiltin) {
-                return emulatorDetector.getByPackage(gameOverride.packageName)
-            }
-        }
-
-        if (platformDefault?.packageName != null && platformDefault.packageName in installedPackages) {
-            val skipBuiltin = isBuiltinPackage(platformDefault.packageName) &&
-                (!builtinEnabled || !libretroCoreMgr.isPlatformSupported(game.platformSlug))
-            if (!skipBuiltin) {
-                return emulatorDetector.getByPackage(platformDefault.packageName)
-            }
-        }
-
-        val adHocPackage = gameOverride?.packageName?.takeIf {
-            !EmulatorRegistry.isKnownPackage(it) && installedAppResolver.isAppInstalled(it)
-        } ?: platformDefault?.packageName?.takeIf {
-            !EmulatorRegistry.isKnownPackage(it) && installedAppResolver.isAppInstalled(it)
-        }
-        if (adHocPackage != null) {
-            val displayName = (if (adHocPackage == gameOverride?.packageName) gameOverride.displayName else platformDefault?.displayName)
-                ?: adHocPackage
-            Logger.debug(TAG, "Resolved ad-hoc emulator binding: $adHocPackage for ${game.platformSlug}")
-            return EmulatorRegistry.synthesizeAdHocEmulatorDef(
-                packageName = adHocPackage,
-                displayName = displayName,
-                platformSlug = game.platformSlug
-            )
-        }
-
-        return emulatorDetector.getPreferredEmulator(game.platformSlug, builtinEnabled)?.def
+        return emulatorResolver.getEmulatorForGame(game.id, game.platformId, game.platformSlug)
     }
 
     private suspend fun buildIntent(emulator: EmulatorDef, romFile: File, game: GameEntity, forResume: Boolean, variantFileId: Long? = null, discM3uPath: String? = null): Intent? {
@@ -1052,7 +993,7 @@ class GameLauncher @Inject constructor(
 
         Logger.debug(TAG, "RetroArch: package=$retroArchPackage, activity=${config.activityClass}")
 
-        val coreName = resolveCoreName(game) ?: run {
+        val coreName = resolveCoreName(game, emulator) ?: run {
             Logger.error(TAG, "No compatible core found for platform: ${game.platformSlug}")
             return null
         }
@@ -1112,87 +1053,48 @@ class GameLauncher @Inject constructor(
         }
     }
 
-    /**
-     * Core selection for the built-in libretro path. Walks: game override ->
-     * platform default -> legacy built-in pref -> registry default. Accepts
-     * any non-empty core id; the built-in path downloads from the libretro
-     * buildbot, so membership in [com.nendo.argosy.libretro.LibretroCoreRegistry]
-     * is a metadata hint, not a gate. If the chosen id isn't a real core, the
-     * download will 404 and surface via [lastCoreDownloadError].
-     */
     private suspend fun resolveBuiltinCoreId(game: GameEntity): String? {
-        val validCoreIds = com.nendo.argosy.libretro.LibretroCoreRegistry
-            .getCoresForPlatform(game.platformSlug).map { it.coreId }.toSet()
-        var rejectedCore: String? = null
-
-        fun accept(coreId: String?, source: String): String? {
-            if (coreId.isNullOrBlank()) return null
-            if (coreId !in validCoreIds) {
-                Logger.warn(TAG, "[BuiltIn] ignoring unknown core '$coreId' from $source for ${game.platformSlug}")
-                if (rejectedCore == null) rejectedCore = coreId
-                return null
+        val emulator = EmulatorRegistry.getByPackage(EmulatorRegistry.BUILTIN_PACKAGE) ?: return null
+        val selection = emulatorResolver.resolveCoreSelectionForGame(
+            gameId = game.id,
+            platformId = game.platformId,
+            platformSlug = game.platformSlug,
+            emulator = emulator
+        ) ?: return null
+        val selectedCore = selection.selectedCore?.id
+        val configuredCores = listOf(
+            emulatorConfigDao.getByGameId(game.id)?.coreName,
+            emulatorConfigDao.getDefaultForPlatform(game.platformId)?.coreName,
+            userPreferencesRepository.getBuiltinCoreSelections().first()[game.platformSlug]
+        ).filterNotNull().filter { it.isNotBlank() }
+        val hasValidConfiguredCore = configuredCores.any { configuredCore ->
+            selection.availableCores.any {
+                it.id == configuredCore || it.id.startsWith(configuredCore)
             }
-            Logger.debug(TAG, "[BuiltIn] core selection: $source -> $coreId")
-            return coreId
         }
-
-        accept(emulatorConfigDao.getByGameId(game.id)?.coreName, "game override")?.let { return it }
-        accept(emulatorConfigDao.getDefaultForPlatform(game.platformId)?.coreName, "platform default")?.let { return it }
-        accept(userPreferencesRepository.getBuiltinCoreSelections().first()[game.platformSlug], "legacy pref")?.let { return it }
-
-        val default = com.nendo.argosy.libretro.LibretroCoreRegistry
-            .getDefaultCoreForPlatform(game.platformSlug)?.coreId
-        Logger.debug(TAG, "[BuiltIn] core selection: registry default -> $default")
-
-        val rejected = rejectedCore
-        if (rejected != null && default != null) {
+        val rejectedCore = configuredCores.firstOrNull()
+        if (!hasValidConfiguredCore && rejectedCore != null && selectedCore != null) {
+            Logger.warn(TAG, "[BuiltIn] ignoring unknown core '$rejectedCore' for ${game.platformSlug}")
             val registry = com.nendo.argosy.libretro.LibretroCoreRegistry
             notificationManager.show(
-                title = "Failed to load ${registry.displayNameFor(rejected)}, " +
-                    "using ${registry.displayNameFor(default)} instead",
+                title = "Failed to load ${registry.displayNameFor(rejectedCore)}, " +
+                    "using ${registry.displayNameFor(selectedCore)} instead",
                 type = com.nendo.argosy.core.notification.NotificationType.WARNING
             )
         }
-        return default
+        Logger.debug(TAG, "[BuiltIn] core selection -> $selectedCore")
+        return selectedCore
     }
 
-    private suspend fun resolveCoreName(game: GameEntity): String? {
-        val gameConfig = emulatorConfigDao.getByGameId(game.id)
-        if (gameConfig?.coreName != null) {
-            val corrected = normalizeLegacyCoreName(gameConfig.coreName, game.platformSlug)
-            Logger.debug(TAG, "Core selection: game-specific override -> $corrected")
-            return corrected
-        }
-
-        val platformConfig = emulatorConfigDao.getDefaultForPlatform(game.platformId)
-        if (platformConfig?.coreName != null) {
-            val corrected = normalizeLegacyCoreName(platformConfig.coreName, game.platformSlug)
-            Logger.debug(TAG, "Core selection: platform default -> $corrected")
-            return corrected
-        }
-
-        val defaultCore = EmulatorRegistry.getDefaultCore(game.platformSlug)
-        if (defaultCore != null) {
-            Logger.debug(TAG, "Core selection: registry default -> ${defaultCore.id}")
-            return defaultCore.id
-        }
-
-        val preferredCore = EmulatorRegistry.getPreferredCore(game.platformSlug)
-        Logger.debug(TAG, "Core selection: registry preferred -> $preferredCore")
-        return preferredCore
-    }
-
-    private fun normalizeLegacyCoreName(coreName: String, platformSlug: String): String {
-        val validCores = EmulatorRegistry.getCoresForPlatform(platformSlug)
-        if (validCores.any { it.id == coreName }) {
-            return coreName
-        }
-        val match = validCores.find { it.id.startsWith(coreName) }
-        if (match != null) {
-            Logger.debug(TAG, "Core name corrected: $coreName -> ${match.id}")
-            return match.id
-        }
-        return coreName
+    private suspend fun resolveCoreName(game: GameEntity, emulator: EmulatorDef): String? {
+        val selectedCore = emulatorResolver.resolveCoreSelectionForGame(
+            gameId = game.id,
+            platformId = game.platformId,
+            platformSlug = game.platformSlug,
+            emulator = emulator
+        )?.selectedCore?.id
+        Logger.debug(TAG, "Core selection -> $selectedCore")
+        return selectedCore
     }
 
     private fun commandForCustom(

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/SaveSyncApiClient.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/SaveSyncApiClient.kt
@@ -3,7 +3,6 @@ package com.nendo.argosy.data.repository
 import android.os.StatFs
 import com.nendo.argosy.data.emulator.EmulatorResolver
 import com.nendo.argosy.data.emulator.SavePathConfig
-import com.nendo.argosy.data.local.dao.EmulatorConfigDao
 import com.nendo.argosy.data.local.dao.GameDao
 import com.nendo.argosy.data.local.dao.SaveSyncDao
 import com.nendo.argosy.data.local.dao.getByIdsChunked
@@ -36,7 +35,6 @@ import javax.inject.Singleton
 @Singleton
 class SaveSyncApiClient @Inject constructor(
     private val saveSyncDao: SaveSyncDao,
-    private val emulatorConfigDao: EmulatorConfigDao,
     private val emulatorResolver: EmulatorResolver,
     private val gameDao: GameDao,
     private val savePathResolver: SavePathResolver,
@@ -78,48 +76,34 @@ class SaveSyncApiClient @Inject constructor(
     ): PlatformSaveHandler = saveHandlerRegistry.getHandler(config, platformSlug, emulatorId)
 
     suspend fun resolveEmulatorForGame(game: GameEntity): String? {
-        val gameConfig = emulatorConfigDao.getByGameId(game.id)
-        if (gameConfig?.packageName != null) {
-            val resolved = emulatorResolver.resolveEmulatorId(gameConfig.packageName)
-            if (resolved != null) {
-                Logger.verbose(TAG) { "[SaveSync] DISCOVER gameId=${game.id} | Resolved emulator from game config | package=${gameConfig.packageName}, emulatorId=$resolved" }
-                return resolved
-            }
+        val emulator = emulatorResolver.getEmulatorForGame(
+            gameId = game.id,
+            platformId = game.platformId,
+            platformSlug = game.platformSlug
+        )
+        if (emulator == null) {
+            Logger.warn(TAG, "[SaveSync] DISCOVER gameId=${game.id} | Cannot resolve effective emulator | platform=${game.platformSlug}")
+            return null
         }
-
-        val platformConfig = emulatorConfigDao.getDefaultForPlatform(game.platformId)
-        if (platformConfig?.packageName != null) {
-            val resolved = emulatorResolver.resolveEmulatorId(platformConfig.packageName)
-            if (resolved != null) {
-                Logger.verbose(TAG) { "[SaveSync] DISCOVER gameId=${game.id} | Resolved emulator from platform default | package=${platformConfig.packageName}, emulatorId=$resolved" }
-                return resolved
-            }
+        Logger.verbose(TAG) {
+            "[SaveSync] DISCOVER gameId=${game.id} | Effective emulator | " +
+                "package=${emulator.packageName}, emulatorId=${emulator.id}"
         }
-
-        emulatorResolver.ensureDetected()
-
-        val preferred = emulatorResolver.getPreferredEmulator(game.platformSlug)
-        if (preferred != null) {
-            Logger.verbose(TAG) { "[SaveSync] DISCOVER gameId=${game.id} | Using preferred emulator for platform=${game.platformSlug} | emulatorId=${preferred.def.id}" }
-            return preferred.def.id
-        }
-
-        val installedEmulators = emulatorResolver.getInstalledForPlatform(game.platformSlug)
-        if (installedEmulators.isNotEmpty()) {
-            val emulatorId = installedEmulators.first().def.id
-            Logger.debug(TAG, "[SaveSync] DISCOVER gameId=${game.id} | Falling back to first installed for platform=${game.platformSlug} | emulatorId=$emulatorId, installed=${installedEmulators.map { it.def.id }}")
-            return emulatorId
-        }
-
-        Logger.warn(TAG, "[SaveSync] DISCOVER gameId=${game.id} | Cannot resolve emulator | platform=${game.platformSlug}, no config and no installed emulators")
-        return null
+        return emulator.id
     }
 
     internal suspend fun resolveCoreForGame(game: GameEntity): String? {
-        val gameConfig = emulatorConfigDao.getByGameId(game.id)
-        if (gameConfig?.coreName != null) return gameConfig.coreName
-        val platformConfig = emulatorConfigDao.getDefaultForPlatform(game.platformId)
-        return platformConfig?.coreName
+        val emulator = emulatorResolver.getEmulatorForGame(
+            gameId = game.id,
+            platformId = game.platformId,
+            platformSlug = game.platformSlug
+        ) ?: return null
+        return emulatorResolver.resolveCoreSelectionForGame(
+            gameId = game.id,
+            platformId = game.platformId,
+            platformSlug = game.platformSlug,
+            emulator = emulator
+        )?.selectedCore?.id
     }
 
     suspend fun resolveCoreForGame(gameId: Long): String? {

--- a/app/src/main/kotlin/com/nendo/argosy/domain/usecase/game/ConfigureEmulatorUseCase.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/domain/usecase/game/ConfigureEmulatorUseCase.kt
@@ -2,6 +2,7 @@ package com.nendo.argosy.domain.usecase.game
 
 import com.nendo.argosy.data.emulator.EmulatorRegistry
 import com.nendo.argosy.data.emulator.InstalledEmulator
+import com.nendo.argosy.data.emulator.LaunchConfig
 import com.nendo.argosy.data.local.dao.EmulatorConfigDao
 import com.nendo.argosy.data.local.dao.SaveSyncDao
 import com.nendo.argosy.data.local.entity.EmulatorConfigEntity
@@ -21,7 +22,7 @@ class ConfigureEmulatorUseCase @Inject constructor(
                 gameId = gameId,
                 packageName = emulator.def.packageName,
                 displayName = emulator.def.displayName,
-                coreName = EmulatorRegistry.getDefaultCore(platformSlug)?.id,
+                coreName = defaultCoreFor(platformSlug, emulator),
                 isDefault = false
             )
             emulatorConfigDao.insert(config)
@@ -38,7 +39,7 @@ class ConfigureEmulatorUseCase @Inject constructor(
                 gameId = null,
                 packageName = emulator.def.packageName,
                 displayName = emulator.def.displayName,
-                coreName = EmulatorRegistry.getDefaultCore(platformSlug)?.id,
+                coreName = defaultCoreFor(platformSlug, emulator),
                 isDefault = true
             )
             emulatorConfigDao.insert(config)
@@ -66,6 +67,14 @@ class ConfigureEmulatorUseCase @Inject constructor(
 
     suspend fun clearForPlatform(platformId: Long) {
         emulatorConfigDao.clearPlatformDefaults(platformId)
+    }
+
+    private fun defaultCoreFor(platformSlug: String, emulator: InstalledEmulator): String? {
+        if (!emulator.def.launchConfig.isCoreSelectable) return null
+        return EmulatorRegistry.getDefaultSelectableCore(
+            platformId = platformSlug,
+            isBuiltIn = emulator.def.launchConfig is LaunchConfig.BuiltIn
+        )?.id
     }
 
     suspend fun setCoreForPlatform(platformId: Long, coreId: String?) {

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeActivity.kt
@@ -705,7 +705,8 @@ class SecondaryHomeActivity :
             steamContentManager = dsm.steamContentManager,
             displayAffinityHelper = affinityHelper,
             downloadFileStatusRepository = dsm.downloadFileStatusRepository,
-            preferencesRepository = dsm.preferencesRepository
+            preferencesRepository = dsm.preferencesRepository,
+            emulatorResolver = dsm.emulatorResolver
         )
 
         dualHomeViewModel.onSelectionPersist = {

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeInputHandler.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeInputHandler.kt
@@ -314,8 +314,7 @@ class SecondaryHomeInputHandler(
             }
             GameDetailOption.CHANGE_CORE -> {
                 lifecycleLaunch {
-                    val cores = com.nendo.argosy.data.emulator.EmulatorRegistry
-                        .getCoresForPlatform(vm.uiState.value.platformSlug)
+                    val cores = vm.uiState.value.availableCores
                     vm.openCorePicker(cores)
                     broadcasts.broadcastCoreModalOpen(
                         cores, vm.uiState.value.selectedCoreName

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeStateManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeStateManager.kt
@@ -1,6 +1,7 @@
 package com.nendo.argosy.hardware
 
 import android.content.Context
+import com.nendo.argosy.data.emulator.EmulatorResolver
 import com.nendo.argosy.data.local.dao.EmulatorConfigDao
 import com.nendo.argosy.data.repository.CollectionRepository
 import com.nendo.argosy.data.repository.DownloadQueueRepository
@@ -31,7 +32,8 @@ class SecondaryHomeStateManager(
     private val steamContentManager: com.nendo.argosy.data.steam.SteamContentManager? = null,
     private val displayAffinityHelper: DisplayAffinityHelper,
     private val downloadFileStatusRepository: com.nendo.argosy.data.repository.DownloadFileStatusRepository,
-    private val preferencesRepository: com.nendo.argosy.data.preferences.UserPreferencesRepository
+    private val preferencesRepository: com.nendo.argosy.data.preferences.UserPreferencesRepository,
+    private val emulatorResolver: EmulatorResolver
 ) {
 
     lateinit var sessionStateStore: SessionStateStore
@@ -127,7 +129,7 @@ class SecondaryHomeStateManager(
                 displayAffinityHelper = affinityHelper,
                 downloadFileStatusRepository = downloadFileStatusRepository,
                 sessionStateStore = sessionStateStore,
-                preferencesRepository = preferencesRepository,
+                emulatorResolver = emulatorResolver,
                 context = context
             )
             vm.loadGame(savedDetailGameId)
@@ -215,7 +217,7 @@ class SecondaryHomeStateManager(
             displayAffinityHelper = affinityHelper,
             downloadFileStatusRepository = downloadFileStatusRepository,
             sessionStateStore = sessionStateStore,
-            preferencesRepository = preferencesRepository,
+            emulatorResolver = emulatorResolver,
             context = context
         )
     }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
@@ -1701,8 +1701,7 @@ fun ArgosyApp(
                                     }
                                     GameDetailOption.CHANGE_CORE -> {
                                         scope.launch {
-                                            val cores = com.nendo.argosy.data.emulator.EmulatorRegistry
-                                                .getCoresForPlatform(vm.uiState.value.platformSlug)
+                                            val cores = vm.uiState.value.availableCores
                                             vm.openCorePicker(cores)
                                             dualScreenManager.openCoreModal(
                                                 cores.map { it.displayName },

--- a/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailInputHandler.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailInputHandler.kt
@@ -559,8 +559,7 @@ class DualGameDetailInputHandler(
             }
             GameDetailOption.CHANGE_CORE -> {
                 lifecycleLaunch {
-                    val cores = com.nendo.argosy.data.emulator.EmulatorRegistry
-                        .getCoresForPlatform(vm.uiState.value.platformSlug)
+                    val cores = vm.uiState.value.availableCores
                     vm.openCorePicker(cores)
                     onBroadcastCoreModalOpen(cores, vm.uiState.value.selectedCoreName)
                 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailModels.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailModels.kt
@@ -4,6 +4,7 @@
 package com.nendo.argosy.ui.dualscreen.gamedetail
 
 import com.nendo.argosy.data.emulator.DiscOption
+import com.nendo.argosy.data.emulator.RetroArchCore
 import com.nendo.argosy.data.model.visibleWithCollapsed
 import com.nendo.argosy.domain.model.UnifiedSaveEntry
 import com.nendo.argosy.domain.model.UnifiedStateEntry
@@ -83,6 +84,7 @@ data class DualGameDetailUiState(
     val activeSaveTimestamp: Long? = null,
     val saveSyncStatusName: String? = null,
     val hasMultipleCores: Boolean = false,
+    val availableCores: List<RetroArchCore> = emptyList(),
     val selectedCoreName: String? = null,
     val selectedCoreId: String? = null,
     val hasFileBasedSaves: Boolean = false,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailViewModel.kt
@@ -20,7 +20,7 @@ import com.nendo.argosy.data.local.entity.GameFileEntity
 import com.nendo.argosy.data.local.entity.getDisplayName
 import com.nendo.argosy.domain.usecase.game.ConfigureEmulatorUseCase
 import com.nendo.argosy.data.emulator.DiscOption
-import com.nendo.argosy.data.emulator.EmulatorRegistry
+import com.nendo.argosy.data.emulator.EmulatorResolver
 import com.nendo.argosy.data.download.ZipExtractor
 import com.nendo.argosy.data.steam.SteamDownloadState
 import com.nendo.argosy.ui.common.appId
@@ -44,7 +44,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -63,7 +62,7 @@ class DualGameDetailViewModel(
     private val displayAffinityHelper: DisplayAffinityHelper,
     private val downloadFileStatusRepository: com.nendo.argosy.data.repository.DownloadFileStatusRepository,
     private val sessionStateStore: SessionStateStore,
-    private val preferencesRepository: com.nendo.argosy.data.preferences.UserPreferencesRepository,
+    private val emulatorResolver: EmulatorResolver,
     private val context: Context
 ) : ViewModel() {
 
@@ -338,34 +337,31 @@ class DualGameDetailViewModel(
 
             val gameSpecificConfig = emulatorConfigDao.getByGameId(game.id)
             val platformDefaultConfig = emulatorConfigDao.getDefaultForPlatform(game.platformId)
-            val configuredEmulatorPackage = gameSpecificConfig?.packageName ?: platformDefaultConfig?.packageName
-            val configuredEmulatorName = gameSpecificConfig?.displayName ?: platformDefaultConfig?.displayName
 
-            val detector = com.nendo.argosy.data.emulator.getSharedEmulatorDetector(context)
-            if (detector.installedEmulators.value.isEmpty()) detector.detectEmulators()
-            val builtinEnabled = preferencesRepository.userPreferences.first().builtinLibretroEnabled
-            val effectiveSavePackage = configuredEmulatorPackage
-                ?: detector.getPreferredEmulator(game.platformSlug, builtinEnabled)?.def?.packageName
+            val effectiveEmulatorDef = emulatorResolver.getEmulatorForGame(
+                gameId = game.id,
+                platformId = game.platformId,
+                platformSlug = game.platformSlug
+            )
+            val effectiveSavePackage = effectiveEmulatorDef?.packageName
             val saveConfig = effectiveSavePackage?.let {
                 com.nendo.argosy.data.emulator.SavePathRegistry.getConfigForPlatformByPackage(it, game.platformSlug)
             }
             val hasFileBasedSaves = com.nendo.argosy.data.emulator.SavePathRegistry
                 .supportsPerGameSavePath(saveConfig, game.platformSlug)
 
-            val platformCores = EmulatorRegistry.getCoresForPlatform(game.platformSlug)
-            val emulatorDef = configuredEmulatorPackage?.let { pkg ->
-                EmulatorRegistry.getByPackage(pkg)
+            val coreSelection = effectiveEmulatorDef?.let {
+                emulatorResolver.resolveCoreSelectionForGame(
+                    gameId = game.id,
+                    platformId = game.platformId,
+                    platformSlug = game.platformSlug,
+                    emulator = it
+                )
             }
-            // emulatorDef == null means we haven't resolved an emulator yet (auto-pick); still show core picker if cores exist.
-            val isCoreSelectable = emulatorDef?.launchConfig?.isCoreSelectable ?: true
-            val hasMultipleCores = isCoreSelectable && platformCores.size > 1
-
-            val selectedCoreId = gameSpecificConfig?.coreName
-                ?: platformDefaultConfig?.coreName
-                ?: EmulatorRegistry.getDefaultCore(game.platformSlug)?.id
-            val selectedCoreName = if (hasMultipleCores) {
-                platformCores.find { it.id == selectedCoreId }?.displayName
-            } else null
+            val availableCores = coreSelection?.availableCores ?: emptyList()
+            val hasMultipleCores = availableCores.size > 1
+            val selectedCoreId = coreSelection?.selectedCore?.id
+            val selectedCoreName = coreSelection?.selectedCore?.displayName
 
             val downloadedVariants = excludePrimaryFile(gameRepository.getVariantsForGame(game.id), game)
                 .filter { it.localPath != null }
@@ -408,8 +404,9 @@ class DualGameDetailViewModel(
                 isDownloaded = isDownloaded,
                 platformSlug = game.platformSlug,
                 platformId = game.platformId,
-                emulatorName = configuredEmulatorName,
+                emulatorName = effectiveEmulatorDef?.displayName,
                 hasMultipleCores = hasMultipleCores,
+                availableCores = availableCores,
                 selectedCoreName = selectedCoreName,
                 selectedCoreId = selectedCoreId,
                 hasFileBasedSaves = hasFileBasedSaves,
@@ -950,13 +947,7 @@ class DualGameDetailViewModel(
         val state = _uiState.value
         viewModelScope.launch {
             configureEmulatorUseCase.setForGame(state.gameId, state.platformId, state.platformSlug, selected)
-            _uiState.update {
-                it.copy(
-                    emulatorName = selected?.def?.displayName,
-                    savePathOverride = null,
-                    displayTargetName = null
-                )
-            }
+            loadGame(state.gameId)
         }
         _activeModal.value = ActiveModal.NONE
     }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/GameDetailViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/GameDetailViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import com.nendo.argosy.data.cache.ImageCacheManager
 import com.nendo.argosy.data.download.ZipExtractor
 import com.nendo.argosy.data.emulator.EmulatorDetector
-import com.nendo.argosy.data.emulator.EmulatorRegistry
 import com.nendo.argosy.data.emulator.LaunchConfig
 import com.nendo.argosy.data.emulator.EmulatorResolver
 import com.nendo.argosy.data.emulator.SavePathRegistry
@@ -434,25 +433,24 @@ class GameDetailViewModel @Inject constructor(
 
             val prefs = preferencesRepository.userPreferences.first()
 
-            val emulatorName = gameSpecificConfig?.displayName
-                ?: platformDefaultConfig?.displayName
-                ?: emulatorDetector.getPreferredEmulator(game.platformSlug, prefs.builtinLibretroEnabled)?.def?.displayName
-
-            val configuredPackage = gameSpecificConfig?.packageName ?: platformDefaultConfig?.packageName
-            val emulatorDef = configuredPackage?.let { emulatorDetector.getByPackage(it) }
-                ?: emulatorDetector.getPreferredEmulator(game.platformSlug, prefs.builtinLibretroEnabled)?.def
-            val isCoreSelectable = emulatorDef?.launchConfig?.isCoreSelectable == true
+            val emulatorDef = emulatorResolver.getEmulatorForGame(
+                gameId = game.id,
+                platformId = game.platformId,
+                platformSlug = game.platformSlug
+            )
+            val emulatorName = emulatorDef?.displayName
             val isBuiltInEmulator = emulatorDef?.launchConfig is LaunchConfig.BuiltIn
-
-            val platformCores = EmulatorRegistry.getSelectableCores(game.platformSlug, isBuiltInEmulator)
-            val hasMultipleCores = isCoreSelectable && platformCores.size > 1
-
-            val selectedCoreId = gameSpecificConfig?.coreName
-                ?: platformDefaultConfig?.coreName
-                ?: EmulatorRegistry.getDefaultSelectableCore(game.platformSlug, isBuiltInEmulator)?.id
-            val selectedCoreName = if (isCoreSelectable) {
-                platformCores.find { it.id == selectedCoreId }?.displayName
-            } else null
+            val coreSelection = emulatorDef?.let {
+                emulatorResolver.resolveCoreSelectionForGame(
+                    gameId = game.id,
+                    platformId = game.platformId,
+                    platformSlug = game.platformSlug,
+                    emulator = it
+                )
+            }
+            val hasMultipleCores = (coreSelection?.availableCores?.size ?: 0) > 1
+            val selectedCoreId = coreSelection?.selectedCore?.id
+            val selectedCoreName = coreSelection?.selectedCore?.displayName
 
             val isSteamGame = game.isSteamGame
             val isAndroidApp = game.isAndroidApp
@@ -511,7 +509,7 @@ class GameDetailViewModel @Inject constructor(
             achievementDelegate.loadCached(gameId, game.rommId != null || game.effectiveRaId != null)
             val cachedAchievements = achievementDelegate.achievements.value
 
-            val emulatorId = emulatorResolver.getEmulatorIdForGame(gameId, game.platformId, game.platformSlug)
+            val emulatorId = emulatorDef?.id
             val canManageSaves = prefs.saveSyncEnabled &&
                 downloadStatus == GameDownloadStatus.DOWNLOADED &&
                 game.rommId != null &&

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PerGameSettingsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/gamedetail/delegates/PerGameSettingsDelegate.kt
@@ -1,7 +1,6 @@
 package com.nendo.argosy.ui.screens.gamedetail.delegates
 
 import com.nendo.argosy.core.input.SoundType
-import com.nendo.argosy.data.emulator.EmulatorDetector
 import com.nendo.argosy.data.emulator.EmulatorRegistry
 import com.nendo.argosy.data.emulator.EmulatorResolver
 import com.nendo.argosy.data.emulator.ExtensionOption
@@ -12,7 +11,6 @@ import com.nendo.argosy.data.local.dao.EmulatorConfigDao
 import com.nendo.argosy.data.repository.EmulatorSaveConfigRepository
 import com.nendo.argosy.data.preferences.EmulatorDisplayTarget
 import com.nendo.argosy.data.preferences.MenuWrapMode
-import com.nendo.argosy.data.preferences.UserPreferencesRepository
 import com.nendo.argosy.data.repository.GameRepository
 import com.nendo.argosy.domain.usecase.game.ConfigureEmulatorUseCase
 import com.nendo.argosy.ui.input.InputDispatcher.Companion.computeWrappedIndex
@@ -21,7 +19,6 @@ import com.nendo.argosy.util.DisplayAffinityHelper
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
@@ -62,12 +59,10 @@ data class PerGameSettingsState(
 
 class PerGameSettingsDelegate @Inject constructor(
     private val emulatorConfigDao: EmulatorConfigDao,
-    private val emulatorDetector: EmulatorDetector,
     private val emulatorResolver: EmulatorResolver,
     private val retroArchPathResolver: RetroArchPathResolver,
     private val emulatorSaveConfigRepository: EmulatorSaveConfigRepository,
     private val configureEmulatorUseCase: ConfigureEmulatorUseCase,
-    private val preferencesRepository: UserPreferencesRepository,
     private val gameRepository: GameRepository,
     private val displayAffinityHelper: DisplayAffinityHelper,
     private val soundManager: SoundFeedbackManager
@@ -160,32 +155,30 @@ class PerGameSettingsDelegate @Inject constructor(
 
     private suspend fun buildState(gameId: Long): PerGameSettingsState? {
         val game = gameRepository.getById(gameId) ?: return null
-        if (emulatorDetector.installedEmulators.value.isEmpty()) {
-            emulatorDetector.detectEmulators()
-        }
-        val prefs = preferencesRepository.userPreferences.first()
 
         val gameConfig = emulatorConfigDao.getByGameId(gameId)
         val platformConfig = emulatorConfigDao.getDefaultForPlatform(game.platformId)
 
-        val emulatorName = gameConfig?.displayName
-            ?: platformConfig?.displayName
-            ?: emulatorDetector.getPreferredEmulator(game.platformSlug, prefs.builtinLibretroEnabled)?.def?.displayName
+        val emulatorDef = emulatorResolver.getEmulatorForGame(
+            gameId = game.id,
+            platformId = game.platformId,
+            platformSlug = game.platformSlug
+        )
+        val emulatorName = emulatorDef?.displayName
+        val coreSelection = emulatorDef?.let {
+            emulatorResolver.resolveCoreSelectionForGame(
+                gameId = game.id,
+                platformId = game.platformId,
+                platformSlug = game.platformSlug,
+                emulator = it
+            )
+        }
+        val showCoreRow = (coreSelection?.availableCores?.size ?: 0) > 1
+        val selectedCoreId = coreSelection?.selectedCore?.id
+        val coreName = coreSelection?.selectedCore?.displayName
 
-        val configuredPackage = gameConfig?.packageName ?: platformConfig?.packageName
-        val emulatorDef = configuredPackage?.let { emulatorDetector.getByPackage(it) }
-            ?: emulatorDetector.getPreferredEmulator(game.platformSlug, prefs.builtinLibretroEnabled)?.def
-        val isBuiltIn = emulatorDef?.launchConfig is LaunchConfig.BuiltIn
-        val isCoreSelectable = emulatorDef?.launchConfig?.isCoreSelectable == true
-        val cores = EmulatorRegistry.getSelectableCores(game.platformSlug, isBuiltIn)
-        val showCoreRow = isCoreSelectable && cores.size > 1
-        val selectedCoreId = gameConfig?.coreName
-            ?: platformConfig?.coreName
-            ?: EmulatorRegistry.getDefaultSelectableCore(game.platformSlug, isBuiltIn)?.id
-        val coreName = if (isCoreSelectable) cores.find { it.id == selectedCoreId }?.displayName else null
-
-        val effectivePackage = emulatorResolver.getEmulatorPackageForGame(gameId, game.platformId, game.platformSlug)
-        val effectiveEmulatorId = effectivePackage?.let { emulatorResolver.resolveEmulatorId(it) }
+        val effectivePackage = emulatorDef?.packageName
+        val effectiveEmulatorId = emulatorDef?.id
         val saveConfig = effectivePackage?.let { SavePathRegistry.getConfigForPlatformByPackage(it, game.platformSlug) }
             ?: effectiveEmulatorId?.let { SavePathRegistry.getConfigForPlatform(it, game.platformSlug) }
         val showSavePathRow = SavePathRegistry.supportsPerGameSavePath(saveConfig, game.platformSlug)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsInitRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsInitRouter.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.nendo.argosy.core.emulator.EmulatorDownloadState
 import com.nendo.argosy.data.cache.GradientPreset
 import com.nendo.argosy.data.emulator.EmulatorRegistry
+import com.nendo.argosy.data.emulator.LaunchConfig
 import com.nendo.argosy.data.platform.PlatformDefinitions
 import com.nendo.argosy.data.preferences.EmulatorDisplayTarget
 import com.nendo.argosy.data.emulator.SavePathRegistry
@@ -339,34 +340,21 @@ internal fun routeLoadSettings(vm: SettingsViewModel) {
                 .mapNotNull { EmulatorRegistry.getById(it) }
                 .filter { it.packageName !in installedPackages && it.downloadUrl != null }
 
-            val rawSelectedEmulatorDef = defaultConfig?.packageName?.let { vm.emulatorDetector.getByPackage(it) }
-            val selectedEmulatorDef = if (!prefs.builtinLibretroEnabled && rawSelectedEmulatorDef?.id == "builtin") {
-                null
-            } else {
-                rawSelectedEmulatorDef
+            val effectiveEmulatorDef = vm.emulatorResolver.getEmulatorForPlatform(
+                platformId = platform.id,
+                platformSlug = platform.slug
+            )
+            val launchConfig = effectiveEmulatorDef?.launchConfig
+            val isRetroArch = launchConfig is LaunchConfig.RetroArch
+            val coreSelection = effectiveEmulatorDef?.let {
+                vm.emulatorResolver.resolveCoreSelectionForPlatform(
+                    platformId = platform.id,
+                    platformSlug = platform.slug,
+                    emulator = it
+                )
             }
-            val adHocConfig = defaultConfig?.takeIf { cfg ->
-                val pkg = cfg.packageName
-                selectedEmulatorDef == null && pkg != null &&
-                    !EmulatorRegistry.isKnownPackage(pkg) && vm.installedAppResolver.isAppInstalled(pkg)
-            }
-            val autoResolvedEmulator = vm.emulatorDetector.getPreferredEmulator(platform.slug, prefs.builtinLibretroEnabled)?.def
-            val effectiveEmulatorDef = selectedEmulatorDef ?: if (adHocConfig != null) null else autoResolvedEmulator
-            val isRetroArch = effectiveEmulatorDef?.launchConfig is com.nendo.argosy.data.emulator.LaunchConfig.RetroArch
-            val hasCoreSelection = effectiveEmulatorDef?.launchConfig?.isCoreSelectable == true
-            val availableCores = if (hasCoreSelection) {
-                EmulatorRegistry.getCoresForPlatform(platform.slug)
-            } else {
-                emptyList()
-            }
-
-            val storedCore = defaultConfig?.coreName
-            val defaultCore = EmulatorRegistry.getDefaultCore(platform.slug)?.id
-            val selectedCore = when {
-                !hasCoreSelection -> null
-                storedCore != null && availableCores.any { it.id == storedCore } -> storedCore
-                else -> defaultCore ?: availableCores.firstOrNull()?.id
-            }
+            val availableCores = coreSelection?.availableCores ?: emptyList()
+            val selectedCore = coreSelection?.selectedCore?.id
 
             val emulatorId = effectiveEmulatorDef?.id
             val emulatorPackage = effectiveEmulatorDef?.packageName
@@ -409,8 +397,8 @@ internal fun routeLoadSettings(vm: SettingsViewModel) {
                 availableCores = availableCores,
                 effectiveEmulatorIsRetroArch = isRetroArch,
                 effectiveEmulatorId = emulatorId,
-                effectiveEmulatorPackage = effectiveEmulatorDef?.packageName ?: adHocConfig?.packageName,
-                effectiveEmulatorName = effectiveEmulatorDef?.displayName ?: adHocConfig?.displayName,
+                effectiveEmulatorPackage = effectiveEmulatorDef?.packageName,
+                effectiveEmulatorName = effectiveEmulatorDef?.displayName,
                 effectiveSavePath = effectiveSavePath,
                 isUserSavePathOverride = isUserSavePathOverride,
                 showSavePath = showSavePath,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import com.nendo.argosy.ui.common.GradientColorExtractor
 import com.nendo.argosy.data.cache.ImageCacheManager
 import com.nendo.argosy.data.cache.ImageCacheProgress
 import com.nendo.argosy.data.emulator.EmulatorDetector
+import com.nendo.argosy.data.emulator.EmulatorResolver
 import com.nendo.argosy.data.emulator.InstalledEmulator
 import com.nendo.argosy.data.emulator.RetroArchConfigParser
 import com.nendo.argosy.data.repository.CoreOptionsRepository
@@ -83,6 +84,7 @@ class SettingsViewModel @Inject constructor(
     internal val installedAppResolver: com.nendo.argosy.data.platform.InstalledAppResolver,
     internal val emulatorConfigRepo: EmulatorConfigRepository,
     internal val emulatorDetector: EmulatorDetector,
+    internal val emulatorResolver: EmulatorResolver,
     internal val romMRepository: RomMRepository,
     internal val notificationManager: NotificationManager,
     internal val gameRepository: GameRepository,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/PlatformDetailSection.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/PlatformDetailSection.kt
@@ -286,13 +286,18 @@ fun PlatformDetailSection(
                     val currentCoreIndex = config.availableCores
                         .indexOfFirst { it.id == config.selectedCore }
                         .takeIf { it >= 0 } ?: 0
+                    val selectedCoreName = config.availableCores
+                        .firstOrNull { it.id == config.selectedCore }
+                        ?.displayName
                     CyclePreference(
                         title = "Core",
-                        value = config.selectedCore ?: "Default",
+                        value = selectedCoreName ?: "Default",
                         isFocused = isFocused(item),
                         onClick = { viewModel.cycleCoreForPlatform(config, 1) },
                         onPrev = { viewModel.cycleCoreForPlatform(config, -1) },
-                        options = remember(config.availableCores) { config.availableCores.map { it.id } },
+                        options = remember(config.availableCores) {
+                            config.availableCores.map { it.displayName }
+                        },
                         onSelect = { viewModel.cycleCoreForPlatform(config, it - currentCoreIndex) },
                         pickerRequestToken = pickerToken(item),
                         valueFooter = if (platformHasNetplay) {

--- a/app/src/test/kotlin/com/nendo/argosy/data/emulator/EmulatorRegistrySelectableCoresTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/emulator/EmulatorRegistrySelectableCoresTest.kt
@@ -1,25 +1,34 @@
 package com.nendo.argosy.data.emulator
 
+import com.nendo.argosy.libretro.LibretroCoreRegistry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * The game-detail core picker must offer cores that the chosen emulator can actually run:
+ * Core pickers must offer cores that the chosen emulator can actually run:
  * built-in games get [LibretroCoreRegistry] cores, external RetroArch gets the RetroArch list.
- * Regression guard for the swanstation-pinned-on-built-in bug.
+ * Regression guard for mixed built-in and external core catalogues.
  */
 class EmulatorRegistrySelectableCoresTest {
 
     @Test
     fun `built-in mode offers only registered built-in cores`() {
-        val ids = EmulatorRegistry.getSelectableCores("psx", isBuiltIn = true).map { it.id }.toSet()
+        val cores = EmulatorRegistry.getSelectableCores("psx", isBuiltIn = true)
+        val ids = cores.map { it.id }.toSet()
 
         assertTrue("built-in psx must offer pcsx_rearmed", "pcsx_rearmed" in ids)
         assertTrue("built-in psx must offer mednafen_psx_hw", "mednafen_psx_hw" in ids)
         assertFalse("swanstation is a RetroArch core, not a built-in one", "swanstation" in ids)
         assertFalse("mednafen_psx (sw RA core) is not a built-in core", "mednafen_psx" in ids)
+        assertEquals(
+            mapOf(
+                "pcsx_rearmed" to "PCSX ReARMed",
+                "mednafen_psx_hw" to "Beetle PSX HW"
+            ),
+            cores.associate { it.id to it.displayName }
+        )
     }
 
     @Test
@@ -50,5 +59,80 @@ class EmulatorRegistrySelectableCoresTest {
         val bySlug = EmulatorRegistry.getSelectableCores("psx", isBuiltIn = true).map { it.id }.toSet()
         val byAlias = EmulatorRegistry.getSelectableCores("ps1", isBuiltIn = true).map { it.id }.toSet()
         assertEquals(bySlug, byAlias)
+    }
+
+    @Test
+    fun `stored external core falls back to built-in default`() {
+        val selection = EmulatorRegistry.resolveCoreSelection(
+            "psx",
+            isBuiltIn = true,
+            storedCoreId = "swanstation"
+        )
+
+        assertEquals("pcsx_rearmed", selection.selectedCore?.id)
+        assertFalse(selection.availableCores.any { it.id == "swanstation" })
+    }
+
+    @Test
+    fun `stored external core remains selected for external retroarch`() {
+        val selection = EmulatorRegistry.resolveCoreSelection(
+            "psx",
+            isBuiltIn = false,
+            storedCoreId = "swanstation"
+        )
+
+        assertEquals("swanstation", selection.selectedCore?.id)
+        assertEquals("SwanStation", selection.selectedCore?.displayName)
+    }
+
+    @Test
+    fun `built-in mode excludes external-only cores across platforms`() {
+        val externalOnlyCores = mapOf(
+            "nes" to "mesen",
+            "snes" to "snes9x2010",
+            "nds" to "desmume",
+            "saturn" to "yabause"
+        )
+
+        externalOnlyCores.forEach { (platform, coreId) ->
+            val builtInIds = EmulatorRegistry.getSelectableCores(platform, isBuiltIn = true)
+                .map { it.id }
+            val externalIds = EmulatorRegistry.getSelectableCores(platform, isBuiltIn = false)
+                .map { it.id }
+
+            assertFalse("$coreId must not be offered by built-in $platform", coreId in builtInIds)
+            assertTrue("$coreId must remain available to external $platform", coreId in externalIds)
+        }
+    }
+
+    @Test
+    fun `built-in mode uses registered display names across platforms`() {
+        val expectedNames = mapOf(
+            "n64" to ("mupen64plus_next_gles3" to "Mupen64+ GLES3"),
+            "lynx" to ("mednafen_lynx" to "Beetle Lynx"),
+            "wonderswan" to ("mednafen_wswan" to "Beetle WS")
+        )
+
+        expectedNames.forEach { (platform, expected) ->
+            val core = EmulatorRegistry.getSelectableCores(platform, isBuiltIn = true)
+                .first { it.id == expected.first }
+            assertEquals(expected.second, core.displayName)
+        }
+    }
+
+    @Test
+    fun `built-in resolver always selects from its available catalogue`() {
+        LibretroCoreRegistry.getSupportedPlatforms().forEach { platform ->
+            val selection = EmulatorRegistry.resolveCoreSelection(
+                platform,
+                isBuiltIn = true,
+                storedCoreId = "external_only_core"
+            )
+
+            assertTrue(
+                "$platform selected a core outside its built-in catalogue",
+                selection.selectedCore == null || selection.selectedCore in selection.availableCores
+            )
+        }
     }
 }

--- a/app/src/test/kotlin/com/nendo/argosy/data/emulator/EmulatorResolverTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/emulator/EmulatorResolverTest.kt
@@ -1,0 +1,265 @@
+package com.nendo.argosy.data.emulator
+
+import com.nendo.argosy.data.local.dao.EmulatorConfigDao
+import com.nendo.argosy.data.local.entity.EmulatorConfigEntity
+import com.nendo.argosy.data.platform.InstalledAppResolver
+import com.nendo.argosy.data.preferences.UserPreferences
+import com.nendo.argosy.data.preferences.UserPreferencesRepository
+import com.nendo.argosy.libretro.LibretroCoreManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class EmulatorResolverTest {
+
+    private lateinit var emulatorDetector: EmulatorDetector
+    private lateinit var emulatorConfigDao: EmulatorConfigDao
+    private lateinit var userPreferencesRepository: UserPreferencesRepository
+    private lateinit var libretroCoreManager: LibretroCoreManager
+    private lateinit var installedAppResolver: InstalledAppResolver
+    private lateinit var installedEmulators: MutableStateFlow<List<InstalledEmulator>>
+    private lateinit var resolver: EmulatorResolver
+
+    @Before
+    fun setup() {
+        emulatorDetector = mockk(relaxed = true)
+        emulatorConfigDao = mockk(relaxed = true)
+        userPreferencesRepository = mockk(relaxed = true)
+        libretroCoreManager = mockk(relaxed = true)
+        installedAppResolver = mockk(relaxed = true)
+        installedEmulators = MutableStateFlow(emptyList())
+
+        every { emulatorDetector.installedEmulators } returns installedEmulators
+        coEvery { emulatorDetector.detectEmulators() } answers { installedEmulators.value }
+        every { userPreferencesRepository.userPreferences } returns flowOf(UserPreferences())
+        every { userPreferencesRepository.getBuiltinCoreSelections() } returns flowOf(emptyMap())
+        every { libretroCoreManager.isPlatformSupported(any()) } returns true
+        every { installedAppResolver.isAppInstalled(any()) } returns false
+
+        resolver = EmulatorResolver(
+            emulatorDetector = emulatorDetector,
+            emulatorConfigDao = emulatorConfigDao,
+            userPreferencesRepository = userPreferencesRepository,
+            libretroCoreMgr = libretroCoreManager,
+            installedAppResolver = installedAppResolver
+        )
+    }
+
+    @Test
+    fun `configured installed emulator is returned`() = runTest {
+        val retroArch = EmulatorRegistry.getById("retroarch")!!
+        install(retroArch)
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns config(
+            gameId = 1L,
+            packageName = retroArch.packageName
+        )
+        coEvery { emulatorConfigDao.getDefaultForPlatform(10L) } returns null
+
+        val resolved = resolver.getEmulatorForGame(1L, 10L, "psx")
+
+        assertEquals(retroArch, resolved)
+    }
+
+    @Test
+    fun `uninstalled configured emulator falls back to installed preferred emulator`() = runTest {
+        val duckStation = EmulatorRegistry.getById("duckstation")!!
+        val retroArch = EmulatorRegistry.getById("retroarch")!!
+        install(retroArch)
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns config(
+            gameId = 1L,
+            packageName = duckStation.packageName
+        )
+        coEvery { emulatorConfigDao.getDefaultForPlatform(10L) } returns null
+        every { emulatorDetector.getPreferredEmulator("psx", true) } returns installed(retroArch)
+
+        val resolved = resolver.getEmulatorForGame(1L, 10L, "psx")
+
+        assertEquals(retroArch, resolved)
+    }
+
+    @Test
+    fun `platform resolution ignores an uninstalled configured emulator`() = runTest {
+        val retroArch = EmulatorRegistry.getById("retroarch")!!
+        val builtIn = EmulatorRegistry.getByPackage(EmulatorRegistry.BUILTIN_PACKAGE)!!
+        install(builtIn)
+        coEvery { emulatorConfigDao.getDefaultForPlatform(10L) } returns config(
+            platformId = 10L,
+            packageName = retroArch.packageName
+        )
+        every { emulatorDetector.getPreferredEmulator("psx", true) } returns installed(builtIn)
+
+        val resolved = resolver.getEmulatorForPlatform(10L, "psx")
+
+        assertEquals(builtIn, resolved)
+    }
+
+    @Test
+    fun `disabled built-in config falls back to external emulator`() = runTest {
+        val builtIn = EmulatorRegistry.getByPackage(EmulatorRegistry.BUILTIN_PACKAGE)!!
+        val retroArch = EmulatorRegistry.getById("retroarch")!!
+        install(builtIn, retroArch)
+        every { userPreferencesRepository.userPreferences } returns flowOf(
+            UserPreferences(builtinLibretroEnabled = false)
+        )
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns config(
+            gameId = 1L,
+            packageName = builtIn.packageName
+        )
+        coEvery { emulatorConfigDao.getDefaultForPlatform(10L) } returns null
+        every { emulatorDetector.getPreferredEmulator("saturn", false) } returns installed(retroArch)
+
+        val resolved = resolver.getEmulatorForGame(1L, 10L, "saturn")
+
+        assertEquals(retroArch, resolved)
+    }
+
+    @Test
+    fun `unsupported built-in config falls back to external emulator`() = runTest {
+        val builtIn = EmulatorRegistry.getByPackage(EmulatorRegistry.BUILTIN_PACKAGE)!!
+        val netherSx2 = EmulatorRegistry.getById("nethersx2")!!
+        install(builtIn, netherSx2)
+        every { libretroCoreManager.isPlatformSupported("ps2") } returns false
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns null
+        coEvery { emulatorConfigDao.getDefaultForPlatform(10L) } returns config(
+            platformId = 10L,
+            packageName = builtIn.packageName
+        )
+        every { emulatorDetector.getPreferredEmulator("ps2", false) } returns installed(netherSx2)
+
+        val resolved = resolver.getEmulatorForGame(1L, 10L, "ps2")
+
+        assertEquals(netherSx2, resolved)
+    }
+
+    @Test
+    fun `configured emulator that does not support the platform is ignored`() = runTest {
+        val duckStation = EmulatorRegistry.getById("duckstation")!!
+        val builtIn = EmulatorRegistry.getByPackage(EmulatorRegistry.BUILTIN_PACKAGE)!!
+        install(duckStation, builtIn)
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns config(
+            gameId = 1L,
+            packageName = duckStation.packageName
+        )
+        coEvery { emulatorConfigDao.getDefaultForPlatform(10L) } returns null
+        every { emulatorDetector.getPreferredEmulator("snes", true) } returns installed(builtIn)
+
+        val resolved = resolver.getEmulatorForGame(1L, 10L, "snes")
+
+        assertEquals(builtIn, resolved)
+    }
+
+    @Test
+    fun `stale cache is refreshed for a lower priority configured emulator`() = runTest {
+        val builtIn = EmulatorRegistry.getByPackage(EmulatorRegistry.BUILTIN_PACKAGE)!!
+        val retroArch = EmulatorRegistry.getById("retroarch")!!
+        install(builtIn)
+        every { userPreferencesRepository.userPreferences } returns flowOf(
+            UserPreferences(builtinLibretroEnabled = false)
+        )
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns config(
+            gameId = 1L,
+            packageName = builtIn.packageName
+        )
+        coEvery { emulatorConfigDao.getDefaultForPlatform(10L) } returns config(
+            platformId = 10L,
+            packageName = retroArch.packageName
+        )
+        coEvery { emulatorDetector.detectEmulators() } answers {
+            install(builtIn, retroArch)
+            installedEmulators.value
+        }
+
+        val resolved = resolver.getEmulatorForGame(1L, 10L, "saturn")
+
+        assertEquals(retroArch, resolved)
+        coVerify(exactly = 1) { emulatorDetector.detectEmulators() }
+    }
+
+    @Test
+    fun `core selection uses the mode of fallback emulator`() = runTest {
+        val builtIn = EmulatorRegistry.getByPackage(EmulatorRegistry.BUILTIN_PACKAGE)!!
+        val retroArch = EmulatorRegistry.getById("retroarch")!!
+        install(builtIn)
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns config(
+            gameId = 1L,
+            packageName = retroArch.packageName,
+            coreName = "yabasanshiro"
+        )
+        coEvery { emulatorConfigDao.getDefaultForPlatform(10L) } returns null
+        every { emulatorDetector.getPreferredEmulator("saturn", true) } returns installed(builtIn)
+
+        val emulator = resolver.getEmulatorForGame(1L, 10L, "saturn")!!
+        val selection = resolver.resolveCoreSelectionForGame(1L, 10L, "saturn", emulator)
+
+        assertEquals(builtIn, emulator)
+        assertEquals("mednafen_saturn", selection?.selectedCore?.id)
+    }
+
+    @Test
+    fun `invalid game core falls through to valid platform core`() = runTest {
+        val builtIn = EmulatorRegistry.getByPackage(EmulatorRegistry.BUILTIN_PACKAGE)!!
+        install(builtIn)
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns config(
+            gameId = 1L,
+            packageName = builtIn.packageName,
+            coreName = "yabasanshiro"
+        )
+        coEvery { emulatorConfigDao.getDefaultForPlatform(10L) } returns config(
+            platformId = 10L,
+            packageName = builtIn.packageName,
+            coreName = "mednafen_saturn"
+        )
+
+        val selection = resolver.resolveCoreSelectionForGame(1L, 10L, "saturn", builtIn)
+
+        assertEquals("mednafen_saturn", selection?.selectedCore?.id)
+    }
+
+    @Test
+    fun `standalone emulator has no core selection`() = runTest {
+        val yabaSanshiro = EmulatorRegistry.getById("yabasanshiro")!!
+        install(yabaSanshiro)
+        coEvery { emulatorConfigDao.getByGameId(1L) } returns config(
+            gameId = 1L,
+            packageName = yabaSanshiro.packageName,
+            coreName = "yabasanshiro"
+        )
+        coEvery { emulatorConfigDao.getDefaultForPlatform(10L) } returns null
+
+        val selection = resolver.resolveCoreSelectionForGame(1L, 10L, "saturn", yabaSanshiro)
+
+        assertNull(selection)
+    }
+
+    private fun install(vararg defs: EmulatorDef) {
+        installedEmulators.value = defs.map(::installed)
+        defs.forEach { def ->
+            every { emulatorDetector.getByPackage(def.packageName) } returns def
+        }
+    }
+
+    private fun installed(def: EmulatorDef): InstalledEmulator =
+        InstalledEmulator(def = def, versionName = "1.0", versionCode = 1L)
+
+    private fun config(
+        platformId: Long? = null,
+        gameId: Long? = null,
+        packageName: String,
+        coreName: String? = null
+    ): EmulatorConfigEntity = EmulatorConfigEntity(
+        platformId = platformId,
+        gameId = gameId,
+        packageName = packageName,
+        displayName = packageName,
+        coreName = coreName,
+        isDefault = gameId == null
+    )
+}

--- a/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/emulator/GameLauncherTest.kt
@@ -51,6 +51,7 @@ class GameLauncherTest {
     private lateinit var installedAppResolver: InstalledAppResolver
     private lateinit var platformLibretroSettingsDao: PlatformLibretroSettingsDao
     private lateinit var emulatorDetector: EmulatorDetector
+    private lateinit var emulatorResolver: EmulatorResolver
     private lateinit var m3uManager: M3uManager
     private lateinit var libretroCoreMgr: LibretroCoreManager
     private lateinit var biosRepository: BiosRepository
@@ -100,9 +101,17 @@ class GameLauncherTest {
 
         every { userPreferencesRepository.userPreferences } returns flowOf(UserPreferences())
         every { userPreferencesRepository.getBuiltinCoreSelections() } returns flowOf(emptyMap())
+        every { libretroCoreMgr.isPlatformSupported(any()) } returns true
         every { emulatorDetector.installedEmulators } returns mockk {
             every { value } returns emptyList()
         }
+        emulatorResolver = EmulatorResolver(
+            emulatorDetector = emulatorDetector,
+            emulatorConfigDao = emulatorConfigDao,
+            userPreferencesRepository = userPreferencesRepository,
+            libretroCoreMgr = libretroCoreMgr,
+            installedAppResolver = installedAppResolver
+        )
 
         launcher = GameLauncher(
             context = context,
@@ -112,9 +121,8 @@ class GameLauncherTest {
             emulatorConfigDao = emulatorConfigDao,
             emulatorLaunchArgsDao = emulatorLaunchArgsDao,
             variantResolver = variantResolver,
-            installedAppResolver = installedAppResolver,
+            emulatorResolver = emulatorResolver,
             platformLibretroSettingsDao = platformLibretroSettingsDao,
-            emulatorDetector = emulatorDetector,
             m3uManager = m3uManager,
             libretroCoreMgr = libretroCoreMgr,
             biosRepository = biosRepository,
@@ -688,22 +696,12 @@ class GameLauncherTest {
 
         stubDetectorWith(installedEmulator(builtinDef))
         every { emulatorDetector.getByPackage(EmulatorRegistry.BUILTIN_PACKAGE) } returns builtinDef
+        every { libretroCoreMgr.isPlatformSupported("ps2") } returns false
+        every { emulatorDetector.getPreferredEmulator("ps2", false) } returns null
 
-        // The built-in claims support via LibretroCoreRegistry.getSupportedPlatforms().
-        // PS2 is NOT in that set. Currently the resolver does not validate this --
-        // it trusts the DB config. This test documents the current behavior.
-        // If built-in is in the installed list AND the DB says built-in for PS2,
-        // the resolver WILL return built-in. This is a known gap.
         val result = launcher.launch(1L)
 
-        // Document current behavior: built-in IS returned (incorrectly).
-        // When a platform-support guard is added, this should become NoEmulator.
-        val isBuiltinLaunch = result is LaunchResult.NoCore || result is LaunchResult.Success
-        val isRejected = result is LaunchResult.NoEmulator
-        assertTrue(
-            "PS2 + built-in config should either be rejected or fail at core lookup, got ${result::class.simpleName}",
-            isBuiltinLaunch || isRejected
-        )
+        assertTrue(result is LaunchResult.NoEmulator)
     }
 
     // -----------------------------------------------------------------------

--- a/app/src/test/kotlin/com/nendo/argosy/data/repository/SaveSyncResolutionTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/repository/SaveSyncResolutionTest.kt
@@ -1,0 +1,74 @@
+package com.nendo.argosy.data.repository
+
+import com.nendo.argosy.data.emulator.EmulatorRegistry
+import com.nendo.argosy.data.emulator.EmulatorResolver
+import com.nendo.argosy.data.emulator.ResolvedCoreSelection
+import com.nendo.argosy.data.local.entity.GameEntity
+import com.nendo.argosy.data.model.GameSource
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class SaveSyncResolutionTest {
+
+    private lateinit var emulatorResolver: EmulatorResolver
+    private lateinit var client: SaveSyncApiClient
+
+    @Before
+    fun setup() {
+        emulatorResolver = mockk()
+        client = SaveSyncApiClient(
+            saveSyncDao = mockk(relaxed = true),
+            emulatorResolver = emulatorResolver,
+            gameDao = mockk(relaxed = true),
+            savePathResolver = mockk(relaxed = true),
+            userPreferencesRepository = mockk(relaxed = true),
+            fal = mockk(relaxed = true),
+            switchSaveHandler = mockk(relaxed = true),
+            gciSaveHandler = mockk(relaxed = true),
+            saveHandlerRegistry = mockk(relaxed = true),
+            conflictDetector = mockk(relaxed = true),
+            saveUploader = dagger.Lazy { mockk(relaxed = true) },
+            saveDownloader = dagger.Lazy { mockk(relaxed = true) }
+        )
+    }
+
+    @Test
+    fun `save sync uses effective emulator and its normalized core`() = runTest {
+        val game = GameEntity(
+            id = 1L,
+            platformId = 10L,
+            platformSlug = "saturn",
+            title = "Test Game",
+            sortTitle = "test game",
+            localPath = null,
+            rommId = 100L,
+            igdbId = null,
+            source = GameSource.ROMM_SYNCED
+        )
+        val builtIn = EmulatorRegistry.getByPackage(EmulatorRegistry.BUILTIN_PACKAGE)!!
+        val availableCores = EmulatorRegistry.getSelectableCores("saturn", isBuiltIn = true)
+        val selectedCore = availableCores.single { it.id == "mednafen_saturn" }
+        coEvery {
+            emulatorResolver.getEmulatorForGame(game.id, game.platformId, game.platformSlug)
+        } returns builtIn
+        coEvery {
+            emulatorResolver.resolveCoreSelectionForGame(
+                game.id,
+                game.platformId,
+                game.platformSlug,
+                builtIn
+            )
+        } returns ResolvedCoreSelection(availableCores, selectedCore)
+
+        assertEquals("builtin", client.resolveEmulatorForGame(game))
+        assertEquals("mednafen_saturn", client.resolveCoreForGame(game))
+        coVerify(exactly = 2) {
+            emulatorResolver.getEmulatorForGame(game.id, game.platformId, game.platformSlug)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/nendo/argosy/domain/usecase/game/ConfigureEmulatorUseCaseTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/domain/usecase/game/ConfigureEmulatorUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.nendo.argosy.domain.usecase.game
 
 import com.nendo.argosy.data.emulator.EmulatorDef
+import com.nendo.argosy.data.emulator.EmulatorRegistry
 import com.nendo.argosy.data.emulator.InstalledEmulator
 import com.nendo.argosy.data.local.dao.EmulatorConfigDao
 import com.nendo.argosy.data.local.dao.SaveSyncDao
@@ -95,6 +96,39 @@ class ConfigureEmulatorUseCaseTest {
     }
 
     @Test
+    fun `setForGame stores built-in default core for platform`() = runTest {
+        val emulator = installed(EmulatorRegistry.getByPackage(EmulatorRegistry.BUILTIN_PACKAGE)!!)
+        val configSlot = slot<EmulatorConfigEntity>()
+        coEvery { emulatorConfigDao.insert(capture(configSlot)) } returns 1L
+
+        useCase.setForGame(123L, 1L, "saturn", emulator)
+
+        assertEquals("mednafen_saturn", configSlot.captured.coreName)
+    }
+
+    @Test
+    fun `setForPlatform stores external RetroArch default core for platform`() = runTest {
+        val emulator = installed(EmulatorRegistry.getById("retroarch")!!)
+        val configSlot = slot<EmulatorConfigEntity>()
+        coEvery { emulatorConfigDao.insert(capture(configSlot)) } returns 1L
+
+        useCase.setForPlatform(1L, "saturn", emulator)
+
+        assertEquals("yabasanshiro", configSlot.captured.coreName)
+    }
+
+    @Test
+    fun `setForPlatform leaves core empty for standalone emulator`() = runTest {
+        val emulator = installed(EmulatorRegistry.getById("yabasanshiro")!!)
+        val configSlot = slot<EmulatorConfigEntity>()
+        coEvery { emulatorConfigDao.insert(capture(configSlot)) } returns 1L
+
+        useCase.setForPlatform(1L, "saturn", emulator)
+
+        assertNull(configSlot.captured.coreName)
+    }
+
+    @Test
     fun `clearForGame deletes game override`() = runTest {
         useCase.clearForGame(456L)
 
@@ -178,6 +212,9 @@ class ConfigureEmulatorUseCaseTest {
             displayName = displayName,
             supportedPlatforms = setOf("nes", "snes", "gba")
         )
-        return InstalledEmulator(def = def, versionName = "1.0", versionCode = 1L)
+        return installed(def)
     }
+
+    private fun installed(def: EmulatorDef): InstalledEmulator =
+        InstalledEmulator(def = def, versionName = "1.0", versionCode = 1L)
 }


### PR DESCRIPTION
## Summary

Fixes #310.

Core availability, defaults, persistence, launch, and save sync now resolve from the same effective emulator. The shared resolver follows game override, platform default, then preferred fallback, while rejecting configured emulators that are uninstalled, disabled, or unsupported for the platform. Core values are then normalised against the mode that will actually run: built-in libretro, external RetroArch, or standalone.

This keeps the platform settings and single/dual-screen game-detail pickers aligned with the launcher, and prevents stale merged-catalogue values from leaking into configuration or save-path resolution.

## Behaviour changes

- Built-in core pickers offer only cores registered for the built-in runtime; external RetroArch retains its curated external catalogue.
- Platform and per-game Core rows show friendly names while retaining the internal IDs used for persistence and launch.
- Selecting an emulator stores that mode's valid default core. Standalone emulators do not retain an irrelevant libretro core.
- Existing game, platform, and legacy core values are considered in priority order, but invalid values fall through to a valid value for the effective emulator mode.
- Known-but-uninstalled, disabled, and platform-incompatible emulator configurations fall through to the same installed fallback used for launch.
- Settings, single-screen detail, dual-screen detail, launch, and save sync share the same emulator/core resolution contract.

## Implementation

- Centralised effective emulator resolution in `EmulatorResolver`, including installation, built-in enablement, and platform-support checks.
- Added a mode-aware core-selection result that pairs the valid catalogue with the selected fallback.
- Routed configuration writes, both game-detail paths, `GameLauncher`, and `SaveSyncApiClient` through that shared resolution.
- Kept the dual-screen picker on the already-resolved catalogue instead of rebuilding a merged list.

## Testing evidence

Tested on an AYN Thor running Android 13 with the official v2.4.0-beta.2 build and the final debug APK from this branch:

- Reproduced the merged/raw-ID picker on the official build for PlayStation and SNES.
- Verified the final debug APK resolves PlayStation to the built-in emulator and shows only `Beetle PSX HW` and `PCSX ReARMed`, with friendly names and the current core marked consistently across both displays.
- Verified SNES follows the same mode-aware behaviour.
- Covered installed, stale, disabled, unsupported, fallback, built-in/external default, standalone, and save-sync resolution cases with regression tests.
- Ran `assembleDebug`, the complete debug unit-test suite, and `lintDebug` successfully.
- Exercised live save sync against RomM v5.0.0: successful `/api/saves` reads followed by two successful negotiations with no uploads or conflicts and `no_op=3`; the second pass processed no queued work.
- Both display activities remained healthy with no Android runtime crash.

## AI assistance

Implemented collaboratively with OpenAI Codex. Codex performed the code-path diagnosis, and the implementation and regression tests were authored collaboratively. I steered the design and scope, personally reviewed, understand, and approve every line, ran local/CI-equivalent validation, and completed device installation and persistence inspection. I reproduced the bug, reviewed the behaviour, and performed the real-hardware look, feel, and UX verification.

## Checklist

- [x] I have tested the changes on real hardware
- [x] I have added or updated unit tests covering the changes
- [x] I have personally reviewed and understand the code being submitted
