### PR TITLE
downloads: increase the number of sections on nsz header

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/NczHeader.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/download/nsz/NczHeader.kt
@@ -72,7 +72,7 @@ object NczHeaderParser {
 
     const val NCA_HEADER_SIZE = 0x4000L
     private const val SECTION_ENTRY_SIZE = 64
-    private const val MAX_SECTION_COUNT = 100
+    private const val MAX_SECTION_COUNT = 32768
 
     private val NCZSECTN_MAGIC = "NCZSECTN".toByteArray(Charsets.US_ASCII)
     private val NCZBLOCK_MAGIC = "NCZBLOCK".toByteArray(Charsets.US_ASCII)

--- a/app/src/test/kotlin/com/nendo/argosy/data/download/nsz/NczHeaderParserTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/download/nsz/NczHeaderParserTest.kt
@@ -58,6 +58,19 @@ class NczHeaderParserTest {
     }
 
     @Test
+    fun `parse reads a header with thousands of sections`() {
+        val sections = (0 until 4008).map { index ->
+            TestSection(0x4000L + index * 0x1000L, 0x1000, 3)
+        }
+
+        val data = buildNczsectnHeader(sections = sections)
+        val result = NczHeaderParser.parse(ByteArrayInputStream(data))
+
+        assertEquals(4008, result.sections.size)
+        assertEquals(0x4000L + 4007 * 0x1000L, result.sections.last().offset)
+    }
+
+    @Test
     fun `parse detects NCZBLOCK header`() {
         val sectionData = buildNczsectnHeader(
             sections = listOf(
@@ -110,11 +123,12 @@ class NczHeaderParserTest {
 
     @Test(expected = IOException::class)
     fun `parse throws on excessive section count`() {
-        val buf = ByteBuffer.allocate(16)
-            .order(ByteOrder.LITTLE_ENDIAN)
-        buf.put("NCZSECTN".toByteArray())
-        buf.putLong(999)
-        NczHeaderParser.parse(ByteArrayInputStream(buf.array()))
+        val sections = (0 until 32769).map { index ->
+            TestSection(0x4000L + index * 0x1000L, 0x1000, 3)
+        }
+
+        val data = buildNczsectnHeader(sections = sections)
+        NczHeaderParser.parse(ByteArrayInputStream(data))
     }
 
     private data class TestSection(


### PR DESCRIPTION
## Summary
Some of my NSZ downloads fail with `NSZ decompression failed: Invalid NCZ section count: XXX` where XXX is a number > 100.
A hardcoded limit is present in the `NczHeaderParser` that prevent NSZ with more than 100 sections to be decompress.
An infinite number is dangerous so putting half of the maximum number of possible sections (65536/2=32768).

## Behavior changes
NSZ and XCZ downloads decompress instead of failing on the header check.

## Hot paths
No. This is the download path, already off main through DownloadManager. No new I/O, network or DB work.

## Testing evidence
I don't think if I have to right a new test for that.
Actual tests cover parsing several headers, +100 should behave the same.
Not tested in real hardware.

## AI assistance
No AI has been used

## Checklist

- [ ] I've tested the changes on real hardware
- [ ] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
