### PR TITLE
fix(sync, downloads): keep cross-linked games apart and decompress nsz sections past 2 GiB

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/NczWriter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/NczWriter.kt
@@ -152,13 +152,11 @@ object NczWriter {
 
             val chunkSize = if (section != null) {
                 val sectionEnd = section.offset + section.size
-                val bytesToSectionEnd = (sectionEnd - pos).toInt()
-                minOf(remaining, bytesToSectionEnd)
+                minOf(remaining.toLong(), sectionEnd - pos).toInt()
             } else {
                 val nextSection = findNextSection(sections, pos)
                 if (nextSection != null) {
-                    val bytesToNext = (nextSection.offset - pos).toInt()
-                    minOf(remaining, bytesToNext)
+                    minOf(remaining.toLong(), nextSection.offset - pos).toInt()
                 } else {
                     remaining
                 }

--- a/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMLibrarySyncService.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMLibrarySyncService.kt
@@ -959,7 +959,7 @@ class RomMLibrarySyncService @Inject constructor(
 
         fun groupFor(rom: RomMRom): SiblingGroup {
             val ids = listOf(rom.id) +
-                rom.effectiveSiblings.filter { !it.isDiscVariant }.map { it.id }
+                rom.sameGameSiblings.filter { !it.isDiscVariant }.map { it.id }
             val existingGroups = ids.mapNotNull { siblingGroups[it] }.distinct()
             val group = mergeSiblingGroups(existingGroups, filters)
             group.expectedIds.addAll(ids)
@@ -970,7 +970,7 @@ class RomMLibrarySyncService @Inject constructor(
         fun trackSiblingMultiDisc(rom: RomMRom) {
             val isSiblingBasedMultiDisc = rom.hasDiscSiblings && !rom.isFolderMultiDisc
             if (isSiblingBasedMultiDisc && rom.id !in processedDiscIds) {
-                val discSiblings = rom.effectiveSiblings.filter { it.isDiscVariant }
+                val discSiblings = rom.sameGameSiblings.filter { it.isDiscVariant }
                 val siblingIds = discSiblings.map { it.id }
 
                 processedDiscIds.add(rom.id)
@@ -1024,7 +1024,7 @@ class RomMLibrarySyncService @Inject constructor(
                 }
 
                 if (rom.isFolderMultiDisc) {
-                    val discSiblings = rom.effectiveSiblings.filter { it.isDiscVariant }
+                    val discSiblings = rom.sameGameSiblings.filter { it.isDiscVariant }
                     if (discSiblings.isNotEmpty()) {
                         val siblingIds = discSiblings.map { it.id }
                         skipIndividualDiscIds.addAll(siblingIds)
@@ -1044,7 +1044,7 @@ class RomMLibrarySyncService @Inject constructor(
                 if (rom.hasNonDiscSiblings) {
                     val group = groupFor(rom)
                     group.members.add(SiblingMember(rom.id, rom.regions, rom.files))
-                    rom.effectiveSiblings
+                    rom.sameGameSiblings
                         .firstOrNull { !it.isDiscVariant && it.isMainSibling == true }
                         ?.let { group.mainSiblingId = it.id }
                     group.winner = chooseWinner(group, rom, filters)

--- a/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMModels.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMModels.kt
@@ -95,6 +95,18 @@ data class RomMRom(
     @Json(name = "is_identified") val isIdentified: Boolean = true
 ) {
     val effectiveSiblings: List<RomMSibling> get() = siblingRoms ?: siblings ?: emptyList()
+
+    /**
+     * Siblings that are the same game as this rom. The server's sibling list is the union
+     * over every metadata source, and a source that files two games under one entry (Moby
+     * keeps one page for Pokemon Red and Blue) cross-links roms whose primary metadata
+     * disagrees. Grouping follows sibling links transitively, so one such link folds two
+     * games into a single library entry. The display name is the primary metadata identity,
+     * so a sibling carrying a different one is a different game; a sibling without a name is
+     * kept, having nothing to disagree with.
+     */
+    val sameGameSiblings: List<RomMSibling>
+        get() = effectiveSiblings.filter { it.name == null || it.name.equals(name, ignoreCase = true) }
     val genres: List<String>? get() = metadatum?.genres
     val companies: List<String>? get() = metadatum?.companies
     val firstReleaseDateMillis: Long? get() = metadatum?.firstReleaseDate
@@ -128,12 +140,12 @@ data class RomMRom(
         get() = hasMultipleFiles && files?.any { it.isDiscVariant } == true
 
     val hasDiscSiblings: Boolean
-        get() = isFolderMultiDisc || (isDiscVariant && effectiveSiblings.any { sibling ->
+        get() = isFolderMultiDisc || (isDiscVariant && sameGameSiblings.any { sibling ->
             sibling.fileNameNoExt.contains(DISC_TAG_REGEX)
         })
 
     val hasNonDiscSiblings: Boolean
-        get() = effectiveSiblings.any { !it.isDiscVariant }
+        get() = sameGameSiblings.any { !it.isDiscVariant }
 
     companion object {
         private val DISC_TAG_REGEX = Regex("Disc \\d+", RegexOption.IGNORE_CASE)

--- a/app/src/test/kotlin/com/nendo/argosy/data/download/nsz/NszRoundTripTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/download/nsz/NszRoundTripTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
 import java.nio.ByteBuffer
@@ -187,6 +188,72 @@ class NszRoundTripTest {
                 "got $error",
             error is IOException
         )
+    }
+
+    /**
+     * A retail game's CTR section routinely spans more than 2 GiB. The chunk clamp used to
+     * route `sectionEnd - pos` through Int, which wraps negative for such a section and feeds
+     * Cipher.update a negative length, failing every dump with a section past Int.MAX_VALUE
+     * with "Bad arguments". The clamp has to stay in Long until after the min.
+     */
+    @Test
+    fun `a section larger than 2 GiB re-encrypts instead of overflowing`() {
+        val plaintext = ByteArray(0x10000) { (it * 31 + 7).toByte() }
+        val header = NczHeaderData(
+            sections = listOf(
+                NczSection(
+                    offset = NCA_HEADER,
+                    size = 0x1_8000_0000L,
+                    cryptoType = 3L,
+                    padding = 0L,
+                    cryptoKey = CRYPTO_KEY,
+                    cryptoCounter = CRYPTO_COUNTER
+                )
+            ),
+            blockHeader = null,
+            payloadOffsetInEntry = 0L
+        )
+        val output = ByteArrayOutputStream()
+
+        NczWriter.decompress(
+            input = zstd(plaintext).inputStream(),
+            output = output,
+            header = header,
+            totalDecompressedSize = plaintext.size.toLong(),
+            onProgress = null
+        )
+
+        assertArrayEquals(encryptCtr(NCA_HEADER, plaintext), output.toByteArray())
+    }
+
+    @Test
+    fun `a gap running past 2 GiB to the next section passes through verbatim`() {
+        val plaintext = ByteArray(0x10000) { (it * 3 + 1).toByte() }
+        val header = NczHeaderData(
+            sections = listOf(
+                NczSection(
+                    offset = NCA_HEADER + 0x1_8000_0000L,
+                    size = 0x1000L,
+                    cryptoType = 3L,
+                    padding = 0L,
+                    cryptoKey = CRYPTO_KEY,
+                    cryptoCounter = CRYPTO_COUNTER
+                )
+            ),
+            blockHeader = null,
+            payloadOffsetInEntry = 0L
+        )
+        val output = ByteArrayOutputStream()
+
+        NczWriter.decompress(
+            input = zstd(plaintext).inputStream(),
+            output = output,
+            header = header,
+            totalDecompressedSize = plaintext.size.toLong(),
+            onProgress = null
+        )
+
+        assertArrayEquals(plaintext, output.toByteArray())
     }
 
     private fun indexOfMagic(bytes: ByteArray, magic: String): Int {

--- a/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/SiblingWinnerTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/SiblingWinnerTest.kt
@@ -293,7 +293,12 @@ class SiblingWinnerTest {
         assertEquals(null, mergeSiblingGroups(emptyList(), priorityFilters).winner)
     }
 
-    private fun namedRom(id: Long, name: String, vararg siblings: RomMSibling) = RomMRom(
+    private fun namedRom(
+        id: Long,
+        name: String,
+        vararg siblings: RomMSibling,
+        tags: List<String>? = null
+    ) = RomMRom(
         id = id,
         name = name,
         fileName = "rom$id.gb",
@@ -309,15 +314,15 @@ class SiblingWinnerTest {
         regions = listOf("Germany"),
         languages = null,
         revision = null,
-        tags = null,
+        tags = tags,
         siblingRoms = siblings.toList()
     )
 
-    private fun sibling(id: Long, name: String?) = RomMSibling(
+    private fun sibling(id: Long, name: String?, fileNameNoExt: String = "rom$id") = RomMSibling(
         id = id,
         name = name,
         fileNameNoTags = "rom$id",
-        fileNameNoExt = "rom$id"
+        fileNameNoExt = fileNameNoExt
     )
 
     /**
@@ -356,5 +361,26 @@ class SiblingWinnerTest {
         )
 
         assertEquals(listOf(3644L), rom.sameGameSiblings.map { it.id })
+    }
+
+    /**
+     * The disc paths delete redundant individual-disc games, so a cross-game sibling that
+     * happens to carry a disc tag must not pull another game into a multi-disc group.
+     */
+    @Test
+    fun `a disc tagged sibling of a different game does not make a multi-disc group`() {
+        val disc = namedRom(
+            10, "Some RPG",
+            sibling(11, "Another RPG", fileNameNoExt = "Another RPG (Disc 2)"),
+            tags = listOf("Disc 1")
+        )
+        val sameGame = namedRom(
+            10, "Some RPG",
+            sibling(11, "Some RPG", fileNameNoExt = "Some RPG (Disc 2)"),
+            tags = listOf("Disc 1")
+        )
+
+        assertFalse(disc.hasDiscSiblings)
+        assertTrue(sameGame.hasDiscSiblings)
     }
 }

--- a/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/SiblingWinnerTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/SiblingWinnerTest.kt
@@ -292,4 +292,69 @@ class SiblingWinnerTest {
     fun `merging nothing yields an empty group`() {
         assertEquals(null, mergeSiblingGroups(emptyList(), priorityFilters).winner)
     }
+
+    private fun namedRom(id: Long, name: String, vararg siblings: RomMSibling) = RomMRom(
+        id = id,
+        name = name,
+        fileName = "rom$id.gb",
+        filePath = "/roms/gb/rom$id.gb",
+        platformId = 5L,
+        platformSlug = "gb",
+        slug = "rom$id",
+        igdbId = null,
+        mobyId = null,
+        summary = null,
+        coverSmall = null,
+        coverLarge = null,
+        regions = listOf("Germany"),
+        languages = null,
+        revision = null,
+        tags = null,
+        siblingRoms = siblings.toList()
+    )
+
+    private fun sibling(id: Long, name: String?) = RomMSibling(
+        id = id,
+        name = name,
+        fileNameNoTags = "rom$id",
+        fileNameNoExt = "rom$id"
+    )
+
+    /**
+     * The server's sibling list is the union over every metadata source, and Moby files
+     * Pokemon Red and Blue under one entry, so the USA dumps of both list each other. That
+     * single link chains the two games into one group and the loser's every regional dump is
+     * absorbed under the winner. A sibling naming a different game must not join the group.
+     */
+    @Test
+    fun `a sibling naming a different game stays out of the group`() {
+        val blue = namedRom(
+            3638, "Pokémon Blue Version",
+            sibling(3636, "Pokémon Blue Version"),
+            sibling(3644, "Pokémon Red Version")
+        )
+
+        assertEquals(listOf(3636L), blue.sameGameSiblings.map { it.id })
+        assertTrue(blue.hasNonDiscSiblings)
+    }
+
+    @Test
+    fun `a rom whose only sibling is a different game consolidates alone`() {
+        val homebrew = namedRom(
+            2989, "Into the Blue",
+            sibling(3636, "Pokémon Blue Version")
+        )
+
+        assertFalse(homebrew.hasNonDiscSiblings)
+    }
+
+    @Test
+    fun `a sibling without a name is kept in the group`() {
+        val rom = namedRom(
+            3645, "Pokémon Red Version",
+            sibling(3644, null)
+        )
+
+        assertEquals(listOf(3644L), rom.sameGameSiblings.map { it.id })
+    }
 }


### PR DESCRIPTION
## Summary

Two leftovers from #391 and #392, found on 2.11.0 on my AYN Thor: the German dump of `Pokemon Red` (`Pokemon - Rote Edition (Germany) (SGB Enhanced)`) never appeared, and NSZ downloads traded "unknown frame descriptor" for "NSZ decompression failed: bad argument".

RomM builds sibling lists as the union over every metadata source, and a source that files two games under one entry cross-links them: Moby keeps one page for `Pokemon Red` and `Pokemon Blue`, so `Pokemon - Blue Version (USA, Europe)` (3638) and `Pokemon - Red Version (USA, Europe)` (3644) list each other despite different igdb ids (1511 vs 1561). `groupFor` follows sibling links transitively, so that one link chained both games into one group. Germany-first priority made `Pokemon - Blaue Edition` win it, and every `Pokemon Red` dump was absorbed as a hidden version of `Pokemon Blue`.

The sibling projection carries no metadata ids, so the display name is the signal: a group now only follows siblings whose `name` matches the rom's own (`sameGameSiblings`), nameless siblings kept. The disc paths use it too, since those delete redundant individual-disc games and a cross-game link there would delete another game's rows. Tradeoff: a same-game pair matched under two names, like `Hyper Dunk (Europe)` and `Double Dribble: 5 on 5` (both igdb 48952), now shows as two entries. A visible duplicate beats a swallowed game.

The NSZ error was mine, from #391. `processAndWrite` clamped chunks with `(sectionEnd - pos).toInt()`, which wraps once a CTR section passes 2 GiB, and `Cipher.update` rejects the wrapped length with exactly `IllegalArgumentException("Bad arguments")`. Every retail dump has such a section; all my fixtures were smaller. The clamp stays in Long now.

## Behavior changes

A rom cross-linked to a different game keeps its own library entry.

Same-game releases matched under different display names appear as two entries.

NSZ files with sections past 2 GiB decompress, which is essentially every retail game.

## Hot paths

No. The name filter is a per-sibling string compare in the library sync, already off main. The NCZ change is arithmetic.

## Testing evidence

`SiblingWinnerTest` covers the cross-game sibling staying out, a rom whose only sibling is a different game syncing alone, a nameless sibling staying in, and a disc-tagged cross-game sibling not forming a multi-disc group. `NszRoundTripTest` feeds a 6 GiB section that fails with the exact `Bad arguments` on the old code and round-trips byte-exact on the new one, plus the same guard for the gap between sections.

I replayed the sync against my own RomM instance with the same paged query the app makes: the German `Pokemon Red` dump (3645) wins its group with `Pokemon - Red Version (USA, Europe)` as its version, and `Pokemon - Blaue Edition` (3636) keeps the `Pokemon Blue` group. The decompressor reproduced a real NSZ's matching NSP with an identical SHA-256, handled two NSZs off my server, and ran a real file on an Android emulator to cover Conscrypt and the zstd Android natives.

Verified on my AYN Thor: `Pokemon Red` shows up after a sync, and a retail NSZ decompresses to a working NSP.

## AI assistance

I used Claude Code to trace both regressions against my RomM instance and to pin the overflow. I verified everything afterwards, including the API traces, the diff and the on-device behavior.

## Checklist

- [x] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
