### PR TITLE
Dim both displays after inactivity on dual-screen devices

### DIFF
--- a/app/src/debug/kotlin/com/nendo/argosy/debugtools/DebugSeedReceiver.kt
+++ b/app/src/debug/kotlin/com/nendo/argosy/debugtools/DebugSeedReceiver.kt
@@ -14,7 +14,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
-/** Debug-only test seam: seeds RomM config and skips first-run. Trigger: adb shell am broadcast -n com.nendo.argosy.debug/com.nendo.argosy.debugtools.DebugSeedReceiver --es url <URL> --es token <RAW_TOKEN> */
+/**
+ * Debug-only setup: pass url/token to seed RomM, or --ez skipSetup true for an offline library.
+ */
 class DebugSeedReceiver : BroadcastReceiver() {
 
     @EntryPoint
@@ -25,8 +27,10 @@ class DebugSeedReceiver : BroadcastReceiver() {
     }
 
     override fun onReceive(context: Context, intent: Intent) {
-        val url = intent.getStringExtra("url") ?: return
-        val token = intent.getStringExtra("token") ?: return
+        val skipSetup = intent.getBooleanExtra("skipSetup", false)
+        val url = intent.getStringExtra("url")
+        val token = intent.getStringExtra("token")
+        if (!skipSetup && (url == null || token == null)) return
         val entryPoint = EntryPointAccessors.fromApplication(
             context.applicationContext,
             SeedEntryPoint::class.java
@@ -34,7 +38,9 @@ class DebugSeedReceiver : BroadcastReceiver() {
         val pending = goAsync()
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
             try {
-                entryPoint.romMRepository().connectWithToken(url, token)
+                if (!skipSetup) {
+                    entryPoint.romMRepository().connectWithToken(requireNotNull(url), requireNotNull(token))
+                }
                 entryPoint.userPreferencesRepository().setFirstRunComplete()
             } finally {
                 pending.finish()

--- a/app/src/main/kotlin/com/nendo/argosy/DualScreenManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/DualScreenManager.kt
@@ -417,6 +417,8 @@ class DualScreenManager(
     private val idleTimerScope =
         com.nendo.argosy.util.SafeCoroutineScope(Dispatchers.Main, "MediaDimRamp")
 
+    val screenDimmerState = com.nendo.argosy.ui.components.ScreenDimmerState()
+
     /**
      * The single notion of "the person did something", raised by every claimed key event, by
      * touch on any of the app's windows, and by claimed joystick motion whose axes actually moved
@@ -425,6 +427,7 @@ class DualScreenManager(
      * the diagnostic log.
      */
     fun notifyUserActivity(source: String) {
+        screenDimmerState.recordActivity()
         lastUserActivityAtMs = android.os.SystemClock.elapsedRealtime()
         Logger.debug(MEDIA_DIM_LOG_TAG, "userActivity source=$source")
         _userActive.value = true

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeActivity.kt
@@ -62,6 +62,7 @@ class SecondaryHomeActivity :
     DualScreenManager.CompanionHost {
 
     private lateinit var dsm: DualScreenManager
+    private var dimmerManager by mutableStateOf<DualScreenManager?>(null)
 
     override fun attachBaseContext(newBase: android.content.Context) {
         val tag = SessionStateStore(newBase).getAppLanguage()
@@ -190,6 +191,7 @@ class SecondaryHomeActivity :
             SecondaryHomeTheme(themeState = themeState.value, fonts = customFonts.value) {
                 if (!isInitialized) return@SecondaryHomeTheme
                 val scrapingArtwork by dsm.imageCacheManager.progress.collectAsState()
+                SecondaryHomeDimmer(dimmerManager, isWizardActive) {
                 androidx.compose.runtime.CompositionLocalProvider(
                     LocalABIconsSwapped provides abIconsSwapped,
                     LocalXYIconsSwapped provides xyIconsSwapped,
@@ -298,6 +300,7 @@ class SecondaryHomeActivity :
                 }
             }
         }
+    }
     }
 
     override fun onResume() {
@@ -1159,6 +1162,7 @@ class SecondaryHomeActivity :
     }
 
     private fun initializeCompanion() {
+        dimmerManager = dsm
         registerDisplayListener()
         initializeDependencies()
         loadInitialState()

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeComposables.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeComposables.kt
@@ -57,6 +57,30 @@ import kotlinx.coroutines.flow.StateFlow
 
 enum class CompanionScreen { HOME, GAME_DETAIL }
 
+@Composable
+fun SecondaryHomeDimmer(
+    manager: com.nendo.argosy.DualScreenManager?,
+    isWizardActive: Boolean,
+    content: @Composable () -> Unit
+) {
+    if (manager == null) {
+        content()
+        return
+    }
+    val prefs by manager.preferencesRepository.userPreferences.collectAsState(
+        initial = com.nendo.argosy.data.preferences.UserPreferences()
+    )
+    val session by manager.playSessionTracker.activeSession.collectAsState()
+    val playback by manager.mediaPlayback.collectAsState()
+    com.nendo.argosy.ui.components.ScreenDimmerOverlay(
+        enabled = prefs.screenDimmerEnabled && session == null && !isWizardActive && playback == null,
+        timeoutMs = prefs.screenDimmerTimeoutMinutes * 60_000L,
+        dimLevel = prefs.screenDimmerLevel / 100f,
+        dimmerState = manager.screenDimmerState,
+        content = content
+    )
+}
+
 /**
  * Whether the media panel is the surface the companion is showing right now. Both role renderers
  * and the activity's key-yield gate derive from this one predicate, so the screen that is drawn

--- a/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
@@ -160,7 +160,8 @@ fun ArgosyApp(
     val netplayInvitePrompt by viewModel.netplayInvitePrompt.collectAsState()
     val netplayInviteFocusIndex by viewModel.netplayInviteFocusIndex.collectAsState()
     val netplayJoinState by viewModel.netplayJoinState.collectAsState()
-    val screenDimmerState = rememberScreenDimmerState()
+    val screenDimmerState = (LocalContext.current as? com.nendo.argosy.MainActivity)
+        ?.dualScreenManager?.screenDimmerState ?: rememberScreenDimmerState()
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
 

--- a/app/src/main/kotlin/com/nendo/argosy/ui/components/ScreenDimmerOverlay.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/components/ScreenDimmerOverlay.kt
@@ -11,8 +11,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -20,15 +20,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 @Stable
-class ScreenDimmerState {
-    private val _lastActivityTime = mutableLongStateOf(System.currentTimeMillis())
-    val lastActivityTime: Long get() = _lastActivityTime.longValue
+class ScreenDimmerState(private val now: () -> Long = { System.nanoTime() / 1_000_000L }) {
+    private val _lastActivityTime = MutableStateFlow(now())
+    val lastActivityTime = _lastActivityTime.asStateFlow()
 
     fun recordActivity() {
-        _lastActivityTime.longValue = System.currentTimeMillis()
+        _lastActivityTime.value = now()
     }
+
+    fun remainingTimeout(timeoutMs: Long): Long =
+        (timeoutMs - (now() - lastActivityTime.value)).coerceAtLeast(0L)
 }
 
 @Composable
@@ -44,18 +49,18 @@ fun ScreenDimmerOverlay(
     content: @Composable () -> Unit
 ) {
     var isDimmed by remember { mutableStateOf(false) }
+    val lastActivityTime by dimmerState.lastActivityTime.collectAsState()
 
-    LaunchedEffect(enabled, timeoutMs, dimmerState.lastActivityTime) {
+    LaunchedEffect(enabled, timeoutMs, dimmerState, lastActivityTime) {
         if (!enabled) {
             isDimmed = false
             return@LaunchedEffect
         }
 
         isDimmed = false
-        delay(timeoutMs)
+        delay(dimmerState.remainingTimeout(timeoutMs))
 
-        val elapsed = System.currentTimeMillis() - dimmerState.lastActivityTime
-        if (elapsed >= timeoutMs) {
+        if (dimmerState.remainingTimeout(timeoutMs) == 0L) {
             isDimmed = true
         }
     }
@@ -63,7 +68,7 @@ fun ScreenDimmerOverlay(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .pointerInput(Unit) {
+            .pointerInput(dimmerState) {
                 detectTapGestures {
                     dimmerState.recordActivity()
                 }
@@ -80,7 +85,7 @@ fun ScreenDimmerOverlay(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Color.Black.copy(alpha = dimLevel))
-                    .pointerInput(Unit) {
+                    .pointerInput(dimmerState) {
                         detectTapGestures {
                             dimmerState.recordActivity()
                         }

--- a/app/src/test/kotlin/com/nendo/argosy/ui/components/ScreenDimmerStateTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/ui/components/ScreenDimmerStateTest.kt
@@ -1,0 +1,32 @@
+package com.nendo.argosy.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScreenDimmerStateTest {
+    @Test
+    fun aRecreatedDisplayUsesTheRemainingIdleTime() {
+        var now = 100L
+        val state = ScreenDimmerState { now }
+
+        now += 40L
+        assertEquals(60L, state.remainingTimeout(100L))
+        now += 80L
+        assertEquals(0L, state.remainingTimeout(100L))
+    }
+
+    @Test
+    fun activityOnEitherDisplayRestartsTheSharedDeadline() {
+        var now = 100L
+        val state = ScreenDimmerState { now }
+        val primary = state.lastActivityTime
+        val companion = state.lastActivityTime
+
+        now += 100L
+        state.recordActivity()
+
+        assertEquals(200L, primary.value)
+        assertEquals(primary.value, companion.value)
+        assertEquals(100L, state.remainingTimeout(100L))
+    }
+}


### PR DESCRIPTION
## Summary

Share the launcher's idle deadline so Screen Dimmer works on both displays. Fixes #402.

## Behavior changes

- Render the existing dimmer overlay on the companion in normal and swapped roles.
- Activity on either display resets the shared deadline; reattached overlays use the remaining timeout.
- Suppress companion dimming during setup, games, and media playback, preserving the existing media dimmer.
- Extend the existing debug-only setup receiver with an offline bypass for empty-library device testing. Release setup is unchanged.

## Hot paths

Activity notifications update one in-memory StateFlow. Each overlay observes it and schedules its idle delay. No new network, database, filesystem, or blocking native work.

## Testing evidence

- AYN Thor: installed `com.nendo.argosy.debug`, used offline setup, and observed both debug display activities running. The user manually tested dimming and confirmed it worked. Production Argosy remained installed and the default launcher; no production data or settings were changed.
- Offline debug iteration build passed in 3m 54s using the agreed local Compose stability override and a five-minute cutoff. The override lives outside the repository and is not included in this PR. This is not a production-configuration build verification.
- Both existing `ScreenDimmerStateTest` tests passed through cached Kotlin/JUnit tools: shared activity deadline reset and remaining timeout after reattachment.
- Smell checks and the staged coupling check passed; static review found no confirmed defects.
- Full Gradle unit suite and lint were not run. The manual confirmation does not separately establish every role, input modality, recreation, or setup/game/media suppression scenario.

## AI assistance

OpenAI Codex performed most research, implementation, tests, and PR drafting, with a separate AI static review. The submitter confirmed code understanding and successful manual device testing.

## Checklist

- [x] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
