### PR TITLE
fix(downloads): decompress nsz entries from the correct offset

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -300,6 +300,8 @@ dependencies {
 
     // Testing
     testImplementation(libs.junit)
+    // The zstd aar ships Android natives only; unit tests need the JVM jar.
+    testImplementation(libs.zstd.jni)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation("net.java.dev.jna:jna:5.14.0")

--- a/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/AesCtrCipher.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/AesCtrCipher.kt
@@ -1,5 +1,7 @@
 package com.nendo.argosy.data.download.nsz
 
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
@@ -7,12 +9,13 @@ import javax.crypto.spec.SecretKeySpec
 /**
  * Streaming AES-128-CTR cipher for NCZ section re-encryption.
  *
- * NCZ sections with cryptoType 3 or 4 store their data as plaintext
+ * NCZ sections with a CTR crypto type store their data as plaintext
  * after zstd decompression. The original NCA had these sections encrypted
  * with AES-128-CTR. We must re-encrypt them to produce a valid NCA.
  *
- * The IV is constructed from the section's 16-byte counter with the
- * initial offset folded into the upper 8 bytes as a big-endian int64.
+ * nsz keeps the section nonce in the counter's first 8 bytes and leaves the
+ * low 8 for the block index. [initialOffset] is absolute inside the
+ * decompressed NCA and need not be 16-byte aligned.
  */
 class AesCtrCipher(
     key: ByteArray,
@@ -26,8 +29,7 @@ class AesCtrCipher(
         require(counter.size == 16) { "CTR counter must be 16 bytes" }
 
         val iv = counter.copyOf()
-        val blockNumber = initialOffset / 16
-        addCounterBigEndian(iv, blockNumber)
+        writeBlockIndexBigEndian(iv, initialOffset / 16)
 
         cipher = Cipher.getInstance("AES/CTR/NoPadding").apply {
             init(
@@ -35,6 +37,11 @@ class AesCtrCipher(
                 SecretKeySpec(key, "AES"),
                 IvParameterSpec(iv)
             )
+        }
+
+        val misalignment = (initialOffset % 16).toInt()
+        if (misalignment > 0) {
+            cipher.update(ByteArray(misalignment))
         }
     }
 
@@ -44,16 +51,15 @@ class AesCtrCipher(
         cipher.update(data, offset, length)
 
     companion object {
-        internal fun addCounterBigEndian(
+        private const val NONCE_SIZE = 8
+
+        internal fun writeBlockIndexBigEndian(
             counter: ByteArray,
-            value: Long
+            blockIndex: Long
         ) {
-            var carry = value
-            for (i in 7 downTo 0) {
-                carry += (counter[i].toLong() and 0xFF)
-                counter[i] = (carry and 0xFF).toByte()
-                carry = carry ushr 8
-            }
+            ByteBuffer.wrap(counter, NONCE_SIZE, NONCE_SIZE)
+                .order(ByteOrder.BIG_ENDIAN)
+                .putLong(blockIndex)
         }
     }
 }

--- a/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/ContainerParser.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/ContainerParser.kt
@@ -21,6 +21,16 @@ data class ContainerEntry(
         }
 }
 
+/**
+ * Header geometry of a parsed PFS0: the total header size and the offset of
+ * the first file inside the data section.
+ */
+data class Pfs0Layout(
+    val entries: List<ContainerEntry>,
+    val headerSize: Int,
+    val firstFileDataOffset: Long
+)
+
 object ContainerParser {
 
     private const val PFS0_MAGIC = 0x30534650 // "PFS0" LE
@@ -32,7 +42,12 @@ object ContainerParser {
     fun parsePfs0(
         raf: RandomAccessFile,
         baseOffset: Long = 0
-    ): List<ContainerEntry> {
+    ): List<ContainerEntry> = parsePfs0Layout(raf, baseOffset).entries
+
+    fun parsePfs0Layout(
+        raf: RandomAccessFile,
+        baseOffset: Long = 0
+    ): Pfs0Layout {
         raf.seek(baseOffset)
         val headerBuf = ByteArray(PFS0_HEADER_BASE)
         raf.readFully(headerBuf)
@@ -63,11 +78,17 @@ object ContainerParser {
         val entryBuf = ByteBuffer.wrap(entryData)
             .order(ByteOrder.LITTLE_ENDIAN)
 
+        var firstFileDataOffset = 0L
+
         for (i in 0 until fileCount) {
             val entryDataOffset = entryBuf.long
             val entrySize = entryBuf.long
             val stringOffset = entryBuf.int
             entryBuf.int // reserved
+
+            if (i == 0) {
+                firstFileDataOffset = entryDataOffset
+            }
 
             val name = readNullTerminated(
                 stringTableData,
@@ -83,7 +104,11 @@ object ContainerParser {
             )
         }
 
-        return entries
+        return Pfs0Layout(
+            entries = entries,
+            headerSize = PFS0_HEADER_BASE + entriesSize + stringTableSize,
+            firstFileDataOffset = firstFileDataOffset
+        )
     }
 
     fun parseHfs0(
@@ -173,14 +198,24 @@ object ContainerParser {
         return Pair(secureEntry.dataOffset, secureEntries)
     }
 
+    /**
+     * [targetHeaderSize] and [firstFileDataOffset] come from the source
+     * container's [Pfs0Layout] and reproduce its padding; zero packs the
+     * header tightly.
+     */
     fun computePfs0Header(
         entries: List<ContainerEntry>,
-        sizes: List<Long>
+        sizes: List<Long>,
+        targetHeaderSize: Int = 0,
+        firstFileDataOffset: Long = 0
     ): ByteArray {
         val names = entries.map { it.outputName }
-        val stringTable = buildStringTable(names)
-        val headerSize = PFS0_HEADER_BASE +
-            (entries.size * PFS0_ENTRY_SIZE) + stringTable.size
+        val overhead = PFS0_HEADER_BASE + entries.size * PFS0_ENTRY_SIZE
+        val stringTable = padStringTable(
+            buildStringTable(names),
+            targetHeaderSize - overhead
+        )
+        val headerSize = overhead + stringTable.size
 
         val buf = ByteBuffer.allocate(headerSize)
             .order(ByteOrder.LITTLE_ENDIAN)
@@ -190,7 +225,7 @@ object ContainerParser {
         buf.putInt(stringTable.size)
         buf.putInt(0) // reserved
 
-        var dataOffset = 0L
+        var dataOffset = firstFileDataOffset
         val nameOffsets = computeStringOffsets(names)
 
         for (i in entries.indices) {
@@ -237,6 +272,19 @@ object ContainerParser {
 
         buf.put(stringTable)
         return buf.array()
+    }
+
+    private fun padStringTable(
+        stringTable: ByteArray,
+        minSize: Int
+    ): ByteArray {
+        val remainder = stringTable.size % 0x10
+        val aligned = if (remainder == 0) {
+            stringTable.size
+        } else {
+            stringTable.size + 0x10 - remainder
+        }
+        return stringTable.copyOf(maxOf(aligned, minSize))
     }
 
     private fun buildStringTable(names: List<String>): ByteArray {

--- a/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/NczHeader.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/NczHeader.kt
@@ -14,7 +14,10 @@ data class NczSection(
     val cryptoCounter: ByteArray
 ) {
     val needsEncryption: Boolean
-        get() = cryptoType == 3L || cryptoType == 4L
+        get() = cryptoType in 3L..6L
+
+    val isPlaintext: Boolean
+        get() = cryptoType == 0L || cryptoType == 1L
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -60,7 +63,12 @@ data class NczBlockHeader(
 data class NczHeaderData(
     val sections: List<NczSection>,
     val blockHeader: NczBlockHeader?,
-    val compressedDataOffset: Long
+    /**
+     * Offset of the first zstd payload byte, measured from the start of the
+     * NCZ entry: callers add the entry's own position in the container
+     * before seeking.
+     */
+    val payloadOffsetInEntry: Long
 )
 
 object NczHeaderParser {
@@ -113,13 +121,13 @@ object NczHeaderParser {
             null
         }
 
-        val compressedDataOffset = NCA_HEADER_SIZE + bytesRead -
+        val payloadOffsetInEntry = NCA_HEADER_SIZE + bytesRead -
             if (blockHeader == null) 8 else 0
 
         return NczHeaderData(
             sections = sections,
             blockHeader = blockHeader,
-            compressedDataOffset = compressedDataOffset
+            payloadOffsetInEntry = payloadOffsetInEntry
         )
     }
 

--- a/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/NczWriter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/NczWriter.kt
@@ -24,13 +24,19 @@ object NczWriter {
         totalDecompressedSize: Long,
         onProgress: ((bytesWritten: Long, totalBytes: Long) -> Unit)?
     ) {
-        if (header.blockHeader != null) {
+        val written = if (header.blockHeader != null) {
             decompressBlock(
                 input, output, header, totalDecompressedSize, onProgress
             )
         } else {
             decompressSolid(
                 input, output, header, totalDecompressedSize, onProgress
+            )
+        }
+        if (written != totalDecompressedSize) {
+            throw IOException(
+                "NCZ body truncated: expected $totalDecompressedSize bytes, " +
+                    "decompressed $written"
             )
         }
     }
@@ -41,7 +47,7 @@ object NczWriter {
         header: NczHeaderData,
         totalDecompressedSize: Long,
         onProgress: ((bytesWritten: Long, totalBytes: Long) -> Unit)?
-    ) {
+    ): Long {
         val zstdStream = ZstdInputStream(input)
         val buf = ByteArray(BUFFER_SIZE)
         var cursor = NczHeaderParser.NCA_HEADER_SIZE
@@ -63,6 +69,8 @@ object NczWriter {
             bytesWritten += read
             onProgress?.invoke(bytesWritten, totalDecompressedSize)
         }
+
+        return bytesWritten
     }
 
     private fun decompressBlock(
@@ -71,7 +79,7 @@ object NczWriter {
         header: NczHeaderData,
         totalDecompressedSize: Long,
         onProgress: ((bytesWritten: Long, totalBytes: Long) -> Unit)?
-    ) {
+    ): Long {
         val blockHeader = header.blockHeader!!
         val blockSize = blockHeader.blockSize
         var cursor = NczHeaderParser.NCA_HEADER_SIZE
@@ -100,10 +108,12 @@ object NczWriter {
                     )
                 }
                 if (decompSize.toInt() != expectedSize) {
-                    decompBuf.copyOf(decompSize.toInt())
-                } else {
-                    decompBuf.copyOf(expectedSize)
+                    throw IOException(
+                        "Zstd block $i expanded to $decompSize bytes, " +
+                            "expected $expectedSize"
+                    )
                 }
+                decompBuf.copyOf(expectedSize)
             }
 
             processAndWrite(
@@ -118,6 +128,8 @@ object NczWriter {
             bytesWritten += decompressed.size
             onProgress?.invoke(bytesWritten, totalDecompressedSize)
         }
+
+        return bytesWritten
     }
 
     private fun processAndWrite(
@@ -148,11 +160,17 @@ object NczWriter {
                 }
             }
 
-            if (section != null && section.needsEncryption) {
+            if (section != null && !section.isPlaintext) {
+                if (!section.needsEncryption) {
+                    throw IOException(
+                        "Unsupported NCZ section crypto type: " +
+                            section.cryptoType
+                    )
+                }
                 val cipher = AesCtrCipher(
                     section.cryptoKey,
                     section.cryptoCounter,
-                    pos - section.offset
+                    pos
                 )
                 val encrypted = cipher.process(
                     data, offset, chunkSize

--- a/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/NszDecompressor.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/NszDecompressor.kt
@@ -49,9 +49,11 @@ object NszDecompressor {
     private class NszLayout(
         val entries: List<ContainerEntry>,
         val outputSizes: List<Long>,
-        val pfs0Header: ByteArray
+        val pfs0Header: ByteArray,
+        val firstFileDataOffset: Long
     ) {
-        val outputFileSize: Long get() = pfs0Header.size.toLong() + outputSizes.sum()
+        val outputFileSize: Long get() =
+            pfs0Header.size.toLong() + firstFileDataOffset + outputSizes.sum()
     }
 
     private class XczLayout(
@@ -67,12 +69,18 @@ object NszDecompressor {
     }
 
     private fun nszLayout(raf: RandomAccessFile): NszLayout {
-        val entries = ContainerParser.parsePfs0(raf)
-        val outputSizes = scanNczSizes(raf, entries)
+        val source = ContainerParser.parsePfs0Layout(raf)
+        val outputSizes = scanNczSizes(raf, source.entries)
         return NszLayout(
-            entries = entries,
+            entries = source.entries,
             outputSizes = outputSizes,
-            pfs0Header = ContainerParser.computePfs0Header(entries, outputSizes)
+            pfs0Header = ContainerParser.computePfs0Header(
+                source.entries,
+                outputSizes,
+                source.headerSize,
+                source.firstFileDataOffset
+            ),
+            firstFileDataOffset = source.firstFileDataOffset
         )
     }
 
@@ -148,8 +156,10 @@ object NszDecompressor {
                     COPY_BUFFER_SIZE
                 ).use { output ->
                     output.write(pfs0Header)
+                    writeZeros(output, layout.firstFileDataOffset)
 
-                    var bytesWritten = pfs0Header.size.toLong()
+                    var bytesWritten = pfs0Header.size.toLong() +
+                        layout.firstFileDataOffset
 
                     for (i in entries.indices) {
                         val entry = entries[i]
@@ -337,10 +347,10 @@ object NszDecompressor {
                 NczHeaderParser.NCA_HEADER_SIZE
         }
 
-        raf.seek(nczHeader.compressedDataOffset)
+        val payloadStart = entry.dataOffset + nczHeader.payloadOffsetInEntry
         val compressedStream = BufferedInputStream(
             RandomAccessFileInputStream(
-                raf, nczHeader.compressedDataOffset
+                raf, payloadStart, entry.dataOffset + entry.size
             ),
             COPY_BUFFER_SIZE
         )
@@ -365,6 +375,17 @@ object NszDecompressor {
         bytesWritten += bodySize
         onProgress?.invoke(bytesWritten, totalOutputSize)
         return bytesWritten
+    }
+
+    private fun writeZeros(output: java.io.OutputStream, count: Long) {
+        if (count <= 0) return
+        val zeros = ByteArray(minOf(count, COPY_BUFFER_SIZE.toLong()).toInt())
+        var remaining = count
+        while (remaining > 0) {
+            val chunk = minOf(zeros.size.toLong(), remaining).toInt()
+            output.write(zeros, 0, chunk)
+            remaining -= chunk
+        }
     }
 
     private fun copyEntry(
@@ -394,22 +415,35 @@ object NszDecompressor {
     }
 
     /**
-     * InputStream adapter over RandomAccessFile for sequential reads
-     * from a fixed starting position.
+     * InputStream adapter over RandomAccessFile for sequential reads from a
+     * fixed starting position, bounded by [endOffset].
      */
     private class RandomAccessFileInputStream(
         private val raf: RandomAccessFile,
-        startOffset: Long
+        startOffset: Long,
+        private val endOffset: Long = Long.MAX_VALUE
     ) : java.io.InputStream() {
+
+        private var position = startOffset
 
         init {
             raf.seek(startOffset)
         }
 
-        override fun read(): Int = raf.read()
+        override fun read(): Int {
+            if (position >= endOffset) return -1
+            val value = raf.read()
+            if (value >= 0) position++
+            return value
+        }
 
-        override fun read(b: ByteArray, off: Int, len: Int): Int =
-            raf.read(b, off, len)
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            val allowed = minOf(len.toLong(), endOffset - position).toInt()
+            if (allowed <= 0) return -1
+            val read = raf.read(b, off, allowed)
+            if (read > 0) position += read
+            return read
+        }
 
         override fun available(): Int = 0
     }

--- a/app/src/test/kotlin/com/nendo/argosy/data/download/nsz/AesCtrCipherTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/download/nsz/AesCtrCipherTest.kt
@@ -1,6 +1,7 @@
 package com.nendo.argosy.data.download.nsz
 
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
 
@@ -70,19 +71,48 @@ class AesCtrCipherTest {
     }
 
     @Test
-    fun `addCounterBigEndian adds value correctly`() {
-        val counter = ByteArray(16) { 0 }
-        AesCtrCipher.addCounterBigEndian(counter, 0x100)
-        assert(counter[6] == 1.toByte())
-        assert(counter[7] == 0.toByte())
+    fun `block index lands in the low half of the counter`() {
+        val counter = ByteArray(16) { 0x11 }
+        AesCtrCipher.writeBlockIndexBigEndian(counter, 0x0102030405060708L)
+
+        assertArrayEquals(
+            "nsz keeps the section nonce in the high half",
+            ByteArray(8) { 0x11 },
+            counter.copyOfRange(0, 8)
+        )
+        assertArrayEquals(
+            byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8),
+            counter.copyOfRange(8, 16)
+        )
     }
 
     @Test
-    fun `addCounterBigEndian handles carry`() {
+    fun `block index replaces rather than adds to the stored counter`() {
         val counter = ByteArray(16) { 0 }
-        counter[7] = 0xFF.toByte()
-        AesCtrCipher.addCounterBigEndian(counter, 1)
-        assert(counter[6] == 1.toByte())
-        assert(counter[7] == 0.toByte())
+        counter[15] = 0xFF.toByte()
+        AesCtrCipher.writeBlockIndexBigEndian(counter, 1)
+
+        assertEquals(0.toByte(), counter[14])
+        assertEquals(1.toByte(), counter[15])
+    }
+
+    @Test
+    fun `cipher resumed at an offset matches the continuous keystream`() {
+        val key = ByteArray(16) { (it * 7 + 1).toByte() }
+        val counter = ByteArray(16) { if (it < 8) (it + 1).toByte() else 0 }
+        val data = ByteArray(512) { (it % 251).toByte() }
+
+        val expected = AesCtrCipher(key, counter, 0).process(data)
+
+        for (split in listOf(16, 0x25, 256)) {
+            val head = AesCtrCipher(key, counter, 0).process(data, 0, split)
+            val tail = AesCtrCipher(key, counter, split.toLong())
+                .process(data, split, data.size - split)
+            assertArrayEquals(
+                "Resuming at offset $split must not shift the keystream",
+                expected,
+                head + tail
+            )
+        }
     }
 }

--- a/app/src/test/kotlin/com/nendo/argosy/data/download/nsz/NszRoundTripTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/download/nsz/NszRoundTripTest.kt
@@ -1,0 +1,373 @@
+package com.nendo.argosy.data.download.nsz
+
+import com.github.luben.zstd.Zstd
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import kotlin.io.path.createTempDirectory
+
+/**
+ * Builds a synthetic NSP, derives an NSZ from it, and asserts the
+ * decompressor reproduces the NSP byte for byte. The container carries a
+ * padded PFS0 string table, a gap before the first file, and an NCZ whose
+ * sections mix a plaintext crypto type with AES-CTR.
+ */
+class NszRoundTripTest {
+
+    private lateinit var tempDir: File
+
+    @Before
+    fun setup() {
+        tempDir = createTempDirectory("nsz_round_trip").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun `solid NSZ decompresses to the original NSP byte for byte`() {
+        val fixture = buildFixture(blockSizeExponent = null)
+
+        val result = NszDecompressor.decompress(fixture.nszFile, null)
+
+        assertEquals("game.nsp", result.name)
+        assertArrayEquals(fixture.expectedNsp, result.readBytes())
+    }
+
+    @Test
+    fun `block NSZ decompresses to the original NSP byte for byte`() {
+        val fixture = buildFixture(blockSizeExponent = 14)
+
+        val result = NszDecompressor.decompress(fixture.nszFile, null)
+
+        assertArrayEquals(fixture.expectedNsp, result.readBytes())
+    }
+
+    @Test
+    fun `measured size matches the size actually written`() {
+        val fixture = buildFixture(blockSizeExponent = null)
+
+        val measured = NszDecompressor.measureDecompressedSize(fixture.nszFile)
+        val result = NszDecompressor.decompress(fixture.nszFile, null)
+
+        assertEquals(fixture.expectedNsp.size.toLong(), measured)
+        assertEquals(fixture.expectedNsp.size.toLong(), result.length())
+    }
+
+    @Test
+    fun `progress never reports more than the total`() {
+        val fixture = buildFixture(blockSizeExponent = 14)
+
+        var last = 0L
+        NszDecompressor.decompress(fixture.nszFile) { written, total ->
+            assertTrue("progress $written exceeded total $total", written <= total)
+            last = written
+        }
+
+        assertEquals(fixture.expectedNsp.size.toLong(), last)
+    }
+
+    @Test
+    fun `truncated payload fails instead of writing a short NSP`() {
+        val fixture = buildFixture(blockSizeExponent = null)
+        val full = fixture.nszFile.readBytes()
+        fixture.nszFile.writeBytes(full.copyOf(full.size - 64))
+
+        val error = runCatching {
+            NszDecompressor.decompress(fixture.nszFile, null)
+        }.exceptionOrNull()
+
+        assertTrue("expected an IOException, got $error", error is IOException)
+        assertTrue(
+            "temp output should not be left behind",
+            tempDir.listFiles().orEmpty().none { it.name.endsWith(".tmp") }
+        )
+    }
+
+    @Test
+    fun `unsupported section crypto type is rejected`() {
+        val fixture = buildFixture(blockSizeExponent = null, cryptoTypeOverride = 2)
+
+        val error = runCatching {
+            NszDecompressor.decompress(fixture.nszFile, null)
+        }.exceptionOrNull()
+
+        assertTrue(error is IOException)
+        assertTrue(
+            "message should name the crypto type: ${error?.message}",
+            error?.message.orEmpty().contains("crypto type")
+        )
+    }
+
+    @Test
+    fun `skip layer hash crypto types are re-encrypted like plain CTR`() {
+        for (cryptoType in listOf(4L, 5L, 6L)) {
+            tempDir.listFiles().orEmpty().forEach { it.delete() }
+            val fixture = buildFixture(
+                blockSizeExponent = null,
+                cryptoTypeOverride = cryptoType
+            )
+
+            val result = NszDecompressor.decompress(fixture.nszFile, null)
+
+            assertArrayEquals(
+                "crypto type $cryptoType round trip",
+                fixture.expectedNsp,
+                result.readBytes()
+            )
+        }
+    }
+
+    @Test
+    fun `block mode rejects a body shorter than the header claims`() {
+        val fixture = buildFixture(blockSizeExponent = 14)
+        val bytes = fixture.nszFile.readBytes()
+        val blockHeader = indexOfMagic(bytes, "NCZBLOCK")
+        val sizeField = blockHeader + 16
+        val claimed = ByteBuffer.wrap(bytes, sizeField, 8)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .long
+        ByteBuffer.wrap(bytes, sizeField, 8)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putLong(claimed + 0x1000)
+        fixture.nszFile.writeBytes(bytes)
+
+        val error = runCatching {
+            NszDecompressor.decompress(fixture.nszFile, null)
+        }.exceptionOrNull()
+
+        assertTrue("expected an IOException, got $error", error is IOException)
+    }
+
+    @Test
+    fun `payload decoding stops at the end of its own entry`() {
+        val sections = listOf(
+            SectionSpec(
+                offset = NCA_HEADER,
+                cryptoType = 1L,
+                plaintext = ByteArray(PLAIN_SIZE) { (it * 7).toByte() }
+            ),
+            SectionSpec(
+                offset = NCA_HEADER + PLAIN_SIZE,
+                cryptoType = 3L,
+                plaintext = ByteArray(CTR_SIZE) { (it * 13 + 5).toByte() }
+            )
+        )
+        var body = ByteArray(0)
+        sections.forEach { body += it.plaintext }
+
+        val split = PLAIN_SIZE
+        val ncz = ByteArray(NCA_HEADER.toInt()) { (it % 97).toByte() } +
+            buildSectionHeader(sections) +
+            zstd(body.copyOfRange(0, split))
+        val strandedFrame = zstd(body.copyOfRange(split, body.size))
+
+        val nszFile = File(tempDir, "game.nsz")
+        nszFile.writeBytes(
+            buildPfs0(listOf("game.ncz" to ncz, "tail.bin" to strandedFrame))
+        )
+
+        val error = runCatching {
+            NszDecompressor.decompress(nszFile, null)
+        }.exceptionOrNull()
+
+        assertTrue(
+            "reading past the entry would have silently completed the NCA, " +
+                "got $error",
+            error is IOException
+        )
+    }
+
+    private fun indexOfMagic(bytes: ByteArray, magic: String): Int {
+        val needle = magic.toByteArray(Charsets.US_ASCII)
+        outer@ for (i in 0..bytes.size - needle.size) {
+            for (j in needle.indices) {
+                if (bytes[i + j] != needle[j]) continue@outer
+            }
+            return i
+        }
+        throw AssertionError("$magic not found in fixture")
+    }
+
+    private data class Fixture(val nszFile: File, val expectedNsp: ByteArray)
+
+    private fun buildFixture(
+        blockSizeExponent: Int?,
+        cryptoTypeOverride: Long? = null
+    ): Fixture {
+        val sections = listOf(
+            SectionSpec(
+                offset = NCA_HEADER,
+                cryptoType = 1L,
+                plaintext = ByteArray(PLAIN_SIZE) { (it * 7).toByte() }
+            ),
+            SectionSpec(
+                offset = NCA_HEADER + PLAIN_SIZE,
+                cryptoType = cryptoTypeOverride ?: 3L,
+                plaintext = ByteArray(CTR_SIZE) { (it * 13 + 5).toByte() }
+            )
+        )
+
+        val ncaPrefix = ByteArray(NCA_HEADER.toInt()) { (it % 97).toByte() }
+        var nca = ncaPrefix
+        for (section in sections) {
+            nca += if (section.cryptoType in 3L..6L) {
+                encryptCtr(section.offset, section.plaintext)
+            } else {
+                section.plaintext
+            }
+        }
+
+        val cnmt = ByteArray(0x400) { 0x5A }
+        val ncz = buildNcz(ncaPrefix, sections, blockSizeExponent)
+
+        val nszFile = File(tempDir, "game.nsz")
+        nszFile.writeBytes(
+            buildPfs0(listOf("meta.cnmt.nca" to cnmt, "game.ncz" to ncz))
+        )
+        return Fixture(
+            nszFile,
+            buildPfs0(listOf("meta.cnmt.nca" to cnmt, "game.nca" to nca))
+        )
+    }
+
+    private data class SectionSpec(
+        val offset: Long,
+        val cryptoType: Long,
+        val plaintext: ByteArray
+    ) {
+        val size: Long get() = plaintext.size.toLong()
+    }
+
+    private fun encryptCtr(offset: Long, plaintext: ByteArray): ByteArray {
+        val iv = CRYPTO_COUNTER.copyOf()
+        ByteBuffer.wrap(iv, 8, 8).order(ByteOrder.BIG_ENDIAN).putLong(offset / 16)
+        val cipher = Cipher.getInstance("AES/CTR/NoPadding")
+        cipher.init(
+            Cipher.ENCRYPT_MODE,
+            SecretKeySpec(CRYPTO_KEY, "AES"),
+            IvParameterSpec(iv)
+        )
+        return cipher.doFinal(plaintext)
+    }
+
+    private fun buildSectionHeader(sections: List<SectionSpec>): ByteArray {
+        val headerBuf = ByteBuffer.allocate(16 + sections.size * 64)
+            .order(ByteOrder.LITTLE_ENDIAN)
+        headerBuf.put("NCZSECTN".toByteArray(Charsets.US_ASCII))
+        headerBuf.putLong(sections.size.toLong())
+        for (section in sections) {
+            headerBuf.putLong(section.offset)
+            headerBuf.putLong(section.size)
+            headerBuf.putLong(section.cryptoType)
+            headerBuf.putLong(0)
+            headerBuf.put(CRYPTO_KEY)
+            headerBuf.put(CRYPTO_COUNTER)
+        }
+        return headerBuf.array()
+    }
+
+    private fun buildNcz(
+        ncaPrefix: ByteArray,
+        sections: List<SectionSpec>,
+        blockSizeExponent: Int?
+    ): ByteArray {
+        val sectionHeader = buildSectionHeader(sections)
+
+        var body = ByteArray(0)
+        sections.forEach { body += it.plaintext }
+
+        if (blockSizeExponent == null) {
+            return ncaPrefix + sectionHeader + zstd(body)
+        }
+
+        val blockSize = 1 shl blockSizeExponent
+        val blocks = (body.indices step blockSize).map {
+            zstd(body.copyOfRange(it, minOf(it + blockSize, body.size)))
+        }
+        val blockBuf = ByteBuffer.allocate(NCZBLOCK_HEADER_SIZE + blocks.size * 4)
+            .order(ByteOrder.LITTLE_ENDIAN)
+        blockBuf.put("NCZBLOCK".toByteArray(Charsets.US_ASCII))
+        blockBuf.put(1)
+        blockBuf.put(0)
+        blockBuf.put(0)
+        blockBuf.put(blockSizeExponent.toByte())
+        blockBuf.putInt(blocks.size)
+        blockBuf.putLong(body.size.toLong())
+        blocks.forEach { blockBuf.putInt(it.size) }
+
+        var payload = ByteArray(0)
+        blocks.forEach { payload += it }
+        return ncaPrefix + sectionHeader + blockBuf.array() + payload
+    }
+
+    private fun zstd(data: ByteArray): ByteArray {
+        val out = ByteArray(Zstd.compressBound(data.size.toLong()).toInt())
+        return out.copyOf(Zstd.compress(out, data, 3).toInt())
+    }
+
+    private fun buildPfs0(files: List<Pair<String, ByteArray>>): ByteArray {
+        val stringTable = ByteArray(STRING_TABLE_SIZE)
+        var cursor = 0
+        val nameOffsets = files.map { (name, _) ->
+            val at = cursor
+            val raw = name.toByteArray(Charsets.US_ASCII)
+            raw.copyInto(stringTable, at)
+            cursor += raw.size + 1
+            at
+        }
+
+        val headerSize = PFS0_HEADER_BASE + files.size * PFS0_ENTRY_SIZE +
+            stringTable.size
+        val buf = ByteBuffer
+            .allocate(
+                headerSize + FIRST_FILE_GAP.toInt() + files.sumOf { it.second.size }
+            )
+            .order(ByteOrder.LITTLE_ENDIAN)
+
+        buf.putInt(PFS0_MAGIC)
+        buf.putInt(files.size)
+        buf.putInt(stringTable.size)
+        buf.putInt(0)
+
+        var dataOffset = FIRST_FILE_GAP
+        for (i in files.indices) {
+            buf.putLong(dataOffset)
+            buf.putLong(files[i].second.size.toLong())
+            buf.putInt(nameOffsets[i])
+            buf.putInt(0)
+            dataOffset += files[i].second.size
+        }
+
+        buf.put(stringTable)
+        buf.put(ByteArray(FIRST_FILE_GAP.toInt()))
+        files.forEach { buf.put(it.second) }
+        return buf.array()
+    }
+
+    private companion object {
+        const val NCA_HEADER = 0x4000L
+        const val PLAIN_SIZE = 0x8000
+        const val CTR_SIZE = 0x14000
+        const val STRING_TABLE_SIZE = 0x30
+        const val FIRST_FILE_GAP = 0x200L
+        const val PFS0_MAGIC = 0x30534650
+        const val PFS0_HEADER_BASE = 16
+        const val PFS0_ENTRY_SIZE = 24
+        const val NCZBLOCK_HEADER_SIZE = 24
+        val CRYPTO_KEY = ByteArray(16) { (it * 11 + 3).toByte() }
+        val CRYPTO_COUNTER = ByteArray(16) { if (it < 8) (it + 2).toByte() else 0 }
+    }
+}


### PR DESCRIPTION
## Summary

Every NSZ I downloaded from my RomM server failed on my AYN Thor with `NSZ decompression failed: unknown frame descriptor`.

`NczHeaderParser` returns the payload offset relative to the start of the NCZ entry, but `decompressNczEntry` passed it to `raf.seek()` as an absolute file offset. The first entry in a real NSP sits thousands of bytes in, so zstd got ticket and cert bytes instead of a frame header.

Three more bugs sat behind that one. All of them corrupt the NSP once the seek is fixed.

`AesCtrCipher` built the CTR counter wrong. nsz keeps the section nonce in the first 8 bytes of the counter and leaves the low 8 for the block index. We added the index into the nonce half instead of writing it into the low half, and took it from a section-relative offset instead of the absolute NCA offset. The cipher was also rebuilt per chunk with no handling for chunks that do not start on a 16-byte boundary, which zstd reads produce constantly. This never threw, it just wrote garbage into every encrypted section.

Crypto types 5 and 6 were written out as plaintext because only 3 and 4 counted as CTR.

A short zstd stream, or a block that expanded to the wrong size, was written out truncated while the PFS0 header still claimed the full length. The payload stream is now bounded to its own entry so zstd cannot run into the next file.

The rebuilt PFS0 dropped the source header padding and the gap in front of the first file, so output could never match the original NSP. Both are preserved now.

I used rom-converto as the reference since it converts these files fine, and ported its NCZ and PFS0 logic first to pin the format down. That port reproduces a real NSZ's matching NSP with an identical SHA-256.

`zstd-jni` was declared aar-only, so no JVM unit test could call zstd. Added the plain jar as a test dependency.

## Behavior changes

NSZ and XCZ downloads decompress instead of failing.

Output NSPs are byte-identical to the source container.

Malformed containers throw `IOException` instead of writing a broken NSP. That covers a short zstd stream, a block of unexpected size, and crypto type 2, which used to pass through unencrypted.

## Hot paths

No. This is the download path, already off main through `DownloadManager`. No new I/O, network or DB work.

## Testing evidence

The suite builds a synthetic NSP, derives an NSZ from it, and asserts the decompressor reproduces the NSP byte for byte in solid and block mode. The fixture has a padded PFS0 string table, a gap before the first file, and an NCZ mixing a plaintext section with AES-CTR. There are cases for crypto types 4, 5 and 6, a truncated payload, a block that lies about its size, and a payload that would read past its own entry.

Separately I ran the rom-converto port against a real NSZ that ships with a matching NSP and compared SHA-256.

## AI assistance

I used Claude Code to analyze the rom-converto and nsz codebases as a reference and to find the bugs. I verified everything afterwards, including the format research and the diff.

## Checklist

- [ ] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
