### PR TITLE
ui: add argosy://launch deep link for external front-ends

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/MainActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/MainActivity.kt
@@ -61,6 +61,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 private const val TAG = "MainActivity"
+private val LAUNCH_EXTRA_KEYS = listOf("path", "romm_id", "game_id", "channel")
 internal fun shouldInitializeScreenCapture(prefs: UserPreferences): Boolean =
     prefs.ambientLedEnabled && prefs.ambientLedScreenEnabled
 
@@ -379,6 +380,8 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+
+        handleDeepLink(intent)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -752,11 +755,22 @@ class MainActivity : ComponentActivity() {
     private fun handleDeepLink(intent: Intent): Boolean {
         val uri = intent.data ?: return false
         if (uri.scheme == "argosy") {
-            Log.d(TAG, "Received deep link: $uri")
-            _pendingDeepLink.value = uri
+            val resolved = mergeLaunchExtras(uri, intent)
+            Log.d(TAG, "Received deep link: $resolved")
+            _pendingDeepLink.value = resolved
             return true
         }
         return false
+    }
+
+    private fun mergeLaunchExtras(uri: android.net.Uri, intent: Intent): android.net.Uri {
+        var builder: android.net.Uri.Builder? = null
+        for (key in LAUNCH_EXTRA_KEYS) {
+            if (uri.getQueryParameter(key) != null) continue
+            val value = intent.getStringExtra(key)?.takeIf { it.isNotBlank() } ?: continue
+            builder = (builder ?: uri.buildUpon()).appendQueryParameter(key, value)
+        }
+        return builder?.build() ?: uri
     }
 
     fun clearPendingDeepLink() {

--- a/app/src/main/kotlin/com/nendo/argosy/domain/model/DeepLinkRequest.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/domain/model/DeepLinkRequest.kt
@@ -1,0 +1,11 @@
+package com.nendo.argosy.domain.model
+
+data class DeepLinkRequest(
+    val gameId: Long? = null,
+    val rommId: Long? = null,
+    val romPath: String? = null,
+    val channelName: String? = null
+) {
+    val hasTarget: Boolean
+        get() = gameId != null || rommId != null || !romPath.isNullOrBlank()
+}

--- a/app/src/main/kotlin/com/nendo/argosy/domain/usecase/game/ResolveDeepLinkGameUseCase.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/domain/usecase/game/ResolveDeepLinkGameUseCase.kt
@@ -1,0 +1,75 @@
+package com.nendo.argosy.domain.usecase.game
+
+import com.nendo.argosy.data.local.dao.GameDao
+import com.nendo.argosy.domain.model.DeepLinkRequest
+import com.nendo.argosy.util.Logger
+import javax.inject.Inject
+
+private const val TAG = "ResolveDeepLinkGame"
+
+sealed interface DeepLinkResolution {
+    data class Resolved(val gameId: Long) : DeepLinkResolution
+    data class NotFound(val reason: String) : DeepLinkResolution
+    data class Ambiguous(val reason: String) : DeepLinkResolution
+}
+
+/**
+ * Turns an external launch request into a local game id.
+ *
+ * Identifiers are tried most-specific first: game id, then RomM rom id, then ROM path.
+ * The path arm falls back to a file-name match when the caller's path does not byte-match
+ * the stored one. A file name matching more than one installed game resolves to
+ * [DeepLinkResolution.Ambiguous] rather than picking one.
+ */
+class ResolveDeepLinkGameUseCase @Inject constructor(
+    private val gameDao: GameDao
+) {
+    suspend operator fun invoke(request: DeepLinkRequest): DeepLinkResolution {
+        request.gameId?.let { id ->
+            return if (gameDao.getById(id) != null) {
+                DeepLinkResolution.Resolved(id)
+            } else {
+                DeepLinkResolution.NotFound("no game with gameId=$id")
+            }
+        }
+
+        request.rommId?.let { id ->
+            val game = gameDao.getByRommId(id)
+            return if (game != null) {
+                DeepLinkResolution.Resolved(game.id)
+            } else {
+                DeepLinkResolution.NotFound("no game with rommId=$id")
+            }
+        }
+
+        val path = request.romPath
+        if (!path.isNullOrBlank()) {
+            return resolveByPath(path)
+        }
+
+        return DeepLinkResolution.NotFound("request carried no game identifier")
+    }
+
+    private suspend fun resolveByPath(path: String): DeepLinkResolution {
+        gameDao.getByPath(path)?.let { return DeepLinkResolution.Resolved(it.id) }
+
+        val fileName = path.substringAfterLast('/')
+        if (fileName.isBlank()) {
+            return DeepLinkResolution.NotFound("path carried no file name: $path")
+        }
+
+        val matches = gameDao.getGamesWithLocalPathInfo()
+            .filter { it.localPath?.substringAfterLast('/').equals(fileName, ignoreCase = true) }
+
+        return when {
+            matches.isEmpty() ->
+                DeepLinkResolution.NotFound("no installed game matches file name $fileName")
+            matches.size > 1 ->
+                DeepLinkResolution.Ambiguous("$fileName matches ${matches.size} installed games")
+            else -> {
+                Logger.info(TAG, "Resolved $fileName by file-name fallback, stored path differs from $path")
+                DeepLinkResolution.Resolved(matches.first().id)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
@@ -113,6 +113,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 private const val KEY_SINK_RECLAIM_GRACE_MS = 250L
+private const val NAV_READY_TIMEOUT_MS = 45_000L
+private const val NAV_READY_POLL_MS = 50L
 
 @Composable
 fun ArgosyApp(
@@ -256,6 +258,49 @@ fun ArgosyApp(
                     "apps" -> {
                         navController.navigate(Screen.Apps.route) {
                             launchSingleTop = true
+                        }
+                    }
+                    "launch" -> {
+                        val request = com.nendo.argosy.ui.deeplink.DeepLinkParser.parse(uri)
+                        if (request == null) {
+                            android.util.Log.w("ArgosyApp", "Deep link carried no target: $uri")
+                        } else {
+                            when (val outcome = viewModel.resolveDeepLinkLaunch(request)) {
+                                is com.nendo.argosy.ui.deeplink.DeepLinkLaunch.Ready -> {
+                                    val graphReady = kotlinx.coroutines.withTimeoutOrNull(NAV_READY_TIMEOUT_MS) {
+                                        while (runCatching { navController.graph }.isFailure) {
+                                            kotlinx.coroutines.delay(NAV_READY_POLL_MS)
+                                        }
+                                        true
+                                    } ?: false
+                                    if (!graphReady) {
+                                        android.util.Log.w(
+                                            "ArgosyApp",
+                                            "Nav graph not ready, dropping deep link for game ${outcome.gameId}"
+                                        )
+                                        android.widget.Toast.makeText(
+                                            context,
+                                            "Argosy was still starting up, try again",
+                                            android.widget.Toast.LENGTH_LONG
+                                        ).show()
+                                    } else {
+                                        navController.navigate(
+                                            Screen.GameDetail.createRoute(outcome.gameId)
+                                        ) {
+                                            launchSingleTop = true
+                                        }
+                                        viewModel.awaitDeepLinkSyncReady()
+                                        viewModel.initiateGameLaunch(outcome.gameId, outcome.channelName)
+                                    }
+                                }
+                                is com.nendo.argosy.ui.deeplink.DeepLinkLaunch.Failed -> {
+                                    android.widget.Toast.makeText(
+                                        context,
+                                        outcome.message,
+                                        android.widget.Toast.LENGTH_LONG
+                                    ).show()
+                                }
+                            }
                         }
                     }
                 }
@@ -1896,6 +1941,7 @@ fun ArgosyApp(
                         navController = navController,
                         startDestination = startDestination,
                         onDrawerToggle = { if (isDrawerOpen) closeDrawer() else openDrawer() },
+                        argosyViewModel = viewModel,
                         modifier = Modifier.blur(contentBlur)
                     )
                 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyViewModel.kt
@@ -194,8 +194,15 @@ class ArgosyViewModel @Inject constructor(
     private val netplayJoinService: com.nendo.argosy.data.netplay.NetplayJoinService,
     private val launchGameUseCase: LaunchGameUseCase,
     private val homeLibraryDelegate: com.nendo.argosy.ui.screens.home.delegates.HomeLibraryDelegate,
-    private val pendingConflictDao: com.nendo.argosy.data.local.dao.PendingConflictDao
+    private val pendingConflictDao: com.nendo.argosy.data.local.dao.PendingConflictDao,
+    private val deepLinkLaunchCoordinator: com.nendo.argosy.ui.deeplink.DeepLinkLaunchCoordinator
 ) : ViewModel() {
+
+    suspend fun resolveDeepLinkLaunch(
+        request: com.nendo.argosy.domain.model.DeepLinkRequest
+    ): com.nendo.argosy.ui.deeplink.DeepLinkLaunch = deepLinkLaunchCoordinator.resolve(request)
+
+    suspend fun awaitDeepLinkSyncReady() = deepLinkLaunchCoordinator.awaitConnectionIfSyncing()
 
     val netplayJoinState: StateFlow<com.nendo.argosy.data.netplay.NetplayJoinState> get() = netplayJoinService.state
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/deeplink/DeepLinkLaunchCoordinator.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/deeplink/DeepLinkLaunchCoordinator.kt
@@ -1,0 +1,68 @@
+package com.nendo.argosy.ui.deeplink
+
+import com.nendo.argosy.data.preferences.UserPreferencesRepository
+import com.nendo.argosy.data.remote.romm.ConnectionState
+import com.nendo.argosy.data.remote.romm.RomMRepository
+import com.nendo.argosy.domain.model.DeepLinkRequest
+import com.nendo.argosy.domain.usecase.game.DeepLinkResolution
+import com.nendo.argosy.domain.usecase.game.ResolveDeepLinkGameUseCase
+import com.nendo.argosy.util.Logger
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import javax.inject.Inject
+
+private const val TAG = "DeepLinkLaunch"
+private const val CONNECT_TIMEOUT_MS = 10_000L
+
+sealed interface DeepLinkLaunch {
+    data class Ready(val gameId: Long, val channelName: String?) : DeepLinkLaunch
+    data class Failed(val message: String) : DeepLinkLaunch
+}
+
+/**
+ * Resolves an external launch request, and gates it on RomM connectivity.
+ *
+ * [resolve] maps the request to a game id. [awaitConnectionIfSyncing] waits up to
+ * [CONNECT_TIMEOUT_MS] for a connection when save sync is enabled, so a deep link arriving
+ * during a cold start does not launch before the pre-launch pull can run. On timeout it
+ * returns anyway and logs a warning; the caller still launches.
+ */
+class DeepLinkLaunchCoordinator @Inject constructor(
+    private val resolveDeepLinkGame: ResolveDeepLinkGameUseCase,
+    private val romMRepository: RomMRepository,
+    private val preferencesRepository: UserPreferencesRepository
+) {
+    suspend fun resolve(request: DeepLinkRequest): DeepLinkLaunch {
+        val resolution = resolveDeepLinkGame(request)
+
+        return when (resolution) {
+            is DeepLinkResolution.Resolved -> {
+                DeepLinkLaunch.Ready(resolution.gameId, request.channelName)
+            }
+            is DeepLinkResolution.NotFound -> {
+                Logger.warn(TAG, "Deep link unresolved: ${resolution.reason}")
+                DeepLinkLaunch.Failed("Game not found in Argosy")
+            }
+            is DeepLinkResolution.Ambiguous -> {
+                Logger.warn(TAG, "Deep link ambiguous: ${resolution.reason}")
+                DeepLinkLaunch.Failed("More than one game matches that file name")
+            }
+        }
+    }
+
+    suspend fun awaitConnectionIfSyncing() {
+        if (romMRepository.isConnected()) return
+        if (!preferencesRepository.userPreferences.first().saveSyncEnabled) return
+
+        val connected = withTimeoutOrNull(CONNECT_TIMEOUT_MS) {
+            romMRepository.connectionState.first { it is ConnectionState.Connected }
+        }
+
+        if (connected == null) {
+            Logger.warn(
+                TAG,
+                "RomM not connected after ${CONNECT_TIMEOUT_MS}ms, launching without a save pull"
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/nendo/argosy/ui/deeplink/DeepLinkParser.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/deeplink/DeepLinkParser.kt
@@ -1,0 +1,44 @@
+package com.nendo.argosy.ui.deeplink
+
+import android.net.Uri
+import com.nendo.argosy.domain.model.DeepLinkRequest
+
+/**
+ * Parses the `argosy://launch` URI an external frontend fires to start a game.
+ *
+ * Accepted forms, in resolution order:
+ *   argosy://launch?game_id=42
+ *   argosy://launch?romm_id=1234
+ *   argosy://launch/1234
+ *   argosy://launch?path=/storage/emulated/0/ROMs/snes/Game.zip
+ *
+ * An optional `channel` selects a named save channel. `path` accepts a bare path or a
+ * file:// URI, since frontends differ on which they hand out.
+ */
+object DeepLinkParser {
+    const val SCHEME = "argosy"
+    private const val HOST_LAUNCH = "launch"
+
+    fun parse(uri: Uri): DeepLinkRequest? {
+        if (!uri.scheme.equals(SCHEME, ignoreCase = true)) return null
+        if (!uri.host.equals(HOST_LAUNCH, ignoreCase = true)) return null
+
+        val positionalRommId = uri.pathSegments.firstOrNull()?.toLongOrNull()
+
+        val request = DeepLinkRequest(
+            gameId = uri.getQueryParameter("game_id")?.toLongOrNull(),
+            rommId = uri.getQueryParameter("romm_id")?.toLongOrNull() ?: positionalRommId,
+            romPath = uri.getQueryParameter("path")?.let(::normalizePath),
+            channelName = uri.getQueryParameter("channel")?.takeIf { it.isNotBlank() }
+        )
+
+        return request.takeIf { it.hasTarget }
+    }
+
+    private fun normalizePath(raw: String): String? {
+        val trimmed = raw.trim()
+        if (trimmed.isEmpty()) return null
+        if (!trimmed.startsWith("file://")) return trimmed
+        return Uri.parse(trimmed).path?.takeIf { it.isNotBlank() }
+    }
+}

--- a/app/src/main/kotlin/com/nendo/argosy/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/navigation/NavGraph.kt
@@ -37,6 +37,7 @@ fun NavGraph(
     navController: NavHostController,
     startDestination: String,
     onDrawerToggle: () -> Unit,
+    argosyViewModel: com.nendo.argosy.ui.ArgosyViewModel,
     modifier: Modifier = Modifier
 ) {
     val navigateToDefault = remember {
@@ -239,6 +240,7 @@ fun NavGraph(
             val gameId = backStackEntry.arguments?.getLong("gameId") ?: return@composable
             GameDetailScreen(
                 gameId = gameId,
+                argosyViewModel = argosyViewModel,
                 onBack = { navController.popBackStack() },
                 onNavigateToPlatformSettings = { platformId ->
                     navController.navigate(

--- a/app/src/test/kotlin/com/nendo/argosy/domain/usecase/game/ResolveDeepLinkGameUseCaseTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/domain/usecase/game/ResolveDeepLinkGameUseCaseTest.kt
@@ -1,0 +1,111 @@
+package com.nendo.argosy.domain.usecase.game
+
+import com.nendo.argosy.data.local.dao.GameDao
+import com.nendo.argosy.data.local.dao.GameLocalPathInfo
+import com.nendo.argosy.data.local.entity.GameEntity
+import com.nendo.argosy.data.model.GameSource
+import com.nendo.argosy.domain.model.DeepLinkRequest
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ResolveDeepLinkGameUseCaseTest {
+
+    private lateinit var gameDao: GameDao
+    private lateinit var useCase: ResolveDeepLinkGameUseCase
+
+    private fun game(id: Long): GameEntity = mockk<GameEntity>(relaxed = true).also {
+        every { it.id } returns id
+    }
+
+    private fun pathInfo(id: Long, path: String) = GameLocalPathInfo(
+        id = id,
+        platformId = 8L,
+        platformSlug = "snes",
+        source = GameSource.ROMM_SYNCED,
+        localPath = path
+    )
+
+    @Before
+    fun setUp() {
+        gameDao = mockk()
+        useCase = ResolveDeepLinkGameUseCase(gameDao)
+    }
+
+    @Test
+    fun `resolves by game id when the game exists`() = runTest {
+        coEvery { gameDao.getById(42L) } returns game(42L)
+
+        val result = useCase(DeepLinkRequest(gameId = 42L))
+
+        assertEquals(DeepLinkResolution.Resolved(42L), result)
+    }
+
+    @Test
+    fun `reports not found when the game id does not exist`() = runTest {
+        coEvery { gameDao.getById(42L) } returns null
+
+        val result = useCase(DeepLinkRequest(gameId = 42L))
+
+        assertTrue(result is DeepLinkResolution.NotFound)
+    }
+
+    @Test
+    fun `resolves by romm id`() = runTest {
+        coEvery { gameDao.getByRommId(1234L) } returns game(7L)
+
+        val result = useCase(DeepLinkRequest(rommId = 1234L))
+
+        assertEquals(DeepLinkResolution.Resolved(7L), result)
+    }
+
+    @Test
+    fun `resolves by exact rom path`() = runTest {
+        val path = "/storage/emulated/0/ROMs/snes/Some Game.zip"
+        coEvery { gameDao.getByPath(path) } returns game(9L)
+
+        val result = useCase(DeepLinkRequest(romPath = path))
+
+        assertEquals(DeepLinkResolution.Resolved(9L), result)
+    }
+
+    @Test
+    fun `falls back to file name when the stored path differs`() = runTest {
+        val requested = "/mnt/other/root/snes/Some Game.zip"
+        coEvery { gameDao.getByPath(requested) } returns null
+        coEvery { gameDao.getGamesWithLocalPathInfo() } returns listOf(
+            pathInfo(3L, "/storage/emulated/0/ROMs/snes/Another Game.zip"),
+            pathInfo(11L, "/storage/emulated/0/ROMs/snes/Some Game.zip")
+        )
+
+        val result = useCase(DeepLinkRequest(romPath = requested))
+
+        assertEquals(DeepLinkResolution.Resolved(11L), result)
+    }
+
+    @Test
+    fun `refuses to guess when a file name matches more than one game`() = runTest {
+        val requested = "/mnt/other/root/snes/Some Game.zip"
+        coEvery { gameDao.getByPath(requested) } returns null
+        coEvery { gameDao.getGamesWithLocalPathInfo() } returns listOf(
+            pathInfo(3L, "/storage/emulated/0/ROMs/snes/Some Game.zip"),
+            pathInfo(11L, "/storage/emulated/0/ROMs/nes/Some Game.zip")
+        )
+
+        val result = useCase(DeepLinkRequest(romPath = requested))
+
+        assertTrue(result is DeepLinkResolution.Ambiguous)
+    }
+
+    @Test
+    fun `reports not found when the request carries no identifier`() = runTest {
+        val result = useCase(DeepLinkRequest())
+
+        assertTrue(result is DeepLinkResolution.NotFound)
+    }
+}


### PR DESCRIPTION
Closes #339

## Summary

Adds an `argosy://launch` deep link so an external front-end can hand a specific game to Argosy, while Argosy keeps ownership of the RomM save/state lifecycle.

The three existing hosts (`game/`, `play/`, `apps`) are all keyed on the internal autoincrement game id, which an outside caller has no way to obtain — a front-end only knows the ROM file it scanned. `launch` accepts what such a caller actually has:

```
argosy://launch?path=/storage/emulated/0/ROMs/snes/Some Game.zip
argosy://launch?romm_id=1234
argosy://launch?game_id=42
argosy://launch/1234                      # positional rom id
argosy://launch?path=...&channel=<name>   # optional save channel
```

Three things worth calling out, since they're the non-obvious parts:

**Intent extras are folded into the URI.** ES-DE substitutes its `%ROM%` variable only when the variable is the *entire* value of a parameter, never interpolated inside a longer string — `%DATA%=argosy://launch?path=%ROM%` arrives with the literal text `%ROM%`. So callers pass the path as an intent extra and `MainActivity` promotes it to a query parameter. Doing it through `Uri.Builder.appendQueryParameter` also percent-encodes the value, which paths containing spaces need.

**Cold start.** `handleDeepLink` was only wired to `onNewIntent`, so a deep link that started the process was silently dropped. It's now called from `onCreate` too. This also fixes the existing `game://` / `play://` / `apps` hosts on cold start.

**ViewModel scoping.** Resolution deliberately reuses the existing pending-launch path (`initiateGameLaunch` + navigate to `GameDetailScreen`) rather than calling `GameLaunchDelegate` directly, so the sync overlay and the LocalModified / HardcoreConflict prompts still render. That required threading the activity-scoped `ArgosyViewModel` through `NavGraph`: `GameDetailScreen` previously resolved its own `hiltViewModel()` against the NavBackStackEntry, so `pendingLaunch` was being set on an instance the screen never observed. I believe this means `argosy://play/{id}` could not have worked either; nothing external could trigger it before, so it looks like it went unnoticed.

Path resolution tries exact `getByPath` first, then falls back to a file-name match, since two front-ends can reach the same ROM by different roots. A file name matching more than one installed game resolves to `Ambiguous` rather than picking one — launching the wrong game would write its save to the wrong server slot.

## Behavior changes

- New `argosy://launch` host. No existing URI shape changes.
- Deep links now work on cold start. Previously `argosy://game/{id}`, `argosy://play/{id}` and `argosy://apps` were dropped when the intent started the process; they now behave as they already did when the app was warm.
- `argosy://play/{id}` becomes functional. The `GameDetailScreen` ViewModel-scoping fix means the pending launch is now observed by the screen that consumes it.
- `NavGraph` takes a new required `argosyViewModel` parameter. Internal signature change, single call site.
- On a `launch` link that resolves to nothing (unknown path, or a file name matching several games) a toast is shown and nothing is launched.
- If the nav graph is not ready within 45s of a cold-start deep link, the link is dropped with a toast rather than throwing. Navigating before the NavHost composes throws `IllegalArgumentException: Navigation graph has not been set`.

## Hot paths

Yes, on the launch path, and only when a `launch` deep link is present:

- **One DB read** to resolve the identifier — `getById`, `getByRommId` or `getByPath`, all indexed. The file-name fallback calls `getGamesWithLocalPathInfo()`, which is bounded by installed games (games with a non-null `localPath`), not library size, and only runs when the exact path misses.
- **A wait, not work, on RomM connectivity.** `awaitConnectionIfSyncing()` suspends up to 10s for `ConnectionState.Connected` when save sync is enabled, so a cold-start deep link doesn't launch before the pre-launch pull can run. It issues no requests of its own; on timeout it proceeds anyway and logs. Skipped entirely when already connected or when save sync is off.
- **A poll** for nav-graph readiness (50ms interval, 45s cap) before navigating. Only on the deep-link path; on a warm app it exits on the first check.

Nothing added to frame or sync paths. No new network calls.

## Testing evidence

Hardware: Pixel 9 Pro XL, Android 17, unrooted. RomM 5.1.0. ES-DE 3.4.1-58 driving Argosy, RetroArch `com.retroarch` 1.22.2 with the snes9x core, SNES pinned to external RetroArch.

Flow driven end to end, repeatedly:

1. **Plumbing, before touching real saves** — a dummy ROM with spaces in the name (`Test Game With Spaces.zip`) launched from ES-DE. ES-DE's log shows the substitution, Argosy shows what arrived:
   ```
   ES-DE:  Data: argosy://launch   Extra name: path   Extra value: %ROM%
           %ROM% expanded: /storage/emulated/0/ROMs/snes/Test Game With Spaces.zip
   Argosy: Received deep link: argosy://launch?path=%2Fstorage%2F...%2FTest%20Game%20With%20Spaces.zip
           Deep link unresolved: no installed game matches file name Test Game With Spaces.zip
   ```
   Confirms find-rule resolution, extras promotion, percent-encoding, spaces surviving, and the resolver correctly declining an unknown game.

2. **Real launch** — a downloaded game launched from ES-DE, cold start:
   ```
   GameLaunchDelegate: launchGame: emulatorPackage=com.retroarch, emulatorId=retroarch, canSync=true
   PlaySessionTracker: SESSION gameId=27615 | Session started | emulator=com.retroarch, core=snes9x
   ActivityTaskManager: START cmp=com.retroarch/.browser.retroactivity.RetroActivityFuture
   ```

3. **Save sync intact through the deep-link path** — pre-launch pull, then session-end push:
   ```
   PreLaunchStateSync: Downloaded 5 states for <game>
   StateCacheManager: Restored state from cache 18 to /storage/emulated/0/RetroArch/states/<game>.state
   SyncStatesOnSessionEnd: QUEUE gameId=27615 | Queued 2 states
   ```
   Verified in the DB afterwards: `state_cache` row `syncStatus='SYNCED'`, `pending_sync_queue = 0`.

4. **Full cross-device round-trip** — played on desktop RetroArch (synced to the same RomM), launched on Android via ES-DE and the state auto-loaded with desktop progress; played on Android, exited cleanly, then desktop picked up the Android state. Both directions, repeatedly.

5. **Cold-start regression** — the crash this fixes (`Navigation graph has not been set`) reproduced reliably before the readiness gate; not reproducible after ~10 cold launches. Argosy takes ~19s to a composed nav graph on a 28k-game library, which is why the cap is generous.

6. **Existing hosts** — `argosy://apps` still handled, verified from the log.

Unit tests: 7 new cases on `ResolveDeepLinkGameUseCase` covering each identifier arm, the file-name fallback, and the ambiguous-match refusal. `DeepLinkParser` is not covered — it depends on `android.net.Uri` and there's no Robolectric in the JVM test setup; happy to add coverage if you'd like it wired up.

## AI assistance

Written primarily by Claude Code, directed and reviewed by me. Design decisions (routing through the existing pending-launch path rather than calling `GameLaunchDelegate` directly; refusing ambiguous file-name matches instead of guessing) were discussed and chosen deliberately. All the on-hardware verification above is real: driven on my device against my RomM server, not inferred. The three bugs listed under Behavior changes were found by running it, not by reading the code.

## Checklist

- [x] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
