### PR TITLE
ui: pocket taco mode, ui scale bugfix, updated overlays to be bounded…

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/DisplayPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/DisplayPreferencesRepository.kt
@@ -47,6 +47,8 @@ data class DisplayPreferences(
     val libraryDefaultSource: String = "ALL",
     val libraryDefaultPlatform: String = "",
     val uiScale: Int = 100,
+    val pocketTacoEnabled: Boolean = false,
+    val pocketTacoPercent: Int = 20,
     val backgroundBlur: Int = 0,
     val backgroundSaturation: Int = 100,
     val backgroundOpacity: Int = 100,
@@ -129,6 +131,8 @@ class DisplayPreferencesRepository @Inject constructor(
         val LIBRARY_DEFAULT_SOURCE = stringPreferencesKey("library_default_source")
         val LIBRARY_DEFAULT_PLATFORM = stringPreferencesKey("library_default_platform")
         val UI_SCALE = intPreferencesKey("ui_scale")
+        val POCKET_TACO_ENABLED = booleanPreferencesKey("pocket_taco_enabled")
+        val POCKET_TACO_PERCENT = intPreferencesKey("pocket_taco_percent")
         val BACKGROUND_BLUR = intPreferencesKey("background_blur")
         val BACKGROUND_SATURATION = intPreferencesKey("background_saturation")
         val BACKGROUND_OPACITY = intPreferencesKey("background_opacity")
@@ -208,6 +212,8 @@ class DisplayPreferencesRepository @Inject constructor(
             libraryDefaultSource = prefs[Keys.LIBRARY_DEFAULT_SOURCE] ?: "ALL",
             libraryDefaultPlatform = prefs[Keys.LIBRARY_DEFAULT_PLATFORM] ?: "",
             uiScale = prefs[Keys.UI_SCALE] ?: 100,
+            pocketTacoEnabled = prefs[Keys.POCKET_TACO_ENABLED] ?: false,
+            pocketTacoPercent = prefs[Keys.POCKET_TACO_PERCENT] ?: 20,
             backgroundBlur = prefs[Keys.BACKGROUND_BLUR] ?: 40,
             backgroundSaturation = prefs[Keys.BACKGROUND_SATURATION] ?: 100,
             backgroundOpacity = prefs[Keys.BACKGROUND_OPACITY] ?: 100,
@@ -383,6 +389,14 @@ class DisplayPreferencesRepository @Inject constructor(
 
     suspend fun setUiScale(scale: Int) {
         dataStore.edit { it[Keys.UI_SCALE] = scale.coerceIn(50, 150) }
+    }
+
+    suspend fun setPocketTacoEnabled(enabled: Boolean) {
+        dataStore.edit { it[Keys.POCKET_TACO_ENABLED] = enabled }
+    }
+
+    suspend fun setPocketTacoPercent(percent: Int) {
+        dataStore.edit { it[Keys.POCKET_TACO_PERCENT] = percent.coerceIn(5, 40) }
     }
 
     suspend fun setBackgroundBlur(blur: Int) {

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
@@ -166,6 +166,8 @@ class UserPreferencesRepository @Inject constructor(
             videoWallpaperDelaySeconds = display.videoWallpaperDelaySeconds,
             videoWallpaperMuted = display.videoWallpaperMuted,
             uiScale = display.uiScale,
+            pocketTacoEnabled = display.pocketTacoEnabled,
+            pocketTacoPercent = display.pocketTacoPercent,
             ambientLedEnabled = display.ambientLedEnabled,
             ambientLedBrightness = display.ambientLedBrightness,
             ambientLedAudioBrightness = display.ambientLedAudioBrightness,
@@ -240,6 +242,8 @@ class UserPreferencesRepository @Inject constructor(
 
     suspend fun setLibraryDefaultPlatform(slug: String) = displayPrefs.setLibraryDefaultPlatform(slug)
     suspend fun setUiScale(scale: Int) = displayPrefs.setUiScale(scale)
+    suspend fun setPocketTacoEnabled(enabled: Boolean) = displayPrefs.setPocketTacoEnabled(enabled)
+    suspend fun setPocketTacoPercent(percent: Int) = displayPrefs.setPocketTacoPercent(percent)
     suspend fun setBackgroundBlur(blur: Int) = displayPrefs.setBackgroundBlur(blur)
     suspend fun setBackgroundSaturation(saturation: Int) = displayPrefs.setBackgroundSaturation(saturation)
     suspend fun setBackgroundOpacity(opacity: Int) = displayPrefs.setBackgroundOpacity(opacity)
@@ -710,6 +714,8 @@ data class UserPreferences(
     val videoWallpaperDelaySeconds: Int = 3,
     val videoWallpaperMuted: Boolean = false,
     val uiScale: Int = 100,
+    val pocketTacoEnabled: Boolean = false,
+    val pocketTacoPercent: Int = 20,
     val ambientLedEnabled: Boolean = false,
     val ambientLedBrightness: Int = 100,
     val ambientLedAudioBrightness: Boolean = true,

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryDisplayTheme.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryDisplayTheme.kt
@@ -43,7 +43,11 @@ fun SecondaryHomeTheme(
         argosyTypography(fonts, themeState.displayFontScale, themeState.bodyFontScale)
     }
 
-    ProvideArgosyThemeLocals(themeState = themeState, palette = palette) {
+    ProvideArgosyThemeLocals(
+        themeState = themeState,
+        palette = palette,
+        isSecondaryDisplay = true
+    ) {
         MaterialTheme(
             colorScheme = argosyColorScheme(palette),
             typography = typography,

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/ui/AutoRestorePrompt.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/ui/AutoRestorePrompt.kt
@@ -30,6 +30,7 @@ import com.nendo.argosy.ui.input.InputHandler
 import com.nendo.argosy.ui.input.InputResult
 import com.nendo.argosy.ui.util.clickableNoFocus
 import kotlinx.coroutines.delay
+import com.nendo.argosy.ui.theme.pocketTacoBottomInset
 
 @Composable
 fun AutoRestorePrompt(
@@ -77,6 +78,7 @@ fun AutoRestorePrompt(
         modifier = Modifier
             .fillMaxSize()
             .background(overlayColor)
+            .padding(bottom = pocketTacoBottomInset())
             .focusProperties { canFocus = false },
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameFrameScreen.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameFrameScreen.kt
@@ -37,6 +37,7 @@ import com.nendo.argosy.ui.components.InputButton
 import com.nendo.argosy.ui.input.InputHandler
 import com.nendo.argosy.ui.input.InputResult
 import com.nendo.argosy.ui.util.clickableNoFocus
+import com.nendo.argosy.ui.theme.pocketTacoBottomInset
 
 @Composable
 fun InGameFrameScreen(
@@ -80,6 +81,7 @@ fun InGameFrameScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .padding(bottom = pocketTacoBottomInset())
             .focusProperties { canFocus = false }
     ) {
         Row(

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameMenu.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameMenu.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import com.nendo.argosy.ui.input.InputHandler
 import com.nendo.argosy.ui.input.InputResult
 import com.nendo.argosy.ui.theme.generated.DimensionTokens
+import com.nendo.argosy.ui.theme.pocketTacoBottomInset
 import com.nendo.argosy.ui.util.clickableNoFocus
 
 sealed class InGameMenuAction {
@@ -264,14 +265,20 @@ fun InGameMenu(
         }
     }
 
+    val menuConfiguration = LocalConfiguration.current
+    val menuBottomReserved = pocketTacoBottomInset()
+
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(overlayColor)
+            .padding(bottom = menuBottomReserved)
             .clickableNoFocus { currentOnAction.value(InGameMenuAction.Resume) },
         contentAlignment = Alignment.Center
     ) {
-        val maxHeightDp = (LocalConfiguration.current.screenHeightDp * 0.9f).dp
+        val availableHeightDp = menuConfiguration.screenHeightDp - menuBottomReserved.value
+        val maxHeightDp =
+            (availableHeightDp * DimensionTokens.Layout.inGameMenuMaxHeightPct / 100f).dp
         val menuGridState = rememberLazyGridState()
 
         LaunchedEffect(focusedIndex, menuItems.size) {
@@ -429,14 +436,20 @@ fun DiscMenu(
         }
     }
 
+    val discConfiguration = LocalConfiguration.current
+    val discBottomReserved = pocketTacoBottomInset()
+
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(overlayColor)
+            .padding(bottom = discBottomReserved)
             .focusProperties { canFocus = false },
         contentAlignment = Alignment.Center
     ) {
-        val maxHeightDp = (LocalConfiguration.current.screenHeightDp * 0.9f).dp
+        val availableHeightDp = discConfiguration.screenHeightDp - discBottomReserved.value
+        val maxHeightDp =
+            (availableHeightDp * DimensionTokens.Layout.inGameMenuMaxHeightPct / 100f).dp
         val listState = rememberLazyListState()
 
         LaunchedEffect(focusedIndex, labels.size) {

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameSettingsScreen.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameSettingsScreen.kt
@@ -71,6 +71,7 @@ import com.nendo.argosy.ui.screens.settings.libretro.libretroSettingsMaxFocusInd
 import com.nendo.argosy.ui.screens.settings.menu.SettingsLayout
 import com.nendo.argosy.ui.theme.Dimens
 import com.nendo.argosy.ui.util.touchOnly
+import com.nendo.argosy.ui.theme.pocketTacoBottomInset
 
 enum class InGameSettingsTab(val label: String) {
     VIDEO("Video"),
@@ -494,6 +495,7 @@ fun InGameSettingsScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(overlayColor)
+            .padding(bottom = pocketTacoBottomInset())
             .focusProperties { canFocus = false },
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameShaderChainScreen.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameShaderChainScreen.kt
@@ -23,6 +23,7 @@ import com.nendo.argosy.ui.input.InputHandler
 import com.nendo.argosy.ui.input.InputResult
 import com.nendo.argosy.ui.screens.settings.sections.ShaderStackSection
 import com.nendo.argosy.ui.theme.Dimens
+import com.nendo.argosy.ui.theme.pocketTacoBottomInset
 
 @Composable
 fun InGameShaderChainScreen(
@@ -135,6 +136,7 @@ fun InGameShaderChainScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(overlayColor)
+            .padding(bottom = pocketTacoBottomInset())
             .focusProperties { canFocus = false },
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameStateManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/ui/InGameStateManager.kt
@@ -53,6 +53,7 @@ import com.nendo.argosy.ui.components.NestedModal
 import com.nendo.argosy.ui.input.InputHandler
 import com.nendo.argosy.ui.input.InputResult
 import com.nendo.argosy.ui.util.clickableNoFocus
+import com.nendo.argosy.ui.theme.pocketTacoBottomInset
 
 enum class StateManagerViewMode { SPLIT, CAROUSEL }
 
@@ -200,6 +201,7 @@ fun InGameStateManager(
         modifier = Modifier
             .fillMaxSize()
             .background(overlayColor)
+            .padding(bottom = pocketTacoBottomInset())
             .focusProperties { canFocus = false }
     ) {
         val isSquarish = maxWidth < 500.dp || (maxWidth / maxHeight < 1.4f)

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/ui/NetplayOverlays.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/ui/NetplayOverlays.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import com.nendo.argosy.ui.input.InputHandler
 import com.nendo.argosy.ui.input.InputResult
 import com.nendo.argosy.ui.util.clickableNoFocus
+import com.nendo.argosy.ui.theme.pocketTacoBottomInset
 
 enum class NetplayProgressStage { RequestingJoin, WaitingForHost, Connecting, Measuring, LoadingState, Ready, Failed }
 
@@ -503,6 +504,7 @@ private fun NetplayScrim(content: @Composable () -> Unit) {
         modifier = Modifier
             .fillMaxSize()
             .background(overlayColor)
+            .padding(bottom = pocketTacoBottomInset())
             .focusProperties { canFocus = false },
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/ui/QuickLoadTimeline.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/ui/QuickLoadTimeline.kt
@@ -49,6 +49,7 @@ import com.nendo.argosy.ui.input.InputResult
 import com.nendo.argosy.ui.util.clickableNoFocus
 import com.nendo.argosy.util.formatSaveSize
 import com.nendo.argosy.util.formatSaveTimestamp
+import com.nendo.argosy.ui.theme.pocketTacoBottomInset
 
 @Composable
 fun QuickLoadTimeline(
@@ -97,6 +98,7 @@ fun QuickLoadTimeline(
         modifier = Modifier
             .fillMaxSize()
             .background(overlayColor)
+            .padding(bottom = pocketTacoBottomInset())
             .focusProperties { canFocus = false },
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/kotlin/com/nendo/argosy/libretro/ui/cheats/CheatsScreen.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/libretro/ui/cheats/CheatsScreen.kt
@@ -52,6 +52,7 @@ import com.nendo.argosy.ui.util.touchOnly
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import com.nendo.argosy.ui.theme.pocketTacoBottomInset
 
 enum class CheatsTab(val label: String) {
     CHEATS("Cheats"),
@@ -545,6 +546,7 @@ fun CheatsScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(overlayColor)
+            .padding(bottom = pocketTacoBottomInset())
             .focusProperties { canFocus = false },
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ModalNavigationDrawer
@@ -30,6 +31,7 @@ import androidx.compose.ui.focus.focusRequester
 import android.content.Intent
 import com.nendo.argosy.ui.util.doubleTapNoFocus
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import com.nendo.argosy.libretro.LibretroActivity
 import androidx.compose.ui.unit.dp
@@ -97,6 +99,7 @@ import com.nendo.argosy.ui.dualscreen.home.DualHomeViewModel
 import com.nendo.argosy.ui.dualscreen.home.toShowcaseState
 import com.nendo.argosy.ui.theme.Dimens
 import com.nendo.argosy.ui.theme.LocalLauncherTheme
+import com.nendo.argosy.ui.theme.LocalUiScale
 import com.nendo.argosy.ui.theme.Motion
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.Lifecycle
@@ -1028,6 +1031,11 @@ fun ArgosyApp(
         val isDarkTheme = LocalLauncherTheme.current.isDarkTheme
         val scrimColor = if (isDarkTheme) Color.Black.copy(alpha = 0.5f) else Color.White.copy(alpha = 0.35f)
         val dimmerEnabled = screenDimmerPrefs.enabled && !isEmulatorRunning && !uiState.isFirstRun
+        val screenHeightDp = LocalConfiguration.current.screenHeightDp
+        val bottomReservedFraction = LocalUiScale.current.bottomReservedFraction
+        val bottomReserved = remember(screenHeightDp, bottomReservedFraction) {
+            (screenHeightDp * bottomReservedFraction).dp
+        }
 
         ScreenDimmerOverlay(
             enabled = dimmerEnabled,
@@ -1038,6 +1046,7 @@ fun ArgosyApp(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
+                    .padding(bottom = bottomReserved)
                     .focusRequester(rootFocusRequester)
                     .focusable()
                     .doubleTapNoFocus { openQuickMenu() }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
@@ -527,7 +527,7 @@ private fun routeStorageCachesConfirm(vm: SettingsViewModel, state: SettingsUiSt
 private fun routeInterfaceConfirm(vm: SettingsViewModel, state: SettingsUiState): InputResult {
     val layoutState = InterfaceLayoutState.from(state)
     when (interfaceItemAtFocusIndex(state.focusedIndex, layoutState)) {
-        InterfaceItem.UiScale -> vm.cycleUiScale()
+        InterfaceItem.PocketTaco -> vm.setPocketTacoEnabled(!state.display.pocketTacoEnabled)
         InterfaceItem.HomeScreen -> vm.navigateToHomeScreen()
         InterfaceItem.LibraryView -> vm.navigateToLibraryView()
         InterfaceItem.BoxArt -> vm.navigateToBoxArt()

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouter.kt
@@ -270,6 +270,15 @@ internal fun routeAdjustUiScale(vm: SettingsViewModel, delta: Int) {
     vm.displayDelegate.adjustUiScale(vm.viewModelScope, delta)
 }
 
+internal fun routeAdjustPocketTacoPercent(vm: SettingsViewModel, delta: Int) {
+    val current = vm.uiState.value.display.pocketTacoPercent
+    val wouldBe = (current + delta).coerceIn(5, 40)
+    if (wouldBe == current && delta != 0) {
+        vm.hapticManager.vibrate(HapticPattern.BOUNDARY_HIT)
+    }
+    vm.displayDelegate.adjustPocketTacoPercent(vm.viewModelScope, delta)
+}
+
 internal fun routeAdjustBackgroundBlur(vm: SettingsViewModel, delta: Int) {
     val current = vm.uiState.value.display.backgroundBlur
     val wouldBe = (current + delta).coerceIn(0, 100)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsInitRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsInitRouter.kt
@@ -488,6 +488,8 @@ internal fun routeLoadSettings(vm: SettingsViewModel) {
             videoWallpaperDelaySeconds = prefs.videoWallpaperDelaySeconds,
             videoWallpaperMuted = prefs.videoWallpaperMuted,
             uiScale = prefs.uiScale,
+            pocketTacoEnabled = prefs.pocketTacoEnabled,
+            pocketTacoPercent = prefs.pocketTacoPercent,
             ambientLedEnabled = prefs.ambientLedEnabled,
             ambientLedBrightness = prefs.ambientLedBrightness,
             ambientLedAudioBrightness = prefs.ambientLedAudioBrightness,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsModels.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsModels.kt
@@ -236,6 +236,8 @@ data class DisplayState(
     val videoWallpaperDelaySeconds: Int = 3,
     val videoWallpaperMuted: Boolean = false,
     val uiScale: Int = 100,
+    val pocketTacoEnabled: Boolean = false,
+    val pocketTacoPercent: Int = 20,
     val ambientLedEnabled: Boolean = false,
     val ambientLedBrightness: Int = 100,
     val ambientLedAudioBrightness: Boolean = true,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
@@ -840,7 +840,10 @@ class SettingsViewModel @Inject constructor(
 
     fun adjustUiScale(delta: Int) = routeAdjustUiScale(this, delta)
 
-    fun cycleUiScale() = displayDelegate.cycleUiScale(viewModelScope)
+    fun setPocketTacoEnabled(enabled: Boolean) =
+        displayDelegate.setPocketTacoEnabled(viewModelScope, enabled)
+
+    fun adjustPocketTacoPercent(delta: Int) = routeAdjustPocketTacoPercent(this, delta)
 
     fun adjustBackgroundBlur(delta: Int) = routeAdjustBackgroundBlur(this, delta)
     fun adjustBackgroundSaturation(delta: Int) = routeAdjustBackgroundSaturation(this, delta)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/DisplaySettingsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/DisplaySettingsDelegate.kt
@@ -409,10 +409,27 @@ class DisplaySettingsDelegate @Inject constructor(
         }
     }
 
-    fun cycleUiScale(scope: CoroutineScope) {
-        val current = _state.value.uiScale
-        val newValue = if (current >= 150) 75 else current + 5
-        setUiScale(scope, newValue)
+    fun setPocketTacoEnabled(scope: CoroutineScope, enabled: Boolean) {
+        scope.launch {
+            preferencesRepository.setPocketTacoEnabled(enabled)
+            _state.update { it.copy(pocketTacoEnabled = enabled) }
+        }
+    }
+
+    fun setPocketTacoPercent(scope: CoroutineScope, percent: Int) {
+        val newValue = percent.coerceIn(5, 40)
+        scope.launch {
+            preferencesRepository.setPocketTacoPercent(newValue)
+            _state.update { it.copy(pocketTacoPercent = newValue) }
+        }
+    }
+
+    fun adjustPocketTacoPercent(scope: CoroutineScope, delta: Int) {
+        val current = _state.value.pocketTacoPercent
+        val newValue = (current + delta).coerceIn(5, 40)
+        if (newValue != current) {
+            setPocketTacoPercent(scope, newValue)
+        }
     }
 
     fun adjustBackgroundBlur(scope: CoroutineScope, delta: Int) {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/InterfaceSection.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/InterfaceSection.kt
@@ -54,6 +54,12 @@ internal sealed class InterfaceItem(
     ) : InterfaceItem(key, section, visibleWhen)
 
     data object UiScale : InterfaceItem("uiScale", "layout")
+    data object PocketTaco : InterfaceItem("pocketTaco", "layout")
+    data object PocketTacoPercent : InterfaceItem(
+        "pocketTacoPercent",
+        "layout",
+        visibleWhen = { it.display.pocketTacoEnabled }
+    )
     data object HomeScreen : InterfaceItem("homeScreen", "layout")
     data object StartupView : InterfaceItem("startupView", "layout")
     data object LibraryView : InterfaceItem("libraryView", "layout")
@@ -61,7 +67,7 @@ internal sealed class InterfaceItem(
 
     companion object {
         val ALL: List<InterfaceItem> = listOf(
-            UiScale, StartupView, HomeScreen, LibraryView, BoxArt
+            UiScale, PocketTaco, PocketTacoPercent, StartupView, HomeScreen, LibraryView, BoxArt
         )
     }
 }
@@ -133,7 +139,26 @@ fun InterfaceSection(uiState: SettingsUiState, viewModel: SettingsViewModel) {
                     isFocused = isFocused(item),
                     step = 5,
                     suffix = "%",
-                    onClick = { viewModel.adjustUiScale(5) }
+                    onAdjust = { viewModel.adjustUiScale(it) }
+                )
+
+                InterfaceItem.PocketTaco -> SwitchPreference(
+                    title = "Pocket Taco Mode",
+                    subtitle = "Shifts the UI up in portrait mode",
+                    isEnabled = display.pocketTacoEnabled,
+                    isFocused = isFocused(item),
+                    onToggle = { viewModel.setPocketTacoEnabled(!display.pocketTacoEnabled) }
+                )
+
+                InterfaceItem.PocketTacoPercent -> SliderPreference(
+                    title = "Reserved Area",
+                    value = display.pocketTacoPercent,
+                    minValue = 5,
+                    maxValue = 40,
+                    isFocused = isFocused(item),
+                    step = 5,
+                    suffix = "%",
+                    onAdjust = { viewModel.adjustPocketTacoPercent(it) }
                 )
 
                 InterfaceItem.HomeScreen -> NavigationPreference(

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/input/InterfaceSectionInput.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/input/InterfaceSectionInput.kt
@@ -57,6 +57,8 @@ internal class InterfaceSectionInput(
         val layoutState = layoutState()
         when (interfaceItemAtFocusIndex(state.focusedIndex, layoutState)) {
             InterfaceItem.UiScale -> { viewModel.adjustUiScale(direction * 5); return InputResult.HANDLED }
+            InterfaceItem.PocketTaco -> { viewModel.setPocketTacoEnabled(direction > 0); return InputResult.HANDLED }
+            InterfaceItem.PocketTacoPercent -> { viewModel.adjustPocketTacoPercent(direction * 5); return InputResult.HANDLED }
             InterfaceItem.StartupView -> { viewModel.cycleDefaultView(); return InputResult.HANDLED }
             else -> {}
         }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/theme/PocketTaco.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/theme/PocketTaco.kt
@@ -1,0 +1,39 @@
+package com.nendo.argosy.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Resolves the fraction of screen height Pocket Taco Mode reserves at the
+ * bottom of the primary display.
+ *
+ * Returns 0 unless all three hold: the mode is enabled, the display is
+ * portrait, and this is not the companion display. The companion never
+ * reserves space - it is a second screen, not a screen held in a grip.
+ */
+fun resolvePocketTacoFraction(
+    enabled: Boolean,
+    percent: Int,
+    screenWidthDp: Int,
+    screenHeightDp: Int,
+    isSecondaryDisplay: Boolean = false
+): Float {
+    if (!enabled || isSecondaryDisplay) return 0f
+    if (screenWidthDp >= screenHeightDp) return 0f
+    return percent.coerceIn(0, 100) / 100f
+}
+
+/**
+ * Bottom inset any full-screen overlay should apply so it does not render into
+ * the band Pocket Taco Mode reserves. Resolves to 0.dp whenever the mode is
+ * inactive, so applying it unconditionally is safe.
+ */
+@Composable
+fun pocketTacoBottomInset(): Dp {
+    val screenHeightDp = LocalConfiguration.current.screenHeightDp
+    val fraction = LocalUiScale.current.bottomReservedFraction
+    return remember(screenHeightDp, fraction) { (screenHeightDp * fraction).dp }
+}

--- a/app/src/main/kotlin/com/nendo/argosy/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/theme/Theme.kt
@@ -330,6 +330,7 @@ fun ALauncherTheme(
 fun ProvideArgosyThemeLocals(
     themeState: ThemeState,
     palette: ArgosyPalette,
+    isSecondaryDisplay: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val focusGlow = palette.effectivePrimary.copy(alpha = 0.4f)
@@ -381,7 +382,14 @@ fun ProvideArgosyThemeLocals(
 
     val uiScaleConfig = UiScaleConfig(
         scale = themeState.uiScale / 100f,
-        aspectRatioClass = aspectRatioClass
+        aspectRatioClass = aspectRatioClass,
+        bottomReservedFraction = resolvePocketTacoFraction(
+            enabled = themeState.pocketTacoEnabled,
+            percent = themeState.pocketTacoPercent,
+            screenWidthDp = configuration.screenWidthDp,
+            screenHeightDp = configuration.screenHeightDp,
+            isSecondaryDisplay = isSecondaryDisplay
+        )
     )
 
     val context = LocalContext.current

--- a/app/src/main/kotlin/com/nendo/argosy/ui/theme/ThemeViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/theme/ThemeViewModel.kt
@@ -65,6 +65,8 @@ data class ThemeState(
     val platformIndicatorContent: PlatformIndicatorContent = PlatformIndicatorContent.NAME,
     val useAccentColorFooter: Boolean = false,
     val uiScale: Int = 100,
+    val pocketTacoEnabled: Boolean = false,
+    val pocketTacoPercent: Int = 20,
     val displayFontScale: Int = 100,
     val bodyFontScale: Int = 100
 )
@@ -193,6 +195,8 @@ fun UserPreferences.toThemeState(): ThemeState = ThemeState(
     platformIndicatorContent = platformIndicatorContent,
     useAccentColorFooter = useAccentColorFooter,
     uiScale = uiScale,
+    pocketTacoEnabled = pocketTacoEnabled,
+    pocketTacoPercent = pocketTacoPercent,
     displayFontScale = displayFontScale,
     bodyFontScale = bodyFontScale
 )

--- a/app/src/main/kotlin/com/nendo/argosy/ui/theme/UiScale.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/theme/UiScale.kt
@@ -6,7 +6,8 @@ import androidx.compose.ui.unit.Dp
 
 data class UiScaleConfig(
     val scale: Float = 1.0f,
-    val aspectRatioClass: AspectRatioClass = AspectRatioClass.STANDARD
+    val aspectRatioClass: AspectRatioClass = AspectRatioClass.STANDARD,
+    val bottomReservedFraction: Float = 0f
 )
 
 enum class AspectRatioClass {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/theme/generated/DimensionTokens.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/theme/generated/DimensionTokens.kt
@@ -76,6 +76,7 @@ object DimensionTokens {
         const val menuBreakpointWide = 600
         const val inGameMenuWidth = 300
         const val inGameMenuWidthWide = 560
+        const val inGameMenuMaxHeightPct = 90
     }
 
     object Elevation {

--- a/app/src/test/kotlin/com/nendo/argosy/ui/screens/settings/sections/InterfacePocketTacoLayoutTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/ui/screens/settings/sections/InterfacePocketTacoLayoutTest.kt
@@ -1,0 +1,59 @@
+package com.nendo.argosy.ui.screens.settings.sections
+
+import com.nendo.argosy.ui.screens.settings.DisplayState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InterfacePocketTacoLayoutTest {
+
+    private fun layout(enabled: Boolean) =
+        InterfaceLayoutState(DisplayState(pocketTacoEnabled = enabled))
+
+    private fun focusableItems(enabled: Boolean): List<InterfaceItem?> {
+        val state = layout(enabled)
+        return (0..interfaceMaxFocusIndex(state)).map { interfaceItemAtFocusIndex(it, state) }
+    }
+
+    @Test
+    fun `percent row is not reachable while pocket taco is off`() {
+        assertFalse(focusableItems(enabled = false).contains(InterfaceItem.PocketTacoPercent))
+    }
+
+    @Test
+    fun `percent row is reachable once pocket taco is on`() {
+        assertTrue(focusableItems(enabled = true).contains(InterfaceItem.PocketTacoPercent))
+    }
+
+    @Test
+    fun `the toggle itself is always reachable`() {
+        assertTrue(focusableItems(enabled = false).contains(InterfaceItem.PocketTaco))
+        assertTrue(focusableItems(enabled = true).contains(InterfaceItem.PocketTaco))
+    }
+
+    @Test
+    fun `enabling pocket taco adds exactly one focusable row`() {
+        assertEquals(
+            interfaceMaxFocusIndex(layout(enabled = false)) + 1,
+            interfaceMaxFocusIndex(layout(enabled = true))
+        )
+    }
+
+    @Test
+    fun `percent row sits directly beneath its toggle`() {
+        val state = layout(enabled = true)
+        assertEquals(
+            interfaceFocusIndexOf(InterfaceItem.PocketTaco, state) + 1,
+            interfaceFocusIndexOf(InterfaceItem.PocketTacoPercent, state)
+        )
+    }
+
+    @Test
+    fun `rows after the percent row shift up when it is hidden`() {
+        assertEquals(
+            interfaceFocusIndexOf(InterfaceItem.StartupView, layout(enabled = true)) - 1,
+            interfaceFocusIndexOf(InterfaceItem.StartupView, layout(enabled = false))
+        )
+    }
+}

--- a/app/src/test/kotlin/com/nendo/argosy/ui/theme/PocketTacoFractionTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/ui/theme/PocketTacoFractionTest.kt
@@ -1,0 +1,72 @@
+package com.nendo.argosy.ui.theme
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private const val PORTRAIT_W = 412
+private const val PORTRAIT_H = 915
+private const val LANDSCAPE_W = 915
+private const val LANDSCAPE_H = 412
+
+class PocketTacoFractionTest {
+
+    @Test
+    fun `enabled in portrait reserves the configured percent`() {
+        assertEquals(
+            0.20f,
+            resolvePocketTacoFraction(true, 20, PORTRAIT_W, PORTRAIT_H),
+            0.0001f
+        )
+    }
+
+    @Test
+    fun `enabled in landscape reserves nothing`() {
+        assertEquals(
+            0f,
+            resolvePocketTacoFraction(true, 20, LANDSCAPE_W, LANDSCAPE_H),
+            0.0001f
+        )
+    }
+
+    @Test
+    fun `disabled reserves nothing even in portrait`() {
+        assertEquals(
+            0f,
+            resolvePocketTacoFraction(false, 40, PORTRAIT_W, PORTRAIT_H),
+            0.0001f
+        )
+    }
+
+    @Test
+    fun `secondary display never reserves even when enabled in portrait`() {
+        assertEquals(
+            0f,
+            resolvePocketTacoFraction(true, 40, PORTRAIT_W, PORTRAIT_H, isSecondaryDisplay = true),
+            0.0001f
+        )
+    }
+
+    @Test
+    fun `a square display is not portrait`() {
+        assertEquals(
+            0f,
+            resolvePocketTacoFraction(true, 20, 800, 800),
+            0.0001f
+        )
+    }
+
+    @Test
+    fun `a portrait tablet still reserves`() {
+        assertEquals(
+            0.15f,
+            resolvePocketTacoFraction(true, 15, 800, 1280),
+            0.0001f
+        )
+    }
+
+    @Test
+    fun `percent is clamped into a usable fraction`() {
+        assertEquals(0f, resolvePocketTacoFraction(true, -10, PORTRAIT_W, PORTRAIT_H), 0.0001f)
+        assertEquals(1f, resolvePocketTacoFraction(true, 250, PORTRAIT_W, PORTRAIT_H), 0.0001f)
+    }
+}

--- a/design-system-docs/tokens.json
+++ b/design-system-docs/tokens.json
@@ -139,7 +139,8 @@
       "modalWidthXl":          575,
       "menuBreakpointWide":    600,
       "inGameMenuWidth":       300,
-      "inGameMenuWidthWide":   560
+      "inGameMenuWidthWide":   560,
+      "inGameMenuMaxHeightPct": 90
     },
     "elevation": {
       "none":    0,


### PR DESCRIPTION
… by the reserved area

## Summary
Adds Pocket Taco Mode: an opt-in setting that reserves a band at the bottom of the
screen in portrait and shifts the UI up out of it. It's for playing with the phone in
a controller grip like the pocket taco, where the bottom of the display is physically covered. 

To be clear, this is to make the menus navigable while keeping the controller on the phone. Games already work.

## Behavior changes
## Behavior changes

1. **New setting: Interface > Layout > "Pocket Taco Mode"** (default off), subtitle
   "Shifts the UI up in portrait mode". When on, a "Reserved Area" row appears
   (5-40%, default 20%, step 5) and hides again when the toggle goes off.

2. **Applies only in portrait, only on the primary display.** Landscape resolves the
   reserve to zero, so landscape and TV are byte-identical to before. The
   companion/secondary display is explicitly excluded (see below).

3. **UI Scale: A/Confirm no longer changes the value.** It previously cycled +5 and
   wrapped 150 -> 75. This removes an existing binding on purpose, per the V2 rule
   that A never adjusts a value - steppers adjust on Left/Right and the inline
   `-` / `+` only.

4. **UI Scale: the touch `-` button now works.** It was wired through `onClick`,
   which `StepperControl` only invokes on increment, so `-` silently applied +5.
   Now uses `onAdjust`. Gamepad Left/Right was always correct.

5. **All in-game overlays inset from the reserved band.** The in-game menu, disc
   menu, state manager, in-game settings, shader chain, frame viewer, quick-load
   timeline, cheats, and the auto-restore prompt no longer render into the covered
   area. The menu and disc menu additionally cap their height against available
   height rather than total screen height. With Pocket Taco off the inset resolves
   to 0.dp, so none of this is observable in landscape or on TV.

## Dual-screen

Pocket Taco is off on the companion display, and that needed a real change rather
than just being left alone. `SecondaryHomeTheme` delegates to the same
`ProvideArgosyThemeLocals` the primary uses, so it was already computing a live
reserve from the companion's own dimensions - it just had no consumer yet, so the
first one added would have silently inherited it. `ProvideArgosyThemeLocals` now
takes `isSecondaryDisplay` (default false) and the companion passes true.

## A note on NetplayOverlays

`NetplayOverlays.kt` is touched, and I know netplay is a maintainer domain - happy
to drop this hunk if you'd rather it stay out.

It is one line, and it is purely a layout inset:

    .padding(bottom = pocketTacoBottomInset())

on the shared private `NetplayScrim` composable. No netplay logic, transport,
session state, or crypto is touched. `pocketTacoBottomInset()` returns `0.dp`
unless Pocket Taco is on *and* the display is portrait *and* it's the primary
screen, so for every existing user and every existing netplay flow this is a
no-op.

The reason it's in scope at all: `NetplayScrim` backs six netplay dialogs, and
without it those are the only in-game overlays that would still render under the
covered part of the screen. Leaving them out would make the feature inconsistent in
exactly the way that's hard to notice later.

That said, it's your call - if you'd prefer netplay untouched I'll pull the hunk
and the netplay dialogs simply keep today's behavior. No objection from me either
way.

## Hot paths

None. No I/O, network, DB access, or blocking work added to any launch, frame, or
sync path.

- The two new preferences ride the existing `UserPreferences` aggregation flow; no
  new DataStore read is introduced.
- Resolution is `resolvePocketTacoFraction(...)`, a pure function of two prefs and
  two ints - a couple of comparisons per composition of `ProvideArgosyThemeLocals`.
- Consumption is a `Modifier.padding`. `pocketTacoBottomInset()` is a `remember`ed
  multiply keyed on screen height and the fraction.

## Testing evidence
Hardware: Pixel 6 (arm64), debug build installed over wireless debugging.

Driven on device: toggled the setting on and off and confirmed the "Reserved Area"
row appears and disappears; adjusted the percentage and watched the launcher UI
shift; checked landscape is unchanged; opened the in-game menu in portrait and
confirmed it no longer runs under the reserved band; confirmed UI Scale now
decreases.

Unit tests, 13 new across two classes:

- `PocketTacoFractionTest` (7) - the resolution rule: enabled/portrait,
  enabled/landscape, disabled, secondary display, the square-display boundary, a
  portrait tablet, and percent clamping.
- `InterfacePocketTacoLayoutTest` (6) - the conditional row: unreachable when the
  toggle is off, reachable when on, adds exactly one focusable index, sits directly
  beneath its toggle, and rows below it shift up when it's hidden.

**What is not covered by tests.** The `padding(bottom = pocketTacoBottomInset())`
call sites, the menu height math, and the UI Scale `onAdjust` wiring are Compose UI,
and this module has no Robolectric or compose-ui-test on the unit-test classpath.
They were verified by hand on device instead.

**What is not covered at all.** The secondary-display exclusion was not exercised on
real dual-screen hardware - it's defended by unit test only. The netplay dialogs
were not opened on device; the inset is a no-op there unless Pocket Taco is on in
portrait.

## AI assistance
Written primarily by Claude Code

## Checklist
<sup>Please check all that apply.</sup>

- [x] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
