### PR TITLE
download: fix ENOTDIR when adding a variant to a flat-downloaded base rom

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/download/DownloadManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/download/DownloadManager.kt
@@ -611,8 +611,12 @@ class DownloadManager @Inject constructor(
         if (baseFile != null && baseFile.isFile &&
             baseFile.parentFile?.absolutePath == platformDir.absolutePath
         ) {
+            val source = if (gameFolder.absolutePath == baseFile.absolutePath) {
+                val stash = File(platformDir, ".${baseFile.name}.promoting")
+                if (baseFile.renameTo(stash)) stash.also { gameFolder.mkdirs() } else baseFile
+            } else baseFile
             val moved = File(gameFolder, baseFile.name)
-            if (baseFile.renameTo(moved)) {
+            if (source.renameTo(moved)) {
                 gameDao.updateLocalPath(gameId, moved.absolutePath, game.source)
                 gameFileDao.getByLocalPath(basePath)?.let { row ->
                     gameFileDao.updateLocalPath(row.id, moved.absolutePath, row.downloadedAt ?: Instant.now())


### PR DESCRIPTION
Fixes #315.

## Summary
Downloading a patched variant of a rom whose base was downloaded as a flat file fails with `FileNotFoundException ... ENOTDIR (Not a directory)` and the variant never downloads.

Root cause is in `DownloadManager.resolveAddonFolder`. When a variant is added, the flat base rom is promoted into a per-game folder named after `rommFileName`. `rommFileName` carries the extension, so for a single-file rom the folder name equals the flat file's own name (e.g. `Pokemon Emerald [Original].gba`). The target folder path then collides with the existing file: `getGameFolder`'s `mkdirs()` silently fails against the file, `resolveAddonFolder` returns a `File` that is actually the flat rom, and the following category-subfolder write (`.../game/<variant>.tmp`) hits `ENOTDIR`.

The fix detects that collision. When the game folder resolves to the same path as the flat base file, it moves the file to a temporary hidden name, creates the folder, then moves it inside. Every non-colliding promotion takes the original path unchanged.

## Behavior changes
- Adding a variant to a rom whose base was downloaded flat now succeeds: the base is promoted into `<rommFileName>/` and the variant lands in `<rommFileName>/game/`, instead of erroring out. Previously this combination failed and left the download broken.
- No change to any non-colliding download path.

## Hot paths
Not a launch/frame/sync path. This is the download-enqueue path, already off the main thread. The added work is one `renameTo` + one `mkdirs`, and only in the collision case (base flat file occupies the target folder path); the common path is untouched.

## Testing evidence
Emulator (Pixel 6 / Android 34 AVD, arm64 lib under translation) against a live RomM 5.0.0 server, driving the exact repro from #315:
1. Download base `Pokemon Emerald [Original].gba` (creates the flat file under `RomM/gba/`).
2. Download variant `Pokemon Emerald [Legacy] (1.0.0).gba`.

Result — no `ENOTDIR`; app log shows the promotion succeeding where it previously failed:

```
resolveAddonFolder: moved flat base Pokemon Emerald [Original].gba into Pokemon Emerald [Original].gba
Download complete ... /RomM/gba/Pokemon Emerald [Original].gba/game/Pokemon Emerald [Legacy] (1.0.0).gba
```

On-device layout after the run:
```
RomM/gba/Pokemon Emerald [Original].gba/          (now a directory)
  Pokemon Emerald [Original].gba                  (base, promoted)
  game/Pokemon Emerald [Legacy] (1.0.0).gba       (variant)
```
No leftover `.promoting` temp file. The pre-fix build reproduces the original failure on the same flow.

Tested again after compilation on a Pixel 9 Pro Fold (the device reporting the error). Same on-device layout, same success.

## AI assistance
Investigated, written, and verified primarily by Claude Code (Opus). I reviewed the diff and drove the on-device test flow myself.

## Checklist
- [x] I've tested the changes on real hardware
- [ ] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
