### PR TITLE
fix ARMSX2 Play Store launch + file-based .ps2 save sync

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/EmulatorRegistry.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/EmulatorRegistry.kt
@@ -710,7 +710,7 @@ object EmulatorRegistry {
             displayName = "ARMSX2 (Play Store)",
             supportedPlatforms = setOf("ps2"),
             launchConfig = LaunchConfig.Custom(
-                activityClass = "kr.co.iefriends.pcsx2.activities.MainActivity"
+                activityClass = "com.armsx2.MainActivity"
             ),
             defaultLaunchMethod = LaunchMethod.SHELL,
             downloadUrl = "https://github.com/ARMSX2/ARMSX2/releases"
@@ -1728,7 +1728,7 @@ object EmulatorRegistry {
             packagePatterns = listOf("come.nanodata.armsx2", "come.nanodata.armsx2.*"),
             supportedPlatforms = setOf("ps2"),
             launchConfig = LaunchConfig.Custom(
-                activityClass = "kr.co.iefriends.pcsx2.activities.MainActivity"
+                activityClass = "com.armsx2.MainActivity"
             ),
             downloadUrl = "https://github.com/ARMSX2/ARMSX2/releases"
         ),

--- a/app/src/main/kotlin/com/nendo/argosy/data/emulator/SavePathRegistry.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/emulator/SavePathRegistry.kt
@@ -407,13 +407,15 @@ object SavePathRegistry {
             usesFolderBasedSaves = true,
             supported = true
         ),
+        // File memcards (one .ps2 per game). Matches raw .ps2 uploads from PCSX2/LRPS2/RomM.
+        // Folder Shared.ps2 + server file .ps2 caused EISDIR on download.
         "armsx2_refresh" to SavePathConfig(
             emulatorId = "armsx2_refresh",
             defaultPaths = listOf(
                 "{extStorage}/Android/data/com.armsx2/files/memcards"
             ),
-            saveExtensions = listOf("*"),
-            usesFolderBasedSaves = true,
+            saveExtensions = listOf("ps2"),
+            usesFolderBasedSaves = false,
             supported = true
         ),
         "armsx2" to SavePathConfig(
@@ -421,8 +423,8 @@ object SavePathRegistry {
             defaultPaths = listOf(
                 "{extStorage}/Android/data/come.nanodata.armsx2/files/memcards"
             ),
-            saveExtensions = listOf("*"),
-            usesFolderBasedSaves = true,
+            saveExtensions = listOf("ps2"),
+            usesFolderBasedSaves = false,
             supported = true
         ),
 

--- a/app/src/main/kotlin/com/nendo/argosy/data/sync/platform/PlatformSaveHandlerRegistry.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/sync/platform/PlatformSaveHandlerRegistry.kt
@@ -74,6 +74,9 @@ class PlatformSaveHandlerRegistry @Inject constructor(
         }
         if (emulatorId in RETROARCH_EMULATOR_IDS) return retroArchSaveHandler
         if (canonical == "switch") return switchSaveHandler
+        // Explicit file-based emulator configs (e.g. ARMSX2 one-.ps2-per-game) must not fall
+        // through to the platform folder handler, or downloads target Shared.ps2 and EISDIR.
+        if (config != null && !config.usesFolderBasedSaves) return defaultSaveHandler
         return folderHandlers[canonical] ?: defaultSaveHandler
     }
 

--- a/app/src/test/kotlin/com/nendo/argosy/data/emulator/SavePathRegistryTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/emulator/SavePathRegistryTest.kt
@@ -177,4 +177,20 @@ class SavePathRegistryTest {
     fun `canSyncWithSettings returns false for unsupported emulator even when sync enabled`() {
         assertFalse(SavePathRegistry.canSyncWithSettings("redream", saveSyncEnabled = true))
     }
+
+    @Test
+    fun `armsx2 uses file-based ps2 memcards`() {
+        val config = SavePathRegistry.getConfig("armsx2")
+        assertNotNull(config)
+        assertFalse(config!!.usesFolderBasedSaves)
+        assertEquals(listOf("ps2"), config.saveExtensions)
+    }
+
+    @Test
+    fun `armsx2_refresh uses file-based ps2 memcards`() {
+        val config = SavePathRegistry.getConfig("armsx2_refresh")
+        assertNotNull(config)
+        assertFalse(config!!.usesFolderBasedSaves)
+        assertEquals(listOf("ps2"), config.saveExtensions)
+    }
 }

--- a/app/src/test/kotlin/com/nendo/argosy/data/sync/platform/PlatformSaveHandlerRegistryRoutingTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/sync/platform/PlatformSaveHandlerRegistryRoutingTest.kt
@@ -87,4 +87,30 @@ class PlatformSaveHandlerRegistryRoutingTest {
 
         assertSame(switchHandler, handler)
     }
+
+    @Test
+    fun `armsx2 file config routes to default file handler not PS2 folder handler`() {
+        val config = SavePathRegistry.getConfig("armsx2")
+        assertNotNull(config)
+        assertTrue("armsx2 must be file-based for raw .ps2 saves", config != null && !config.usesFolderBasedSaves)
+
+        val handler = registry.getHandler(config, "ps2", "armsx2")
+
+        assertSame(
+            "Must use DefaultSaveHandler for per-game .ps2 files",
+            defaultHandler,
+            handler,
+        )
+    }
+
+    @Test
+    fun `armsx2_refresh file config routes to default file handler`() {
+        val config = SavePathRegistry.getConfig("armsx2_refresh")
+        assertNotNull(config)
+        assertTrue(config != null && !config.usesFolderBasedSaves)
+
+        val handler = registry.getHandler(config, "ps2", "armsx2_refresh")
+
+        assertSame(defaultHandler, handler)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two ARMSX2 breakages that block launch and RomM save restore when the server holds **raw per-game `.ps2`** memcards (PCSX2 / LRPS2 style).

1. **Launch (Play Store package `come.nanodata.armsx2`)**  
   Registry still pointed at dead NetherSX2 activity  
   `kr.co.iefriends.pcsx2.activities.MainActivity` → ActivityNotFound.  
   Updated EmulatorDef + EmulatorFamily to `com.armsx2.MainActivity` (same as the non–Play Store `com.armsx2` entry).

2. **Save sync (file `.ps2` vs folder memcard)**  
   ARMSX2 was `usesFolderBasedSaves = true`, so downloads used `Ps2FolderHandler` / `Shared.ps2`. Writing a file `.ps2` onto that path fails with **EISDIR**.  
   - `armsx2` / `armsx2_refresh`: `usesFolderBasedSaves = false`, `saveExtensions = ["ps2"]`  
   - `getHandler`: if config explicitly disables folder saves, return `DefaultSaveHandler` (do not fall through to platform folder handlers)

## Notes for users after this lands

- ARMSX2: **Folder Memory Cards OFF**, Slot 1 filename = the per-game `.ps2` name (or let Argosy write into `…/memcards/`).
- Folder-card workflows for ARMSX2 are no longer the default; NetherSX2/Aether-style folder configs are unchanged.

## Test plan

- [x] Unit: `SavePathRegistry` armsx2 / armsx2_refresh file-based config
- [x] Unit: `PlatformSaveHandlerRegistry` routes armsx2 → `DefaultSaveHandler`
- [ ] Device: Play Store ARMSX2 launches a local PS2 ROM from Argosy
- [ ] Device: RomM file `.ps2` download lands under `…/memcards/<name>.ps2` without EISDIR
- [ ] Regression: RetroArch folder configs (PSP/3DS) still route to folder handlers

Fixes #338  
Related: #282, #325