### PR TITLE
fix(sync): keep the regional releases the region priority asks for

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/local/dao/GameFileDao.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/local/dao/GameFileDao.kt
@@ -178,4 +178,7 @@ interface GameFileDao {
 
     @Query("SELECT * FROM game_files WHERE localPath = :localPath LIMIT 1")
     suspend fun getByLocalPath(localPath: String): GameFileEntity?
+
+    @Query("SELECT gameId FROM game_files WHERE versionGroup = :versionGroup LIMIT 1")
+    suspend fun getGameIdForVersionGroup(versionGroup: String): Long?
 }

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/AccountScopedPreferenceKeys.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/AccountScopedPreferenceKeys.kt
@@ -44,7 +44,8 @@ object AccountScopedPreferenceKeys {
         "sync_filter_exclude_beta",
         "sync_filter_exclude_proto",
         "sync_filter_exclude_demo",
-        "sync_filter_exclude_hack"
+        "sync_filter_exclude_hack",
+        "sync_filter_exclude_unofficial"
     )
 
     private val DOWNLOAD_CATEGORIES = setOf(

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/SettingsBackupKeys.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/SettingsBackupKeys.kt
@@ -264,6 +264,7 @@ object SettingsBackupKeys {
         SettingsBackupKey("sync_filter_exclude_proto", SettingsBackupType.BOOLEAN),
         SettingsBackupKey("sync_filter_exclude_demo", SettingsBackupType.BOOLEAN),
         SettingsBackupKey("sync_filter_exclude_hack", SettingsBackupType.BOOLEAN),
+        SettingsBackupKey("sync_filter_exclude_unofficial", SettingsBackupType.BOOLEAN),
         SettingsBackupKey("sync_screenshots_enabled", SettingsBackupType.BOOLEAN),
         SettingsBackupKey("upload_screenshots_enabled", SettingsBackupType.BOOLEAN)
     )

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/SyncFilterPreferences.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/SyncFilterPreferences.kt
@@ -7,8 +7,16 @@ data class SyncFilterPreferences(
     val excludePrototype: Boolean = true,
     val excludeDemo: Boolean = true,
     val excludeHack: Boolean = false,
+    val excludeUnofficial: Boolean = false,
     val deleteOrphans: Boolean = true
 ) {
+    /**
+     * Whether [enabledRegions] is an ordered preference rather than a blacklist. Only an include
+     * list carries priority, so consumers that rank by region must not read an exclude list.
+     */
+    val hasRegionPriority: Boolean
+        get() = regionMode == RegionFilterMode.INCLUDE && enabledRegions.isNotEmpty()
+
     /** Enabled regions in priority order followed by disabled; canonical order when priority is off. */
     val pickerDisplayOrder: List<String>
         get() = if (regionMode != RegionFilterMode.INCLUDE) ALL_KNOWN_REGIONS

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/SyncPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/SyncPreferencesRepository.kt
@@ -89,6 +89,7 @@ class SyncPreferencesRepository @Inject constructor(
         val SYNC_FILTER_EXCLUDE_PROTO = booleanPreferencesKey("sync_filter_exclude_proto")
         val SYNC_FILTER_EXCLUDE_DEMO = booleanPreferencesKey("sync_filter_exclude_demo")
         val SYNC_FILTER_EXCLUDE_HACK = booleanPreferencesKey("sync_filter_exclude_hack")
+        val SYNC_FILTER_EXCLUDE_UNOFFICIAL = booleanPreferencesKey("sync_filter_exclude_unofficial")
         val SYNC_FILTER_DELETE_ORPHANS = booleanPreferencesKey("sync_filter_delete_orphans")
         val SYNC_SCREENSHOTS_ENABLED = booleanPreferencesKey("sync_screenshots_enabled")
         val UPLOAD_SCREENSHOTS_ENABLED = booleanPreferencesKey("upload_screenshots_enabled")
@@ -279,6 +280,7 @@ class SyncPreferencesRepository @Inject constructor(
                 excludePrototype = prefs[Keys.SYNC_FILTER_EXCLUDE_PROTO] ?: true,
                 excludeDemo = prefs[Keys.SYNC_FILTER_EXCLUDE_DEMO] ?: true,
                 excludeHack = prefs[Keys.SYNC_FILTER_EXCLUDE_HACK] ?: false,
+                excludeUnofficial = prefs[Keys.SYNC_FILTER_EXCLUDE_UNOFFICIAL] ?: false,
                 deleteOrphans = prefs[Keys.SYNC_FILTER_DELETE_ORPHANS] ?: true
             ),
             syncScreenshotsEnabled = prefs[Keys.SYNC_SCREENSHOTS_ENABLED] ?: false,
@@ -483,6 +485,10 @@ class SyncPreferencesRepository @Inject constructor(
 
     suspend fun setSyncFilterExcludeHack(exclude: Boolean) {
         dataStore.edit { it[Keys.SYNC_FILTER_EXCLUDE_HACK] = exclude }
+    }
+
+    suspend fun setSyncFilterExcludeUnofficial(exclude: Boolean) {
+        dataStore.edit { it[Keys.SYNC_FILTER_EXCLUDE_UNOFFICIAL] = exclude }
     }
 
     suspend fun setSyncFilterDeleteOrphans(delete: Boolean) {

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
@@ -360,6 +360,8 @@ class UserPreferencesRepository @Inject constructor(
     suspend fun setSyncFilterExcludePrototype(exclude: Boolean) = syncPrefs.setSyncFilterExcludePrototype(exclude)
     suspend fun setSyncFilterExcludeDemo(exclude: Boolean) = syncPrefs.setSyncFilterExcludeDemo(exclude)
     suspend fun setSyncFilterExcludeHack(exclude: Boolean) = syncPrefs.setSyncFilterExcludeHack(exclude)
+    suspend fun setSyncFilterExcludeUnofficial(exclude: Boolean) =
+        syncPrefs.setSyncFilterExcludeUnofficial(exclude)
     suspend fun setSyncFilterDeleteOrphans(delete: Boolean) = syncPrefs.setSyncFilterDeleteOrphans(delete)
     suspend fun setSyncScreenshotsEnabled(enabled: Boolean) = syncPrefs.setSyncScreenshotsEnabled(enabled)
     suspend fun setUploadScreenshotsEnabled(enabled: Boolean) = syncPrefs.setUploadScreenshotsEnabled(enabled)

--- a/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMCollectionSyncService.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMCollectionSyncService.kt
@@ -2,6 +2,7 @@ package com.nendo.argosy.data.remote.romm
 
 import com.nendo.argosy.data.local.dao.CollectionDao
 import com.nendo.argosy.data.local.dao.GameDao
+import com.nendo.argosy.data.model.VersionGroups
 import com.nendo.argosy.data.local.entity.CollectionEntity
 import com.nendo.argosy.data.local.entity.CollectionGameEntity
 import com.nendo.argosy.data.local.entity.CollectionType
@@ -28,6 +29,7 @@ class RomMCollectionSyncService @Inject constructor(
     private val connectionManager: RomMConnectionManager,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val gameDao: GameDao,
+    private val gameFileDao: com.nendo.argosy.data.local.dao.GameFileDao,
     private val collectionDao: CollectionDao,
     private val collectionMembershipDao: com.nendo.argosy.data.local.dao.CollectionMembershipDao,
     private val overlayWriter: com.nendo.argosy.data.repository.GameUserOverlayWriter,
@@ -373,10 +375,20 @@ class RomMCollectionSyncService @Inject constructor(
         }
     }
 
+    /**
+     * Sibling consolidation keeps one row per group and absorbs the rest, so a collection that
+     * names an absorbed rom has no row of its own to point at. Falling back to the version group
+     * finds the row that swallowed it; resolving to null instead drops the game from the
+     * collection, and the membership repointed onto the winner is then deleted as stale.
+     */
+    internal suspend fun resolveCollectionGameId(rommId: Long): Long? =
+        gameDao.getByRommId(rommId)?.id
+            ?: gameFileDao.getGameIdForVersionGroup(VersionGroups.groupKey(rommId))
+
     private suspend fun syncCollectionGames(collectionId: Long, remoteRomIds: List<Long>) {
         val localGameIds = collectionDao.getGameIdsInCollection(collectionId).toSet()
         val remoteGameIds = remoteRomIds.mapNotNull { rommId ->
-            gameDao.getByRommId(rommId)?.id
+            resolveCollectionGameId(rommId)
         }.toSet()
 
         for (gameId in remoteGameIds - localGameIds) {

--- a/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMLibrarySyncService.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMLibrarySyncService.kt
@@ -957,17 +957,18 @@ class RomMLibrarySyncService @Inject constructor(
         var totalFetched = 0
         var platformTotal: Int? = null
 
+        /**
+         * Sibling lists are not symmetric: a rom can name fewer siblings than one of its own
+         * siblings names, so a group can start as two and only meet once a rom bridging them
+         * arrives. Merging has to put both running winners back through [chooseWinner], since
+         * keeping whichever group formed first decides the release by page order rather than by
+         * the region priority.
+         */
         fun groupFor(rom: RomMRom): SiblingGroup {
             val ids = listOf(rom.id) +
                 rom.effectiveSiblings.filter { !it.isDiscVariant }.map { it.id }
             val existingGroups = ids.mapNotNull { siblingGroups[it] }.distinct()
-            val group = existingGroups.firstOrNull() ?: SiblingGroup()
-            existingGroups.drop(1).forEach { other ->
-                group.members.addAll(other.members)
-                group.expectedIds.addAll(other.expectedIds)
-                if (group.mainSiblingId == null) group.mainSiblingId = other.mainSiblingId
-                if (group.winner == null) group.winner = other.winner
-            }
+            val group = mergeSiblingGroups(existingGroups, filters)
             group.expectedIds.addAll(ids)
             ids.forEach { siblingGroups[it] = group }
             return group
@@ -1683,6 +1684,27 @@ internal class SiblingGroup {
      */
     val isComplete: Boolean get() = expectedIds.isNotEmpty() &&
         members.mapTo(mutableSetOf()) { it.id }.containsAll(expectedIds)
+}
+
+/**
+ * Folds groups that turned out to be one into the first of them. Both running winners go back
+ * through [chooseWinner]: keeping the winner of whichever group formed first decides the
+ * release by the order the server paged its roms in rather than by the region priority.
+ */
+internal fun mergeSiblingGroups(
+    existingGroups: List<SiblingGroup>,
+    filters: SyncFilterPreferences
+): SiblingGroup {
+    val group = existingGroups.firstOrNull() ?: SiblingGroup()
+    existingGroups.drop(1).forEach { other ->
+        group.members.addAll(other.members)
+        group.expectedIds.addAll(other.expectedIds)
+        if (group.mainSiblingId == null) group.mainSiblingId = other.mainSiblingId
+        other.winner?.let { candidate ->
+            group.winner = chooseWinner(group, candidate, filters)
+        }
+    }
+    return group
 }
 
 /**

--- a/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMLibrarySyncService.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMLibrarySyncService.kt
@@ -1707,9 +1707,27 @@ internal fun chooseWinner(
     }
     if (candidate.id == group.mainSiblingId) return candidate
     if (current.id == group.mainSiblingId) return current
-    return if (filters.regionRank(candidate.regions) < filters.regionRank(current.regions)) {
-        candidate
-    } else {
-        current
+    val candidateRank = filters.regionRank(candidate.regions)
+    val currentRank = filters.regionRank(current.regions)
+    if (candidateRank != currentRank) {
+        return if (candidateRank < currentRank) candidate else current
     }
+    if (candidate.isRerelease != current.isRerelease) {
+        return if (current.isRerelease) candidate else current
+    }
+    return current
 }
+
+private val RERELEASE_TAG_MARKERS =
+    listOf("virtual console", "switch online", "classic mini", "gamecube")
+
+/**
+ * A re-release of the same game on later hardware. Region rank cannot separate it from the
+ * original dump, both being tagged the same region, so without this the winner is whichever
+ * the server happened to page in first.
+ */
+internal val RomMRom.isRerelease: Boolean
+    get() = tags?.any { tag ->
+        val lower = tag.lowercase()
+        RERELEASE_TAG_MARKERS.any { lower.contains(it) }
+    } ?: false

--- a/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMLibrarySyncService.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMLibrarySyncService.kt
@@ -1057,7 +1057,7 @@ class RomMLibrarySyncService @Inject constructor(
 
                     if (group.isComplete) {
                         val outcome = consolidateSiblingGroup(
-                            api, group, platform, absorptionPairs, scope, ::trackSiblingMultiDisc
+                            api, group, platform, absorptionPairs, scope, filters, ::trackSiblingMultiDisc
                         )
                         added += outcome.added
                         updated += outcome.updated
@@ -1086,7 +1086,7 @@ class RomMLibrarySyncService @Inject constructor(
 
         for (group in siblingGroups.values.distinct()) {
             val outcome = consolidateSiblingGroup(
-                api, group, platform, absorptionPairs, scope, ::trackSiblingMultiDisc
+                api, group, platform, absorptionPairs, scope, filters, ::trackSiblingMultiDisc
             )
             added += outcome.added
             updated += outcome.updated
@@ -1113,12 +1113,13 @@ class RomMLibrarySyncService @Inject constructor(
         platform: RomMPlatform,
         absorptionPairs: MutableList<Pair<Long, Long>>,
         scope: SyncScope,
+        filters: SyncFilterPreferences,
         trackMultiDisc: (RomMRom) -> Unit
     ): ConsolidationOutcome {
         if (group.consolidated) return ConsolidationOutcome(0, 0)
         val members = group.members
         if (members.isEmpty()) return ConsolidationOutcome(0, 0)
-        val winner = resolveGroupWinner(api, group) ?: return ConsolidationOutcome(0, 0)
+        val winner = resolveGroupWinner(api, group, filters) ?: return ConsolidationOutcome(0, 0)
 
         group.consolidated = true
         var added = 0
@@ -1187,11 +1188,19 @@ class RomMLibrarySyncService @Inject constructor(
      * was already seen and reduced to a projection. Re-fetch it in that case rather than
      * consolidating under the wrong ROM.
      */
-    private suspend fun resolveGroupWinner(api: RomMApi, group: SiblingGroup): RomMRom? {
+    private suspend fun resolveGroupWinner(
+        api: RomMApi,
+        group: SiblingGroup,
+        filters: SyncFilterPreferences
+    ): RomMRom? {
         val running = group.winner ?: return null
         val mainId = group.mainSiblingId
         if (mainId == null || running.id == mainId) return running
         if (group.members.none { it.id == mainId }) return running
+        if (filters.hasRegionPriority) {
+            val mainRegions = group.members.firstOrNull { it.id == mainId }?.regions
+            if (filters.regionRank(running.regions) <= filters.regionRank(mainRegions)) return running
+        }
 
         return try {
             val response = api.getRom(mainId)
@@ -1678,8 +1687,10 @@ internal class SiblingGroup {
 
 /**
  * Running pick of the sibling a group consolidates under, so only one full [RomMRom] per
- * group stays resident. Mirrors the deferred rule it replaced: a declared main sibling
- * wins outright, otherwise the best region rank wins, ties going to the member seen first.
+ * group stays resident. An explicit region priority outranks the server's declared main
+ * sibling, which otherwise decides the whole group and drops the regional release the user
+ * asked for. Without a priority the declared main sibling wins, ties going to the member
+ * seen first.
  */
 internal fun chooseWinner(
     group: SiblingGroup,
@@ -1687,6 +1698,13 @@ internal fun chooseWinner(
     filters: SyncFilterPreferences
 ): RomMRom {
     val current = group.winner ?: return candidate
+    if (filters.hasRegionPriority) {
+        val candidateRank = filters.regionRank(candidate.regions)
+        val currentRank = filters.regionRank(current.regions)
+        if (candidateRank != currentRank) {
+            return if (candidateRank < currentRank) candidate else current
+        }
+    }
     if (candidate.id == group.mainSiblingId) return candidate
     if (current.id == group.mainSiblingId) return current
     return if (filters.regionRank(candidate.regions) < filters.regionRank(current.regions)) {

--- a/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMSyncFilter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMSyncFilter.kt
@@ -121,18 +121,37 @@ object RomMSyncFilter {
     }
 
     private fun passesRevisionFilter(rom: RomMRom, filters: SyncFilterPreferences): Boolean {
-        val revision = rom.revision?.lowercase() ?: ""
-        val name = rom.name.lowercase()
-        val tags = rom.tags?.map { it.lowercase() } ?: emptyList()
+        val variant = VariantTags(rom)
 
-        if (filters.excludeBeta && (revision.contains("beta") || name.contains("(beta)"))) return false
-        if (filters.excludePrototype && (revision.contains("proto") || name.contains("(proto)"))) return false
-        if (filters.excludeDemo && (revision.contains("demo") || name.contains("(demo)") || name.contains("(sample)"))) {
+        if (filters.excludeBeta && variant.has("beta")) return false
+        if (filters.excludePrototype && variant.has("proto", "debug")) return false
+        if (filters.excludeDemo && variant.has("demo", "sample")) return false
+        if (filters.excludeHack && isHack(rom.name.lowercase(), variant.revision, variant.tags)) {
             return false
         }
-        if (filters.excludeHack && isHack(name, revision, tags)) return false
+        if (filters.excludeUnofficial && variant.has("pirate", "unl", "aftermarket")) return false
 
         return true
+    }
+
+    /**
+     * The release tags of a rom, read from every field RomM puts them in. A rom matched against
+     * metadata carries the clean IGDB title in `name`, so the parenthesised tags survive only in
+     * `tags` and the file name; reading `name` alone silently matches nothing for most of a
+     * library. Debug builds count as prototypes, both being unreleased internal builds, unlike a
+     * demo, which is a released promotional cut.
+     */
+    private class VariantTags(rom: RomMRom) {
+        val revision = rom.revision?.lowercase() ?: ""
+        val tags = rom.tags?.map { it.lowercase() } ?: emptyList()
+        private val bracketed =
+            "${rom.name.lowercase()} ${rom.fileName?.lowercase() ?: ""}"
+
+        fun has(vararg keywords: String): Boolean = keywords.any { keyword ->
+            revision.contains(keyword) ||
+                tags.any { it.startsWith(keyword) } ||
+                bracketed.contains("($keyword")
+        }
     }
 
     private fun isHack(name: String, revision: String, tags: List<String>): Boolean {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
@@ -1355,6 +1355,8 @@ class SettingsViewModel @Inject constructor(
     fun setExcludePrototype(exclude: Boolean) = syncDelegate.setExcludePrototype(viewModelScope, exclude)
     fun setExcludeDemo(exclude: Boolean) = syncDelegate.setExcludeDemo(viewModelScope, exclude)
     fun setExcludeHack(exclude: Boolean) = syncDelegate.setExcludeHack(viewModelScope, exclude)
+    fun setExcludeUnofficial(exclude: Boolean) =
+        syncDelegate.setExcludeUnofficial(viewModelScope, exclude)
     fun setDeleteOrphans(delete: Boolean) = syncDelegate.setDeleteOrphans(viewModelScope, delete)
 
     fun toggleSyncScreenshots() = routeToggleSyncScreenshots(this)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/components/SyncFiltersModal.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/components/SyncFiltersModal.kt
@@ -55,6 +55,7 @@ fun SyncFiltersModal(
     onToggleExcludePrototype: (Boolean) -> Unit,
     onToggleExcludeDemo: (Boolean) -> Unit,
     onToggleExcludeHack: (Boolean) -> Unit,
+    onToggleExcludeUnofficial: (Boolean) -> Unit,
     onToggleDeleteOrphans: (Boolean) -> Unit,
     onShowRegionPicker: () -> Unit,
     onDismissRegionPicker: () -> Unit,
@@ -171,10 +172,19 @@ fun SyncFiltersModal(
                 }
                 item {
                     SwitchPreference(
+                        title = stringResource(R.string.settings_sync_filters_exclude_unofficial_title),
+                        subtitle = stringResource(R.string.settings_sync_filters_exclude_unofficial_subtitle),
+                        isEnabled = syncFilters.excludeUnofficial,
+                        isFocused = focusIndex == 6,
+                        onToggle = onToggleExcludeUnofficial
+                    )
+                }
+                item {
+                    SwitchPreference(
                         title = stringResource(R.string.settings_sync_filters_remove_orphans_title),
                         subtitle = stringResource(R.string.settings_sync_filters_remove_orphans_subtitle),
                         isEnabled = syncFilters.deleteOrphans,
-                        isFocused = focusIndex == 6,
+                        isFocused = focusIndex == 7,
                         onToggle = onToggleDeleteOrphans
                     )
                 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/SyncSettingsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/SyncSettingsDelegate.kt
@@ -149,7 +149,7 @@ class SyncSettingsDelegate @Inject constructor(
 
     fun moveSyncFiltersModalFocus(delta: Int) {
         _state.update { state ->
-            val maxIndex = 6
+            val maxIndex = 7
             val newIndex = (state.syncFiltersModalFocusIndex + delta).coerceIn(0, maxIndex)
             state.copy(syncFiltersModalFocusIndex = newIndex)
         }
@@ -164,7 +164,8 @@ class SyncSettingsDelegate @Inject constructor(
             3 -> setExcludePrototype(scope, !state.syncFilters.excludePrototype)
             4 -> setExcludeDemo(scope, !state.syncFilters.excludeDemo)
             5 -> setExcludeHack(scope, !state.syncFilters.excludeHack)
-            6 -> setDeleteOrphans(scope, !state.syncFilters.deleteOrphans)
+            6 -> setExcludeUnofficial(scope, !state.syncFilters.excludeUnofficial)
+            7 -> setDeleteOrphans(scope, !state.syncFilters.deleteOrphans)
         }
     }
 
@@ -342,6 +343,15 @@ class SyncSettingsDelegate @Inject constructor(
             preferencesRepository.setSyncFilterExcludeHack(exclude)
             _state.update {
                 it.copy(syncFilters = it.syncFilters.copy(excludeHack = exclude))
+            }
+        }
+    }
+
+    fun setExcludeUnofficial(scope: CoroutineScope, exclude: Boolean) {
+        scope.launch {
+            preferencesRepository.setSyncFilterExcludeUnofficial(exclude)
+            _state.update {
+                it.copy(syncFilters = it.syncFilters.copy(excludeUnofficial = exclude))
             }
         }
     }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/SyncSettingsSection.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/SyncSettingsSection.kt
@@ -314,6 +314,7 @@ fun SyncSettingsSection(
                 onToggleExcludePrototype = { viewModel.setExcludePrototype(it) },
                 onToggleExcludeDemo = { viewModel.setExcludeDemo(it) },
                 onToggleExcludeHack = { viewModel.setExcludeHack(it) },
+                onToggleExcludeUnofficial = { viewModel.setExcludeUnofficial(it) },
                 onToggleDeleteOrphans = { viewModel.setDeleteOrphans(it) },
                 onShowRegionPicker = { viewModel.showRegionPicker() },
                 onDismissRegionPicker = { viewModel.dismissRegionPicker() },
@@ -350,7 +351,12 @@ private fun buildFiltersSubtitle(
         if (filters.excludeBeta) context.getString(R.string.settings_sync_metadata_filters_beta) else null,
         if (filters.excludePrototype) context.getString(R.string.settings_sync_metadata_filters_prototype) else null,
         if (filters.excludeDemo) context.getString(R.string.settings_sync_metadata_filters_demo) else null,
-        if (filters.excludeHack) context.getString(R.string.settings_sync_metadata_filters_hack) else null
+        if (filters.excludeHack) context.getString(R.string.settings_sync_metadata_filters_hack) else null,
+        if (filters.excludeUnofficial) {
+            context.getString(R.string.settings_sync_metadata_filters_unofficial)
+        } else {
+            null
+        }
     )
     if (excludes.isNotEmpty()) {
         parts.add(

--- a/app/src/main/res/values-b+zh+Hans/strings_settings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings_settings.xml
@@ -272,6 +272,7 @@
     <string name="settings_sync_metadata_filters_prototype">原型</string>
     <string name="settings_sync_metadata_filters_demo">试玩</string>
     <string name="settings_sync_metadata_filters_hack">改版</string>
+    <string name="settings_sync_metadata_filters_unofficial">非授权</string>
 
     <string name="settings_sync_cache_screenshots_title">缓存截图</string>
     <string name="settings_sync_cache_screenshots_subtitle">封面和背景图始终会被缓存</string>
@@ -1674,6 +1675,8 @@
     <string name="settings_sync_filters_exclude_prototype_title">排除原型</string>
     <string name="settings_sync_filters_exclude_demo_title">排除试玩版</string>
     <string name="settings_sync_filters_exclude_hack_title">排除ROM改版</string>
+    <string name="settings_sync_filters_exclude_unofficial_title">排除非授权版本</string>
+    <string name="settings_sync_filters_exclude_unofficial_subtitle">盗版、非授权和后市场版本</string>
     <string name="settings_sync_filters_remove_orphans_title">移除孤立条目</string>
     <string name="settings_sync_filters_remove_orphans_subtitle">删除服务器上已不存在的游戏</string>
     <string name="settings_sync_filters_hint_navigate">导航</string>

--- a/app/src/main/res/values-b+zh+Hant/strings_settings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings_settings.xml
@@ -251,6 +251,7 @@
     <string name="settings_sync_metadata_filters_prototype">原型</string>
     <string name="settings_sync_metadata_filters_demo">試玩版</string>
     <string name="settings_sync_metadata_filters_hack">改版</string>
+    <string name="settings_sync_metadata_filters_unofficial">非授權</string>
 
     <string name="settings_sync_cache_screenshots_title">快取螢幕截圖</string>
     <string name="settings_sync_cache_screenshots_subtitle">封面與背景一律會快取</string>
@@ -1584,6 +1585,8 @@
     <string name="settings_sync_filters_exclude_prototype_title">排除原型</string>
     <string name="settings_sync_filters_exclude_demo_title">排除試玩版</string>
     <string name="settings_sync_filters_exclude_hack_title">排除ROM改版</string>
+    <string name="settings_sync_filters_exclude_unofficial_title">排除非授權版本</string>
+    <string name="settings_sync_filters_exclude_unofficial_subtitle">盜版、非授權和後市場版本</string>
     <string name="settings_sync_filters_remove_orphans_title">移除孤立項目</string>
     <string name="settings_sync_filters_remove_orphans_subtitle">刪除伺服器上已不存在的遊戲</string>
     <string name="settings_sync_filters_hint_navigate">瀏覽</string>

--- a/app/src/main/res/values-de/strings_settings.xml
+++ b/app/src/main/res/values-de/strings_settings.xml
@@ -290,6 +290,7 @@
     <string name="settings_sync_metadata_filters_prototype">proto</string>
     <string name="settings_sync_metadata_filters_demo">demo</string>
     <string name="settings_sync_metadata_filters_hack">hacks</string>
+    <string name="settings_sync_metadata_filters_unofficial">nicht lizenzierte</string>
 
     <string name="settings_sync_cache_screenshots_title">Screenshots zwischenspeichern</string>
     <string name="settings_sync_cache_screenshots_subtitle">Boxart und Hintergründe werden immer zwischengespeichert</string>
@@ -1724,6 +1725,8 @@
     <string name="settings_sync_filters_exclude_prototype_title">Prototyp ausschließen</string>
     <string name="settings_sync_filters_exclude_demo_title">Demo ausschließen</string>
     <string name="settings_sync_filters_exclude_hack_title">ROM-Hacks ausschließen</string>
+    <string name="settings_sync_filters_exclude_unofficial_title">Nicht lizenzierte ausschließen</string>
+    <string name="settings_sync_filters_exclude_unofficial_subtitle">Raubkopien, nicht lizenzierte und Aftermarket-Titel</string>
     <string name="settings_sync_filters_remove_orphans_title">Verwaiste Einträge entfernen</string>
     <string name="settings_sync_filters_remove_orphans_subtitle">Spiele löschen, die nicht mehr auf dem Server sind</string>
     <string name="settings_sync_filters_hint_navigate">Navigieren</string>

--- a/app/src/main/res/values-es/strings_settings.xml
+++ b/app/src/main/res/values-es/strings_settings.xml
@@ -298,6 +298,7 @@
     <string name="settings_sync_metadata_filters_prototype">proto</string>
     <string name="settings_sync_metadata_filters_demo">demo</string>
     <string name="settings_sync_metadata_filters_hack">hacks</string>
+    <string name="settings_sync_metadata_filters_unofficial">no licenciados</string>
 
     <string name="settings_sync_cache_screenshots_title">Almacenar capturas en caché</string>
     <string name="settings_sync_cache_screenshots_subtitle">Las carátulas y los fondos siempre se almacenan en caché</string>
@@ -1770,6 +1771,8 @@
     <string name="settings_sync_filters_exclude_prototype_title">Excluir prototipos</string>
     <string name="settings_sync_filters_exclude_demo_title">Excluir demos</string>
     <string name="settings_sync_filters_exclude_hack_title">Excluir ROM hacks</string>
+    <string name="settings_sync_filters_exclude_unofficial_title">Excluir no licenciados</string>
+    <string name="settings_sync_filters_exclude_unofficial_subtitle">Versiones piratas, no licenciadas y aftermarket</string>
     <string name="settings_sync_filters_remove_orphans_title">Quitar entradas huérfanas</string>
     <string name="settings_sync_filters_remove_orphans_subtitle">Eliminar juegos que ya no están en el servidor</string>
     <string name="settings_sync_filters_hint_navigate">Navegar</string>

--- a/app/src/main/res/values-fr/strings_settings.xml
+++ b/app/src/main/res/values-fr/strings_settings.xml
@@ -288,6 +288,7 @@
     <string name="settings_sync_metadata_filters_prototype">proto</string>
     <string name="settings_sync_metadata_filters_demo">demo</string>
     <string name="settings_sync_metadata_filters_hack">hacks</string>
+    <string name="settings_sync_metadata_filters_unofficial">non licenciés</string>
 
     <string name="settings_sync_cache_screenshots_title">Mettre en cache les captures d\'écran</string>
     <string name="settings_sync_cache_screenshots_subtitle">Les jaquettes et arrière-plans sont toujours mis en cache</string>
@@ -1760,6 +1761,8 @@
     <string name="settings_sync_filters_exclude_prototype_title">Exclure les prototypes</string>
     <string name="settings_sync_filters_exclude_demo_title">Exclure les démos</string>
     <string name="settings_sync_filters_exclude_hack_title">Exclure les ROM hacks</string>
+    <string name="settings_sync_filters_exclude_unofficial_title">Exclure les non licenciés</string>
+    <string name="settings_sync_filters_exclude_unofficial_subtitle">Versions pirates, non licenciées et aftermarket</string>
     <string name="settings_sync_filters_remove_orphans_title">Supprimer les entrées orphelines</string>
     <string name="settings_sync_filters_remove_orphans_subtitle">Supprimer les jeux qui ne sont plus sur le serveur</string>
     <string name="settings_sync_filters_hint_navigate">Naviguer</string>

--- a/app/src/main/res/values-hi/strings_settings.xml
+++ b/app/src/main/res/values-hi/strings_settings.xml
@@ -280,6 +280,7 @@
     <string name="settings_sync_metadata_filters_prototype">प्रोटो</string>
     <string name="settings_sync_metadata_filters_demo">डेमो</string>
     <string name="settings_sync_metadata_filters_hack">हैक्स</string>
+    <string name="settings_sync_metadata_filters_unofficial">अनलाइसेंस्ड</string>
 
     <string name="settings_sync_cache_screenshots_title">स्क्रीनशॉट कैश करें</string>
     <string name="settings_sync_cache_screenshots_subtitle">बॉक्सआर्ट और बैकग्राउंड हमेशा कैश किए जाते हैं</string>
@@ -1714,6 +1715,8 @@
     <string name="settings_sync_filters_exclude_prototype_title">प्रोटोटाइप छोड़ें</string>
     <string name="settings_sync_filters_exclude_demo_title">डेमो छोड़ें</string>
     <string name="settings_sync_filters_exclude_hack_title">ROM हैक छोड़ें</string>
+    <string name="settings_sync_filters_exclude_unofficial_title">अनलाइसेंस्ड बाहर रखें</string>
+    <string name="settings_sync_filters_exclude_unofficial_subtitle">पायरेट, अनलाइसेंस्ड और आफ्टरमार्केट रिलीज़</string>
     <string name="settings_sync_filters_remove_orphans_title">अनाथ एंट्री हटाएँ</string>
     <string name="settings_sync_filters_remove_orphans_subtitle">सर्वर पर अब न मौजूद गेम हटाएँ</string>
     <string name="settings_sync_filters_hint_navigate">नेविगेट करें</string>

--- a/app/src/main/res/values-ru/strings_settings.xml
+++ b/app/src/main/res/values-ru/strings_settings.xml
@@ -295,6 +295,7 @@
     <string name="settings_sync_metadata_filters_prototype">прото</string>
     <string name="settings_sync_metadata_filters_demo">демо</string>
     <string name="settings_sync_metadata_filters_hack">хаки</string>
+    <string name="settings_sync_metadata_filters_unofficial">нелицензионные</string>
 
     <string name="settings_sync_cache_screenshots_title">Кэшировать скриншоты</string>
     <string name="settings_sync_cache_screenshots_subtitle">Обложки и фоны кэшируются всегда</string>
@@ -1803,6 +1804,8 @@
     <string name="settings_sync_filters_exclude_prototype_title">Исключить прототипы</string>
     <string name="settings_sync_filters_exclude_demo_title">Исключить демо</string>
     <string name="settings_sync_filters_exclude_hack_title">Исключить ROM-хаки</string>
+    <string name="settings_sync_filters_exclude_unofficial_title">Исключить нелицензионные</string>
+    <string name="settings_sync_filters_exclude_unofficial_subtitle">Пиратские, нелицензионные и aftermarket-издания</string>
     <string name="settings_sync_filters_remove_orphans_title">Удалять осиротевшие записи</string>
     <string name="settings_sync_filters_remove_orphans_subtitle">Удалять игры, которых больше нет на сервере</string>
     <string name="settings_sync_filters_hint_navigate">Навигация</string>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -545,6 +545,7 @@
     <string name="settings_sync_metadata_filters_demo">demo</string>
     <!-- Short word, plural, for fan-modified versions of a game. Lower case. -->
     <string name="settings_sync_metadata_filters_hack">hacks</string>
+    <string name="settings_sync_metadata_filters_unofficial">unlicensed</string>
 
     <!-- Row title. Verb phrase: keep copies of the in-game pictures on this device. -->
     <string name="settings_sync_cache_screenshots_title">Cache Screenshots</string>
@@ -3258,6 +3259,8 @@
     <string name="settings_sync_filters_exclude_demo_title">Exclude Demo</string>
     <!-- Row title. Verb phrase: skip ROM hack games during sync. -->
     <string name="settings_sync_filters_exclude_hack_title">Exclude ROM Hacks</string>
+    <string name="settings_sync_filters_exclude_unofficial_title">Exclude Unlicensed</string>
+    <string name="settings_sync_filters_exclude_unofficial_subtitle">Pirate, unlicensed and aftermarket releases</string>
     <!-- Row title. Verb phrase: delete local games the server no longer has. -->
     <string name="settings_sync_filters_remove_orphans_title">Remove Orphaned Entries</string>
     <!-- Second line of that row. -->

--- a/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/CollectionAbsorbedRomTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/CollectionAbsorbedRomTest.kt
@@ -1,0 +1,71 @@
+package com.nendo.argosy.data.remote.romm
+
+import com.nendo.argosy.data.local.dao.GameDao
+import com.nendo.argosy.data.local.dao.GameFileDao
+import com.nendo.argosy.data.local.entity.GameEntity
+import com.nendo.argosy.data.model.VersionGroups
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * A collection names the rom ids the server holds, but sibling consolidation keeps one row per
+ * group. Resolving a collection entry only by rom id loses every absorbed member, which drops
+ * the game from the collection even though its files are in the library.
+ */
+class CollectionAbsorbedRomTest {
+
+    private lateinit var gameDao: GameDao
+    private lateinit var gameFileDao: GameFileDao
+    private lateinit var service: RomMCollectionSyncService
+
+    @Before
+    fun setup() {
+        gameDao = mockk(relaxed = true)
+        gameFileDao = mockk(relaxed = true)
+        service = RomMCollectionSyncService(
+            connectionManager = mockk(relaxed = true),
+            userPreferencesRepository = mockk(relaxed = true),
+            gameDao = gameDao,
+            gameFileDao = gameFileDao,
+            collectionDao = mockk(relaxed = true),
+            collectionMembershipDao = mockk(relaxed = true),
+            overlayWriter = mockk(relaxed = true),
+            syncCoordinator = mockk(relaxed = true)
+        )
+    }
+
+    @Test
+    fun `a rom with its own row resolves directly`() = runBlocking {
+        coEvery { gameDao.getByRommId(535L) } returns gameRow(id = 90L)
+
+        assertEquals(90L, service.resolveCollectionGameId(535L))
+    }
+
+    @Test
+    fun `an absorbed rom resolves to the game that swallowed it`() = runBlocking {
+        coEvery { gameDao.getByRommId(536L) } returns null
+        coEvery {
+            gameFileDao.getGameIdForVersionGroup(VersionGroups.groupKey(536L))
+        } returns 90L
+
+        assertEquals(90L, service.resolveCollectionGameId(536L))
+    }
+
+    @Test
+    fun `a rom that is genuinely absent stays unresolved`() = runBlocking {
+        coEvery { gameDao.getByRommId(999L) } returns null
+        coEvery { gameFileDao.getGameIdForVersionGroup(any()) } returns null
+
+        assertNull(service.resolveCollectionGameId(999L))
+    }
+
+    private fun gameRow(id: Long): GameEntity = mockk(relaxed = true) {
+        every { this@mockk.id } returns id
+    }
+}

--- a/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/RomMSyncFilterVariantTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/RomMSyncFilterVariantTest.kt
@@ -1,0 +1,169 @@
+package com.nendo.argosy.data.remote.romm
+
+import com.nendo.argosy.data.preferences.SyncFilterPreferences
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Variant exclusions read a rom's release tags from the tag list, the revision and the file
+ * name, because a rom matched against metadata carries a clean title that holds none of them.
+ * Debug builds ride with prototypes, both being unreleased internal builds, while pirate,
+ * unlicensed and aftermarket carts are originals rather than modified dumps and get their own
+ * switch.
+ */
+class RomMSyncFilterVariantTest {
+
+    private fun rom(
+        fsName: String,
+        name: String = "Clean IGDB Title",
+        revision: String? = null,
+        tags: List<String>? = null
+    ) = RomMRom(
+        id = 1L,
+        name = name,
+        fileName = "$fsName.zip",
+        filePath = "/roms/gba/$fsName.zip",
+        platformId = 1L,
+        platformSlug = "gba",
+        slug = "rom",
+        igdbId = null,
+        mobyId = null,
+        summary = null,
+        coverSmall = null,
+        coverLarge = null,
+        regions = null,
+        languages = null,
+        revision = revision,
+        tags = tags
+    )
+
+    private val prototypeOnly = SyncFilterPreferences(
+        excludeBeta = false,
+        excludePrototype = true,
+        excludeDemo = false
+    )
+
+    private val unofficialOnly = SyncFilterPreferences(
+        excludeBeta = false,
+        excludePrototype = false,
+        excludeDemo = false,
+        excludeUnofficial = true
+    )
+
+    private val nothingExcluded = SyncFilterPreferences(
+        excludeBeta = false,
+        excludePrototype = false,
+        excludeDemo = false
+    )
+
+    @Test
+    fun `debug builds are excluded by the prototype filter`() {
+        val debug = rom(
+            "Pokemon - Rubin-Edition (Germany) (Debug Version)",
+            name = "Pokemon Ruby Version",
+            tags = listOf("Debug Version")
+        )
+
+        assertFalse(RomMSyncFilter.shouldSyncRom(debug, prototypeOnly))
+        assertTrue(RomMSyncFilter.shouldSyncRom(debug, nothingExcluded))
+    }
+
+    /**
+     * A rom RomM matched against metadata carries the clean IGDB title, so every release tag
+     * lives in the tag list and the file name. Reading the title alone matched nothing.
+     */
+    @Test
+    fun `variant tags are read when the title is the clean igdb one`() {
+        val cases = mapOf(
+            "'98 Koushien (Japan) (Demo)" to listOf("Demo"),
+            "Findet Nemo (Germany) (Beta)" to listOf("Beta"),
+            "GP-1 Racing (USA) (Proto)" to listOf("Proto"),
+            "ASO - Armored Scrum Object (Japan) (En) (Sample)" to listOf("Sample")
+        )
+
+        cases.forEach { (fsName, tags) ->
+            val excluded = rom(fsName, name = "Clean IGDB Title", tags = tags)
+            assertFalse(fsName, RomMSyncFilter.shouldSyncRom(excluded, SyncFilterPreferences()))
+        }
+    }
+
+    @Test
+    fun `numbered variant tags still match`() {
+        val beta2 = rom("Some Game (USA) (Beta 2)", tags = listOf("Beta 2"))
+        val proto1 = rom("Some Game (USA) (Proto 1)", tags = listOf("Proto 1"))
+
+        assertFalse(RomMSyncFilter.shouldSyncRom(beta2, SyncFilterPreferences()))
+        assertFalse(RomMSyncFilter.shouldSyncRom(proto1, SyncFilterPreferences()))
+    }
+
+    @Test
+    fun `prototypes still match after debug was folded in`() {
+        assertFalse(
+            RomMSyncFilter.shouldSyncRom(rom("Some Game (USA) (Proto)", tags = listOf("Proto")), prototypeOnly)
+        )
+        assertFalse(RomMSyncFilter.shouldSyncRom(rom("Some Game", revision = "proto"), prototypeOnly))
+    }
+
+    @Test
+    fun `pirate unlicensed and aftermarket are excluded together`() {
+        val names = listOf(
+            "Pokemon - Leaf Green (USA) (Pirate)",
+            "Some Game (Taiwan) (Unl)",
+            "Some Game (USA) (Unlicensed)",
+            "Some Game (USA) (Aftermarket)"
+        )
+
+        names.forEach { name ->
+            assertFalse(name, RomMSyncFilter.shouldSyncRom(rom(name), unofficialOnly))
+            assertTrue(name, RomMSyncFilter.shouldSyncRom(rom(name), nothingExcluded))
+        }
+        val tagged = rom(
+            "Pokemon - Leaf Green (USA) (Pirate)",
+            name = "Pokemon LeafGreen Version",
+            tags = listOf("Pirate")
+        )
+        assertFalse(RomMSyncFilter.shouldSyncRom(tagged, unofficialOnly))
+    }
+
+    @Test
+    fun `unofficial is read from revision and tags as well as the name`() {
+        assertFalse(RomMSyncFilter.shouldSyncRom(rom("Some Game", revision = "pirate"), unofficialOnly))
+        assertFalse(
+            RomMSyncFilter.shouldSyncRom(rom("Some Game", tags = listOf("aftermarket")), unofficialOnly)
+        )
+    }
+
+    @Test
+    fun `an ordinary release is untouched by either filter`() {
+        val ordinary = rom("Mario Party 2 (Europe) (En,Fr,De,Es,It)", name = "Mario Party 2")
+
+        assertTrue(RomMSyncFilter.shouldSyncRom(ordinary, prototypeOnly))
+        assertTrue(RomMSyncFilter.shouldSyncRom(ordinary, unofficialOnly))
+        assertTrue(RomMSyncFilter.shouldSyncRom(ordinary, SyncFilterPreferences()))
+    }
+
+    @Test
+    fun `a german release with a hardware tag is untouched`() {
+        val pokemon = rom(
+            "Pokemon - Rote Edition (Germany) (SGB Enhanced)",
+            name = "Pokemon Red Version",
+            tags = listOf("SGB Enhanced")
+        )
+
+        assertTrue(RomMSyncFilter.shouldSyncRom(pokemon, prototypeOnly))
+        assertTrue(RomMSyncFilter.shouldSyncRom(pokemon, unofficialOnly))
+        assertTrue(RomMSyncFilter.shouldSyncRom(pokemon, SyncFilterPreferences()))
+    }
+
+    @Test
+    fun `unofficial stays off by default so aftermarket carts keep syncing`() {
+        assertFalse(SyncFilterPreferences().excludeUnofficial)
+        assertTrue(
+            RomMSyncFilter.shouldSyncRom(
+                rom("Some Game (USA) (Aftermarket)", tags = listOf("Aftermarket")),
+                SyncFilterPreferences()
+            )
+        )
+    }
+}

--- a/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/SiblingWinnerTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/SiblingWinnerTest.kt
@@ -208,4 +208,88 @@ class SiblingWinnerTest {
         assertFalse(rom(3, "Europe", tags = listOf("SGB Enhanced")).isRerelease)
         assertFalse(rom(4, "Europe").isRerelease)
     }
+
+    /**
+     * Two groups form when sibling lists disagree about the set, and merging must re-run the
+     * pick. Keeping the group that formed first hands the release to page order: the German
+     * dump wins when its id sorts lower and loses when it does not.
+     */
+    @Test
+    fun `merging two groups re-runs the pick instead of keeping the first winner`() {
+        val usaFirst = SiblingGroup()
+        usaFirst.winner = rom(3644, "USA", "Europe")
+        val german = rom(3645, "Germany")
+
+        val merged = chooseWinner(usaFirst, german, priorityFilters)
+
+        assertEquals(3645L, merged?.id)
+    }
+
+    @Test
+    fun `merging is symmetric whichever group formed first`() {
+        val germanFirst = SiblingGroup()
+        germanFirst.winner = rom(3645, "Germany")
+
+        val merged = chooseWinner(germanFirst, rom(3644, "USA", "Europe"), priorityFilters)
+
+        assertEquals(3645L, merged?.id)
+    }
+
+    private fun groupOf(winner: RomMRom, vararg expected: Long) = SiblingGroup().apply {
+        this.winner = winner
+        members.add(SiblingMember(winner.id, winner.regions, winner.files))
+        expectedIds.addAll(expected.toList())
+    }
+
+    /**
+     * The German dump of Pokemon Red sorts after the USA one, so its group formed second and the
+     * merge discarded it. The English dump of Blue sorts after the German one, which is the only
+     * reason Blue survived the same code path.
+     */
+    @Test
+    fun `merging keeps the better ranked region whichever group formed first`() {
+        val usaFirst = mergeSiblingGroups(
+            listOf(
+                groupOf(rom(3644, "USA", "Europe"), 3644L, 3645L),
+                groupOf(rom(3645, "Germany"), 3644L, 3645L)
+            ),
+            priorityFilters
+        )
+        val germanFirst = mergeSiblingGroups(
+            listOf(
+                groupOf(rom(3636, "Germany"), 3636L, 3638L),
+                groupOf(rom(3638, "USA", "Europe"), 3636L, 3638L)
+            ),
+            priorityFilters
+        )
+
+        assertEquals(3645L, usaFirst.winner?.id)
+        assertEquals(3636L, germanFirst.winner?.id)
+    }
+
+    @Test
+    fun `merging carries every member and expected id across`() {
+        val merged = mergeSiblingGroups(
+            listOf(
+                groupOf(rom(3644, "USA", "Europe"), 3644L, 3645L),
+                groupOf(rom(3645, "Germany"), 3645L, 3651L)
+            ),
+            priorityFilters
+        )
+
+        assertEquals(setOf(3644L, 3645L, 3651L), merged.expectedIds)
+        assertEquals(setOf(3644L, 3645L), merged.members.map { it.id }.toSet())
+    }
+
+    @Test
+    fun `merging a single group leaves its winner alone`() {
+        val only = groupOf(rom(3645, "Germany"), 3645L)
+
+        assertEquals(3645L, mergeSiblingGroups(listOf(only), priorityFilters).winner?.id)
+    }
+
+    @Test
+    fun `merging nothing yields an empty group`() {
+        assertEquals(null, mergeSiblingGroups(emptyList(), priorityFilters).winner)
+    }
 }

--- a/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/SiblingWinnerTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/SiblingWinnerTest.kt
@@ -3,6 +3,8 @@ package com.nendo.argosy.data.remote.romm
 import com.nendo.argosy.data.preferences.RegionFilterMode
 import com.nendo.argosy.data.preferences.SyncFilterPreferences
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -16,7 +18,7 @@ class SiblingWinnerTest {
         enabledRegions = listOf("USA", "Europe", "Japan")
     )
 
-    private fun rom(id: Long, vararg regions: String) = RomMRom(
+    private fun rom(id: Long, vararg regions: String, tags: List<String>? = null) = RomMRom(
         id = id,
         name = "rom$id",
         fileName = "rom$id.nes",
@@ -31,7 +33,8 @@ class SiblingWinnerTest {
         coverLarge = null,
         regions = regions.toList(),
         languages = null,
-        revision = null
+        revision = null,
+        tags = tags
     )
 
     private fun feed(group: SiblingGroup, roms: List<RomMRom>): RomMRom? {
@@ -161,5 +164,48 @@ class SiblingWinnerTest {
         val winner = feedWith(group, listOf(rom(1, "USA"), rom(2, "Europe")), filters)
 
         assertEquals(1L, winner?.id)
+    }
+
+    @Test
+    fun `an original release beats a re-release of the same region`() {
+        val forward = feedWith(
+            SiblingGroup(),
+            listOf(
+                rom(535, "Europe", tags = listOf("Wii Virtual Console")),
+                rom(536, "Europe")
+            ),
+            priorityFilters
+        )
+        val reverse = feedWith(
+            SiblingGroup(),
+            listOf(
+                rom(536, "Europe"),
+                rom(535, "Europe", tags = listOf("Wii Virtual Console"))
+            ),
+            priorityFilters
+        )
+
+        assertEquals(536L, forward?.id)
+        assertEquals(536L, reverse?.id)
+    }
+
+    @Test
+    fun `a better region still beats an original release`() {
+        val group = SiblingGroup()
+        val winner = feedWith(
+            group,
+            listOf(rom(1, "USA"), rom(2, "Germany", tags = listOf("Switch Online"))),
+            priorityFilters
+        )
+
+        assertEquals(2L, winner?.id)
+    }
+
+    @Test
+    fun `re-release markers are read from the tag list`() {
+        assertTrue(rom(1, "Europe", tags = listOf("Wii U Virtual Console")).isRerelease)
+        assertTrue(rom(2, "Europe", tags = listOf("Classic Mini")).isRerelease)
+        assertFalse(rom(3, "Europe", tags = listOf("SGB Enhanced")).isRerelease)
+        assertFalse(rom(4, "Europe").isRerelease)
     }
 }

--- a/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/SiblingWinnerTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/SiblingWinnerTest.kt
@@ -1,5 +1,6 @@
 package com.nendo.argosy.data.remote.romm
 
+import com.nendo.argosy.data.preferences.RegionFilterMode
 import com.nendo.argosy.data.preferences.SyncFilterPreferences
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -105,5 +106,60 @@ class SiblingWinnerTest {
         val winner = feed(group, listOf(rom(4, "Brazil"), rom(5, "Korea")))
 
         assertEquals(4L, winner?.id)
+    }
+
+    private val priorityFilters = SyncFilterPreferences(
+        enabledRegions = listOf("Germany", "Europe", "World", "USA"),
+        regionMode = RegionFilterMode.INCLUDE
+    )
+
+    private fun feedWith(
+        group: SiblingGroup,
+        roms: List<RomMRom>,
+        with: SyncFilterPreferences
+    ): RomMRom? {
+        roms.forEach { candidate ->
+            group.members.add(SiblingMember(candidate.id, candidate.regions, candidate.files))
+            group.winner = chooseWinner(group, candidate, with)
+        }
+        return group.winner
+    }
+
+    @Test
+    fun `an ordered region priority beats a declared main sibling`() {
+        val group = SiblingGroup()
+        group.mainSiblingId = 1L
+        val winner = feedWith(group, listOf(rom(1, "USA"), rom(2, "Europe")), priorityFilters)
+
+        assertEquals(2L, winner?.id)
+    }
+
+    @Test
+    fun `region priority wins whichever order the members arrive in`() {
+        val forward = SiblingGroup().also { it.mainSiblingId = 1L }
+        val reverse = SiblingGroup().also { it.mainSiblingId = 1L }
+        val first = feedWith(forward, listOf(rom(1, "USA"), rom(2, "Germany")), priorityFilters)
+        val second = feedWith(reverse, listOf(rom(2, "Germany"), rom(1, "USA")), priorityFilters)
+
+        assertEquals(2L, first?.id)
+        assertEquals(2L, second?.id)
+    }
+
+    @Test
+    fun `the main sibling still breaks a tie between equally ranked regions`() {
+        val group = SiblingGroup()
+        group.mainSiblingId = 2L
+        val winner = feedWith(group, listOf(rom(1, "Europe"), rom(2, "Europe")), priorityFilters)
+
+        assertEquals(2L, winner?.id)
+    }
+
+    @Test
+    fun `an exclude list carries no priority so the main sibling still wins`() {
+        val group = SiblingGroup()
+        group.mainSiblingId = 1L
+        val winner = feedWith(group, listOf(rom(1, "USA"), rom(2, "Europe")), filters)
+
+        assertEquals(1L, winner?.id)
     }
 }


### PR DESCRIPTION
## Summary

My filters include regions in priority order, Germany first, then Europe, World and USA, with Beta, Prototype, Demo and ROM Hacks excluded and orphan removal on.

Two roms I expected never showed up: `Pokemon - Rote Edition (Germany) (SGB Enhanced)` and `Mario Party 2 (Europe) (En,Fr,De,Es,It)`. Blue and Yellow were fine and only Red was gone, which turned out to be the useful clue.

`groupFor` merges two sibling groups when the sibling lists disagree about the set, and the merge kept the winner of whichever group formed first instead of running `chooseWinner` again. Roms page in by id, so the German dump won for Blue (3636 before 3638) and lost for Red (3644 before 3645). Pure ordering luck. Merging re-runs the pick now.

Mario Party 2 has two Europe dumps at the same rank, and the tie went to whoever arrived first, so the Wii Virtual Console dump won and the plain one was absorbed as a hidden version. At equal region rank an original release now beats a re-release, read from the tag list (`Virtual Console`, `Switch Online`, `Classic Mini`, `GameCube`).

Collections lost the same games twice over. `syncCollectionGames` resolved rom ids with `gameDao.getByRommId`, which returns nothing for an absorbed sibling, so the membership absorption had just repointed onto the winner was deleted again as stale. It falls back to the version group now.

The variant filters were matching against the wrong field entirely. `passesRevisionFilter` looked for `(demo)`, `(beta)` and `(proto)` in `rom.name`, but that is the clean IGDB title. RomM keeps release tags in `tags` and `fs_name`, so those filters hit almost nothing for any rom with metadata. Reading all three fields, on my library the beta filter goes from 35 to 201 matches, prototype from 58 to 203 and demo from 88 to 254.

Debug builds ride with Prototype now, both being unreleased internal builds. `Pokemon - Rubin-Edition (Germany) (Debug Version)` was passing before.

There is also a new Exclude Unlicensed switch for `(Pirate)`, `(Unl)`, `(Unlicensed)` and `(Aftermarket)`. It is off by default and kept separate from ROM Hacks, because unlicensed and aftermarket carts are original games rather than modified dumps and folding them into hacks would take homebrew with them.

While in the sibling code I also made an explicit region priority outrank the server's `is_main_sibling` flag. My server does not set it so nothing changes here, but a declared main sibling was overriding the priority outright.

## Behavior changes

Regional releases the priority ranks best win their sibling group regardless of the order the server pages roms in.

Collections keep games whose rom was absorbed into a sibling.

An original release beats a re-release at equal region rank.

Beta, Prototype and Demo actually filter now. Expect noticeably more roms to drop out than before, since they were matching close to nothing.

Debug builds are excluded by the Prototype filter, and there is a new Exclude Unlicensed filter, off by default.

## Hot paths

No. This runs in the library sync, already off main, and adds no I/O. The collection fallback is one indexed lookup on `game_files`, and only for a rom id with no row of its own.

## Testing evidence

`SiblingWinnerTest` covers the merge in both id orderings, priority against a declared main sibling, the re-release tie break and members carrying across a merge. `RomMSyncFilterVariantTest` covers the tag fields, numbered tags like `Beta 2`, and both roms above as negative controls that have to keep syncing. `CollectionAbsorbedRomTest` covers an absorbed rom resolving to the game that swallowed it.

The suite passes.

I also replayed the sync against my own RomM instance with a read only API key, using the same paged query the app makes, and confirmed the merge picked the wrong dump for Red and the right one for Blue.

Not run on hardware yet.

## AI assistance

I used Claude Code to trace the sync path and find the bugs against my own RomM instance. I verified everything afterwards, including the diff and the API traces.

## Checklist

- [ ] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
