### PR TITLE
fix(ra): parse JSON response from gameid hash lookup

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/remote/ra/RAApi.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/remote/ra/RAApi.kt
@@ -61,7 +61,7 @@ interface RAApi {
     suspend fun resolveGameId(
         @Query("r") request: String = "gameid",
         @Query("m") hash: String
-    ): Response<okhttp3.ResponseBody>
+    ): Response<RAGameIdResponse>
 
     // Read-only unlock fetch for browsing UI. Does NOT register a play session
     // (unlike startsession which side-effects "Currently Playing" attribution).

--- a/app/src/main/kotlin/com/nendo/argosy/data/remote/ra/RAModels.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/remote/ra/RAModels.kt
@@ -32,6 +32,13 @@ data class RABaseResponse(
 )
 
 @JsonClass(generateAdapter = true)
+data class RAGameIdResponse(
+    @Json(name = "Success") val success: Boolean,
+    @Json(name = "GameID") val gameId: Long? = null,
+    @Json(name = "Error") val error: String? = null
+)
+
+@JsonClass(generateAdapter = true)
 data class RAGameInfoResponse(
     @Json(name = "Success") val success: Boolean,
     @Json(name = "PatchData") val patchData: RAPatchData? = null,

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/RetroAchievementsRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/RetroAchievementsRepository.kt
@@ -168,10 +168,14 @@ class RetroAchievementsRepository @Inject constructor(
         if (!response.isSuccessful) {
             throw Exception("resolveGameId failed: HTTP ${response.code()}")
         }
-        val body = response.body()?.string()
+        val body = response.body()
             ?: throw Exception("resolveGameId: empty response body")
-        val gameId = body.trim().toLongOrNull() ?: 0
-        return if (gameId > 0) gameId else null
+        if (body.success) {
+            body.gameId?.let { return it.takeIf { id -> id > 0 } }
+        } else {
+            Logger.warn(TAG, "resolveGameId failed: ${body.error ?: "unknown error"}")
+        }
+        return null
     }
 
     suspend fun login(username: String, password: String): RALoginResult {


### PR DESCRIPTION
Closes #329

## Summary

RetroAchievements' legacy `dorequest.php?r=gameid` endpoint now returns **JSON** (`{"Success":true,"GameID":341}`) instead of a plain number. `RetroAchievementsRepository.resolveGameId()` parsed the body with `toLongOrNull()`, which always fails on JSON, so every hash→game lookup reported "no match". As a result, RA sessions were silently skipped for any game whose RomM sync payload has no fallback `raId` (verified in logcat: `RA hash lookup returned no match ... falling back to romm raId=null` → `Game has no RA ID, skipping RA session`).

This fixes the resolution so registered hashes correctly resolve to their RA game ID.

## Changes

- **`RAModels.kt`**: add `RAGameIdResponse` model (`Success` / `GameID` / `Error`)
- **`RAApi.kt`**: type `resolveGameId` response as `RAGameIdResponse` (was raw `ResponseBody`)
- **`RetroAchievementsRepository.kt`**: parse the JSON body via Moshi; log the server error when `Success=false`; return null otherwise

## Verification

**Tested on the actual device (Mango AIR_X, Android 14) and verified working** — built from this branch, installed via adb, and the RA session confirmed in live logcat:

- Before: `VerifyRAGameIdUseCase: RA hash lookup returned no match` for hash `11aa974b516f7013362cc9e5268b07f4` (a registered hash on RA game 341)
- Server-side: `curl "https://retroachievements.org/dorequest.php?r=gameid&m=11aa974b516f7013362cc9e5268b07f4"` → `{"Success":true,"GameID":341}`
- After: logcat shows `Game loaded: title=Final Fantasy III, resolvedRaId=341` → `Session started for game 341` → `Sending 115 achievements to native for console 3`

## AI-generated fix disclosure

This fix was authored with the assistance of an AI coding agent (opencode, DeepSeek-powered). Diagnosis came from on-device logcat analysis and direct testing of the RA endpoint; the change was verified by building the app and testing on the reporter's hardware before submission.
