### PR TITLE
settings: allow updating the RomM server URL without signing out

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/data/local/dao/RomMAccountDao.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/local/dao/RomMAccountDao.kt
@@ -62,6 +62,9 @@ interface RomMAccountDao {
     @Query("UPDATE romm_accounts SET deviceId = :deviceId, deviceClientVersion = :clientVersion WHERE id = :id")
     suspend fun updateDevice(id: Long, deviceId: String?, clientVersion: String?)
 
+    @Query("UPDATE romm_accounts SET baseUrl = :newUrl, token = CASE WHEN isActive = 1 THEN :token ELSE token END WHERE baseUrl = :oldUrl")
+    suspend fun updateServerUrl(oldUrl: String, newUrl: String, token: String)
+
     @Query("DELETE FROM romm_accounts WHERE id = :id")
     suspend fun deleteById(id: Long)
 }

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/SyncPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/SyncPreferencesRepository.kt
@@ -322,10 +322,11 @@ class SyncPreferencesRepository @Inject constructor(
         it[Keys.SAVE_WATCHER_ENABLED] ?: false
     }
 
-    suspend fun setRommConfig(url: String?, username: String?) {
+    suspend fun setRommConfig(url: String?, username: String?, token: String? = null) {
         dataStore.edit { prefs ->
             if (url != null) prefs[Keys.ROMM_URL] = url else prefs.remove(Keys.ROMM_URL)
             if (username != null) prefs[Keys.ROMM_USERNAME] = username else prefs.remove(Keys.ROMM_USERNAME)
+            if (token != null) prefs[Keys.ROMM_TOKEN] = token
         }
     }
 

--- a/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/preferences/UserPreferencesRepository.kt
@@ -327,7 +327,7 @@ class UserPreferencesRepository @Inject constructor(
 
     // --- Sync delegates ---
 
-    suspend fun setRommConfig(url: String?, username: String?) = syncPrefs.setRommConfig(url, username)
+    suspend fun setRommConfig(url: String?, username: String?, token: String? = null) = syncPrefs.setRommConfig(url, username, token)
     suspend fun setDownloadCategoryDefault(categoryKey: String, include: Boolean) =
         syncPrefs.setDownloadCategoryDefault(categoryKey, include)
     suspend fun setDownloadCategoryPlatformOverride(platformSlug: String, categoryKey: String, include: Boolean?) =

--- a/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMConnectionManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMConnectionManager.kt
@@ -24,6 +24,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import com.nendo.argosy.data.remote.ssl.isCertificateTrustFailure
@@ -258,6 +261,64 @@ class RomMConnectionManager @Inject constructor(
         return result
     }
 
+    suspend fun updateServerUrl(url: String, replacementToken: String? = null): RomMResult<String> = withContext(Dispatchers.IO) {
+        connectMutex.withLock {
+            val prefs = userPreferencesRepository.preferences.first()
+            val oldUrl = prefs.rommBaseUrl ?: return@withLock RomMResult.Error("No server configured")
+            val token = replacementToken ?: prefs.rommToken
+                ?: return@withLock RomMResult.Error("Sign in again", code = 401)
+            var lastError = RomMResult.Error("Connection failed")
+            for (candidateUrl in buildUrlsToTry(url)) {
+                val normalizedUrl = candidateUrl.trimEnd('/') + "/"
+                try {
+                    val heartbeat = createApi(normalizedUrl, null).heartbeat()
+                    if (!heartbeat.isSuccessful) {
+                        lastError = RomMResult.Error("Connection failed", code = heartbeat.code())
+                        continue
+                    }
+                    val newApi = createApi(normalizedUrl, token)
+                    val user = newApi.getCurrentUser()
+                    if (!user.isSuccessful) {
+                        return@withLock RomMResult.Error("Authentication failed", code = user.code())
+                    }
+                    if (user.body() == null || (prefs.rommUserId != null && user.body()?.id != prefs.rommUserId)) {
+                        return@withLock RomMResult.Error("Account does not match", code = 409)
+                    }
+                    if (replacementToken != null && replacementToken != prefs.rommToken) {
+                        val deviceId = prefs.rommDeviceId
+                        if (deviceId == null || newApi.getDevices().body()?.none { it.id == deviceId } != false) {
+                            return@withLock RomMResult.Error("Could not verify the existing server", code = 409)
+                        }
+                    }
+                    val body = heartbeat.body()
+                    val version = body?.version ?: "unknown"
+                    val capabilities = RomMCapabilities.from(version, body?.libretroApiEnabled, body?.steamGridDbEnabled)
+                    withContext(NonCancellable) {
+                        rommAccountRepository.get().updateServerUrl(oldUrl, normalizedUrl, token)
+                        baseUrl = normalizedUrl
+                        accessToken = token
+                        api = newApi
+                        saveSyncRepository.get().setApi(newApi)
+                        biosRepository.setApi(newApi)
+                        saveSyncRepository.get().setCapabilities(capabilities)
+                        reconnectJob?.cancel()
+                        reconnectPending = false
+                        _connectionState.value = ConnectionState.Connected(version, capabilities)
+                    }
+                    return@withLock RomMResult.Success(normalizedUrl)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    lastError = RomMResult.Error(
+                        e.message ?: "Connection failed",
+                        kind = if (e.isCertificateTrustFailure()) RomMErrorKind.UNTRUSTED_CERTIFICATE else null
+                    )
+                }
+            }
+            lastError
+        }
+    }
+
     /** Probes a server URL with a throwaway client, leaving the live session untouched. */
     suspend fun probeServerVersion(url: String): RomMResult<String> {
         var lastError: String? = null
@@ -347,6 +408,13 @@ class RomMConnectionManager @Inject constructor(
     }
 
     suspend fun connectWithToken(url: String, token: String): RomMResult<String> {
+        val storedUrl = userPreferencesRepository.preferences.first().rommBaseUrl
+        if (!storedUrl.isNullOrBlank() && storedUrl.trimEnd('/') != url.trim().trimEnd('/')) {
+            return when (val result = updateServerUrl(url, token)) {
+                is RomMResult.Success -> RomMResult.Success(token)
+                is RomMResult.Error -> result
+            }
+        }
         _connectionState.value = ConnectionState.Connecting
         val connectResult = attemptConnection(url, token, registerDevice = false)
         if (connectResult is RomMResult.Error) {
@@ -531,6 +599,16 @@ class RomMConnectionManager @Inject constructor(
     }
 
     private suspend fun finalizeDeviceAuth(base: String, body: RomMDeviceAuthTokenResponse) {
+        val storedUrl = userPreferencesRepository.preferences.first().rommBaseUrl
+        if (!storedUrl.isNullOrBlank() && storedUrl.trimEnd('/') != base.trimEnd('/')) {
+            when (val result = updateServerUrl(base, body.accessToken)) {
+                is RomMResult.Error -> throw IllegalStateException(result.message)
+                is RomMResult.Success -> {
+                    cancelDeviceAuth()
+                    return
+                }
+            }
+        }
         val newApi = createApi(base, body.accessToken)
         val heartbeat = try { newApi.heartbeat() } catch (_: Exception) { null }
         val version = heartbeat?.body()?.version ?: "unknown"

--- a/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/remote/romm/RomMRepository.kt
@@ -49,6 +49,8 @@ class RomMRepository @Inject constructor(
     suspend fun probeServerVersion(url: String): RomMResult<String> =
         connectionManager.probeServerVersion(url)
 
+    suspend fun updateServerUrl(url: String): RomMResult<String> = connectionManager.updateServerUrl(url)
+
     suspend fun connectWithToken(url: String, token: String): RomMResult<String> =
         connectionManager.connectWithToken(url, token)
 

--- a/app/src/main/kotlin/com/nendo/argosy/data/repository/RomMAccountRepository.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/data/repository/RomMAccountRepository.kt
@@ -15,6 +15,8 @@ import com.nendo.argosy.data.preferences.UserPreferencesRepository
 import com.nendo.argosy.data.remote.romm.RomMApiProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -50,6 +52,20 @@ class RomMAccountRepository @Inject constructor(
     suspend fun activeAccount(): RomMAccountEntity? = rommAccountDao.getActive()
 
     suspend fun accountCount(): Int = rommAccountDao.count()
+
+    suspend fun updateServerUrl(oldUrl: String, newUrl: String, token: String) = withContext(NonCancellable) {
+        val prefs = userPreferencesRepository.preferences.first()
+        check(prefs.rommBaseUrl == oldUrl)
+        val oldToken = checkNotNull(prefs.rommToken)
+        rommAccountDao.updateServerUrl(oldUrl, newUrl, token)
+        try {
+            userPreferencesRepository.setRommConfig(newUrl, prefs.rommUsername, token)
+        } catch (e: Exception) {
+            rommAccountDao.updateServerUrl(newUrl, oldUrl, oldToken)
+            throw e
+        }
+        rommApiProvider.invalidateAll()
+    }
 
     /**
      * Records a successful pairing and makes it the live account. Returns the row id.

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
@@ -358,6 +358,8 @@ private fun routeRomMConfirm(vm: SettingsViewModel, state: SettingsUiState): Inp
     val items = buildRomMItemsFromState(state)
     when (rommItemAtFocusIndex(state.focusedIndex, items)) {
         RomMItem.RomManager -> vm.startRommConfig()
+        RomMItem.ServerUrl -> vm.serverDelegate.setRommFocusField(state.focusedIndex)
+        RomMItem.SaveServerUrl -> vm.saveRommUrl()
         RomMItem.RomMSignOut -> vm.requestRommSignOut()
         RomMItem.Accounts -> vm.navigateToSection(SettingsSection.ACCOUNTS)
         RomMItem.SyncSettings -> vm.navigateToSection(SettingsSection.SYNC_SETTINGS)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsConfirmRouter.kt
@@ -131,27 +131,34 @@ import com.nendo.argosy.ui.screens.settings.sections.LibraryLayoutState
 
 private fun rommConfigMaxIndex(server: ServerState): Int {
     if (server.rommDevicePairing) return 0
-    return when (server.rommAuthMethod) {
-        RomMAuthMethod.DEVICE -> 4
-        RomMAuthMethod.PAIRING_CODE -> if (server.rommHasCamera) 6 else 5
-    }
+    return rommConfigIndices(server).cancelIndex
 }
 
 private data class RommConfigIndices(
     val connectIndex: Int,
     val scanIndex: Int?,
     val certificateIndex: Int,
-    val cancelIndex: Int
+    val cancelIndex: Int,
+    val saveUrlIndex: Int? = null
 )
 
-private fun rommConfigIndices(server: ServerState): RommConfigIndices = when (server.rommAuthMethod) {
-    RomMAuthMethod.DEVICE -> RommConfigIndices(2, null, 3, 4)
-    RomMAuthMethod.PAIRING_CODE ->
-        if (server.rommHasCamera) {
-            RommConfigIndices(3, 4, 5, 6)
-        } else {
-            RommConfigIndices(3, null, 4, 5)
-        }
+private fun rommConfigIndices(server: ServerState): RommConfigIndices {
+    val indices = when (server.rommAuthMethod) {
+        RomMAuthMethod.DEVICE -> RommConfigIndices(2, null, 3, 4)
+        RomMAuthMethod.PAIRING_CODE ->
+            if (server.rommHasCamera) {
+                RommConfigIndices(3, 4, 5, 6)
+            } else {
+                RommConfigIndices(3, null, 4, 5)
+            }
+    }
+    return if (server.rommUrl.isNotBlank()) indices.copy(
+        connectIndex = indices.connectIndex + 1,
+        scanIndex = indices.scanIndex?.plus(1),
+        certificateIndex = indices.certificateIndex + 1,
+        cancelIndex = indices.cancelIndex + 1,
+        saveUrlIndex = indices.connectIndex
+    ) else indices
 }
 
 private fun nextRommAuthMethod(current: RomMAuthMethod): RomMAuthMethod = when (current) {
@@ -347,6 +354,7 @@ private fun routeRomMConfirm(vm: SettingsViewModel, state: SettingsUiState): Inp
                 return InputResult.handled(SoundType.OPEN_MODAL)
             }
             indices.connectIndex -> vm.connectToRomm()
+            indices.saveUrlIndex -> vm.saveRommUrl()
             indices.scanIndex -> vm.showRommScanner()
             indices.certificateIndex -> vm.requestCertificatePicker()
             indices.cancelIndex -> vm.cancelRommConfig()
@@ -358,8 +366,6 @@ private fun routeRomMConfirm(vm: SettingsViewModel, state: SettingsUiState): Inp
     val items = buildRomMItemsFromState(state)
     when (rommItemAtFocusIndex(state.focusedIndex, items)) {
         RomMItem.RomManager -> vm.startRommConfig()
-        RomMItem.ServerUrl -> vm.serverDelegate.setRommFocusField(state.focusedIndex)
-        RomMItem.SaveServerUrl -> vm.saveRommUrl()
         RomMItem.RomMSignOut -> vm.requestRommSignOut()
         RomMItem.Accounts -> vm.navigateToSection(SettingsSection.ACCOUNTS)
         RomMItem.SyncSettings -> vm.navigateToSection(SettingsSection.SYNC_SETTINGS)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsInitRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsInitRouter.kt
@@ -257,7 +257,7 @@ internal fun routeObserveConnectionState(vm: SettingsViewModel) {
             ?.capabilities?.supportsScreenshotUpload == true
         val musicApi = (connectionState as? ConnectionState.Connected)
             ?.capabilities?.supportsMusicApi == true
-        vm.serverDelegate.updateState(vm._uiState.value.server.copy(
+        vm.serverDelegate.updateState(vm.serverDelegate.state.value.copy(
             connectionStatus = status,
             rommVersion = version,
             screenshotUploadSupported = screenshotUpload,
@@ -649,6 +649,7 @@ internal fun routeLoadSettings(vm: SettingsViewModel) {
         vm.serverDelegate.updateState(ServerState(
             connectionStatus = connectionStatus,
             rommUrl = prefs.rommBaseUrl ?: "",
+            rommConfigUrl = prefs.rommBaseUrl ?: "",
             rommUsername = prefs.rommUsername ?: "",
             rommVersion = rommVersion,
             lastRommSync = prefs.lastRommSync,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsModels.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsModels.kt
@@ -890,6 +890,7 @@ data class ServerState(
     val rommHasCamera: Boolean = false,
     val rommConnecting: Boolean = false,
     val rommConfigError: String? = null,
+    val rommUrlSaved: Boolean = false,
     val rommFocusField: Int? = null,
     val rommDevicePairing: Boolean = false,
     val rommDeviceUserCode: String? = null,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsViewModel.kt
@@ -1737,6 +1737,8 @@ class SettingsViewModel @Inject constructor(
     fun cancelRommConfig() = routeCancelRommConfig(this)
 
     fun setRommConfigUrl(url: String) = serverDelegate.setRommConfigUrl(url)
+
+    fun saveRommUrl() = serverDelegate.saveRommUrl(viewModelScope)
     fun commitRommUrl() = serverDelegate.commitRommUrl(viewModelScope)
     fun setRommConfigPairingCode(code: String) = serverDelegate.setRommConfigPairingCode(code)
     fun setRommAuthMethod(method: RomMAuthMethod) = serverDelegate.setRommAuthMethod(method)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/components/RomMConfigForm.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/components/RomMConfigForm.kt
@@ -84,6 +84,7 @@ fun RomMConfigForm(uiState: SettingsUiState, viewModel: SettingsViewModel) {
     val isDevice = authMethod == RomMAuthMethod.DEVICE
     val isPairingCode = authMethod == RomMAuthMethod.PAIRING_CODE
     val hasCamera = uiState.server.rommHasCamera
+    val canUpdateUrl = uiState.server.rommUrl.isNotBlank()
 
     LaunchedEffect(uiState.server.rommFocusField) {
         when (uiState.server.rommFocusField) {
@@ -107,13 +108,14 @@ fun RomMConfigForm(uiState: SettingsUiState, viewModel: SettingsViewModel) {
             label = { Text(stringResource(R.string.settings_romm_config_server_url_label)) },
             placeholder = { Text(stringResource(R.string.settings_romm_config_server_url_placeholder)) },
             singleLine = true,
+            enabled = !uiState.server.rommConnecting,
             shape = inputShape,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Go),
             keyboardActions = KeyboardActions(
                 onGo = {
                     if (!uiState.server.rommConnecting && uiState.server.rommConfigUrl.isNotBlank()) {
                         keyboard?.hide()
-                        viewModel.commitRommUrl()
+                        if (canUpdateUrl) viewModel.saveRommUrl() else viewModel.commitRommUrl()
                     }
                 }
             ),
@@ -121,7 +123,7 @@ fun RomMConfigForm(uiState: SettingsUiState, viewModel: SettingsViewModel) {
                 .fillMaxWidth()
                 .focusRequester(urlFocusRequester)
                 .onFocusChanged { fs ->
-                    if (wasUrlFocused && !fs.isFocused && uiState.server.rommConfigUrl.isNotBlank()) {
+                    if (!canUpdateUrl && wasUrlFocused && !fs.isFocused && uiState.server.rommConfigUrl.isNotBlank()) {
                         viewModel.commitRommUrl()
                     }
                     wasUrlFocused = fs.isFocused
@@ -178,6 +180,13 @@ fun RomMConfigForm(uiState: SettingsUiState, viewModel: SettingsViewModel) {
                 style = MaterialTheme.typography.bodySmall,
                 modifier = Modifier.padding(start = Dimens.spacingSm)
             )
+        } else if (uiState.server.rommUrlSaved) {
+            Text(
+                text = stringResource(R.string.settings_romm_url_saved),
+                color = MaterialTheme.colorScheme.primary,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = Dimens.spacingSm)
+            )
         }
 
         Spacer(modifier = Modifier.height(Dimens.spacingSm))
@@ -185,6 +194,20 @@ fun RomMConfigForm(uiState: SettingsUiState, viewModel: SettingsViewModel) {
         var buttonIndex = when (authMethod) {
             RomMAuthMethod.DEVICE -> 2
             RomMAuthMethod.PAIRING_CODE -> 3
+        }
+
+        if (canUpdateUrl) {
+            ActionPreference(
+                title = stringResource(
+                    if (uiState.server.rommConnecting) R.string.settings_romm_url_saving
+                    else R.string.settings_romm_url_save
+                ),
+                subtitle = stringResource(R.string.settings_romm_url_subtitle),
+                isFocused = uiState.focusedIndex == buttonIndex,
+                isEnabled = !uiState.server.rommConnecting && uiState.server.rommConfigUrl.isNotBlank(),
+                onClick = { viewModel.saveRommUrl() }
+            )
+            buttonIndex++
         }
 
         ActionPreference(

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/ServerSettingsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/ServerSettingsDelegate.kt
@@ -101,6 +101,7 @@ class ServerSettingsDelegate @Inject constructor(
         _state.update {
             it.copy(
                 rommConfiguring = true,
+                rommUrlSaved = false,
                 rommAuthMethod = defaultAuthMethod(),
                 rommConfigUrl = it.rommUrl,
                 rommConfigPairingCode = "",
@@ -129,6 +130,7 @@ class ServerSettingsDelegate @Inject constructor(
         _state.update {
             it.copy(
                 rommConfiguring = false,
+                rommUrlSaved = false,
                 rommConfigUrl = it.rommUrl,
                 rommConfigPairingCode = "",
                 rommConfigError = null,
@@ -142,18 +144,23 @@ class ServerSettingsDelegate @Inject constructor(
     }
 
     fun setRommConfigUrl(url: String) {
-        _state.update { it.copy(rommConfigUrl = url, rommConfigError = null) }
+        _state.update { it.copy(rommConfigUrl = url, rommConfigError = null, rommUrlSaved = false) }
     }
 
     fun saveRommUrl(scope: CoroutineScope) {
         val state = _state.value
         if (state.rommConnecting || state.rommConfigUrl.isBlank()) return
-        _state.update { it.copy(rommConnecting = true, rommConfigError = null) }
+        _state.update { it.copy(rommConnecting = true, rommConfigError = null, rommUrlSaved = false) }
         scope.launch {
             try {
                 when (val result = romMRepository.updateServerUrl(state.rommConfigUrl)) {
                     is RomMResult.Success -> _state.update {
-                        it.copy(rommUrl = result.data, rommConfigUrl = result.data, connectionStatus = ConnectionStatus.ONLINE)
+                        it.copy(
+                            rommUrl = result.data,
+                            rommConfigUrl = result.data,
+                            rommUrlSaved = true,
+                            connectionStatus = ConnectionStatus.ONLINE
+                        )
                     }
                     is RomMResult.Error -> _state.update {
                         it.copy(rommConfigError = when {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/ServerSettingsDelegate.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/delegates/ServerSettingsDelegate.kt
@@ -129,7 +129,7 @@ class ServerSettingsDelegate @Inject constructor(
         _state.update {
             it.copy(
                 rommConfiguring = false,
-                rommConfigUrl = "",
+                rommConfigUrl = it.rommUrl,
                 rommConfigPairingCode = "",
                 rommConfigError = null,
                 rommConnecting = false,
@@ -142,7 +142,32 @@ class ServerSettingsDelegate @Inject constructor(
     }
 
     fun setRommConfigUrl(url: String) {
-        _state.update { it.copy(rommConfigUrl = url) }
+        _state.update { it.copy(rommConfigUrl = url, rommConfigError = null) }
+    }
+
+    fun saveRommUrl(scope: CoroutineScope) {
+        val state = _state.value
+        if (state.rommConnecting || state.rommConfigUrl.isBlank()) return
+        _state.update { it.copy(rommConnecting = true, rommConfigError = null) }
+        scope.launch {
+            try {
+                when (val result = romMRepository.updateServerUrl(state.rommConfigUrl)) {
+                    is RomMResult.Success -> _state.update {
+                        it.copy(rommUrl = result.data, rommConfigUrl = result.data, connectionStatus = ConnectionStatus.ONLINE)
+                    }
+                    is RomMResult.Error -> _state.update {
+                        it.copy(rommConfigError = when {
+                            result.kind != null -> result.describe()
+                            result.code == 401 || result.code == 403 -> context.getString(R.string.settings_romm_url_sign_in_again)
+                            result.code == 409 -> context.getString(R.string.settings_romm_url_account_mismatch)
+                            else -> context.getString(R.string.settings_romm_url_failed)
+                        })
+                    }
+                }
+            } finally {
+                _state.update { it.copy(rommConnecting = false) }
+            }
+        }
     }
 
     fun setRommConfigPairingCode(code: String) {

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/RomMSection.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/RomMSection.kt
@@ -5,6 +5,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.LibraryBooks
 import androidx.compose.material.icons.automirrored.filled.Logout
@@ -13,8 +19,14 @@ import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.res.stringResource
 import com.nendo.argosy.R
 import com.nendo.argosy.ui.components.ActionPreference
@@ -36,6 +48,8 @@ internal sealed class RomMItem(val key: String, val section: String) {
     class Header(key: String, section: String, val titleRes: Int) : RomMItem(key, section)
 
     data object RomManager : RomMItem("romManager", "server")
+    data object ServerUrl : RomMItem("serverUrl", "server")
+    data object SaveServerUrl : RomMItem("saveServerUrl", "server")
     data object RomMSignOut : RomMItem("rommSignOut", "server")
     data object Accounts : RomMItem("rommAccounts", "server")
     data object SyncSettings : RomMItem("syncSettings", "library")
@@ -50,6 +64,8 @@ internal fun buildRomMItems(
     add(RomMItem.RomManager)
     add(RomMItem.Accounts)
     if (isSignedIntoRomM) {
+        add(RomMItem.ServerUrl)
+        add(RomMItem.SaveServerUrl)
         add(RomMItem.RomMSignOut)
     }
 
@@ -133,6 +149,15 @@ private fun RomMContent(uiState: SettingsUiState, viewModel: SettingsViewModel) 
     val context = LocalContext.current
     val layout = remember(allItems) { createRomMLayout(allItems) }
     val sections = remember(allItems, context) { layout.buildSections(Unit, context) }
+    val urlFocusRequester = remember { FocusRequester() }
+    val keyboard = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(uiState.server.rommFocusField) {
+        if (uiState.server.rommFocusField != null && isSignedIntoRomM) {
+            urlFocusRequester.requestFocus()
+            viewModel.clearRommFocusField()
+        }
+    }
 
     fun isFocused(item: RomMItem): Boolean =
         uiState.focusedIndex == layout.focusIndexOf(item, Unit)
@@ -194,6 +219,41 @@ private fun RomMContent(uiState: SettingsUiState, viewModel: SettingsViewModel) 
                 isEnabled = !uiState.server.rommSigningOut,
                 isDangerous = true,
                 onClick = { viewModel.requestRommSignOut() }
+            )
+
+            RomMItem.ServerUrl -> OutlinedTextField(
+                value = uiState.server.rommConfigUrl,
+                onValueChange = { viewModel.setRommConfigUrl(it) },
+                label = { Text(stringResource(R.string.settings_romm_url_label)) },
+                singleLine = true,
+                enabled = !uiState.server.rommConnecting,
+                isError = uiState.server.rommConfigError != null,
+                supportingText = {
+                    Text(
+                        text = uiState.server.rommConfigError
+                            ?: stringResource(R.string.settings_romm_url_subtitle),
+                        color = if (uiState.server.rommConfigError != null) MaterialTheme.colorScheme.error
+                            else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { keyboard?.hide() }),
+                colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
+                    unfocusedBorderColor = if (isFocused(item)) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.outline
+                ),
+                modifier = Modifier.fillMaxWidth().focusRequester(urlFocusRequester)
+            )
+
+            RomMItem.SaveServerUrl -> ActionPreference(
+                title = stringResource(
+                    if (uiState.server.rommConnecting) R.string.settings_romm_url_saving
+                    else R.string.settings_romm_url_save
+                ),
+                subtitle = "",
+                isFocused = isFocused(item),
+                isEnabled = !uiState.server.rommConnecting && uiState.server.rommConfigUrl.isNotBlank(),
+                onClick = { viewModel.saveRommUrl() }
             )
 
             RomMItem.Accounts -> NavigationPreference(

--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/RomMSection.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/sections/RomMSection.kt
@@ -5,12 +5,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.LibraryBooks
 import androidx.compose.material.icons.automirrored.filled.Logout
@@ -19,14 +13,8 @@ import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.res.stringResource
 import com.nendo.argosy.R
 import com.nendo.argosy.ui.components.ActionPreference
@@ -48,8 +36,6 @@ internal sealed class RomMItem(val key: String, val section: String) {
     class Header(key: String, section: String, val titleRes: Int) : RomMItem(key, section)
 
     data object RomManager : RomMItem("romManager", "server")
-    data object ServerUrl : RomMItem("serverUrl", "server")
-    data object SaveServerUrl : RomMItem("saveServerUrl", "server")
     data object RomMSignOut : RomMItem("rommSignOut", "server")
     data object Accounts : RomMItem("rommAccounts", "server")
     data object SyncSettings : RomMItem("syncSettings", "library")
@@ -64,8 +50,6 @@ internal fun buildRomMItems(
     add(RomMItem.RomManager)
     add(RomMItem.Accounts)
     if (isSignedIntoRomM) {
-        add(RomMItem.ServerUrl)
-        add(RomMItem.SaveServerUrl)
         add(RomMItem.RomMSignOut)
     }
 
@@ -149,15 +133,6 @@ private fun RomMContent(uiState: SettingsUiState, viewModel: SettingsViewModel) 
     val context = LocalContext.current
     val layout = remember(allItems) { createRomMLayout(allItems) }
     val sections = remember(allItems, context) { layout.buildSections(Unit, context) }
-    val urlFocusRequester = remember { FocusRequester() }
-    val keyboard = LocalSoftwareKeyboardController.current
-
-    LaunchedEffect(uiState.server.rommFocusField) {
-        if (uiState.server.rommFocusField != null && isSignedIntoRomM) {
-            urlFocusRequester.requestFocus()
-            viewModel.clearRommFocusField()
-        }
-    }
 
     fun isFocused(item: RomMItem): Boolean =
         uiState.focusedIndex == layout.focusIndexOf(item, Unit)
@@ -219,41 +194,6 @@ private fun RomMContent(uiState: SettingsUiState, viewModel: SettingsViewModel) 
                 isEnabled = !uiState.server.rommSigningOut,
                 isDangerous = true,
                 onClick = { viewModel.requestRommSignOut() }
-            )
-
-            RomMItem.ServerUrl -> OutlinedTextField(
-                value = uiState.server.rommConfigUrl,
-                onValueChange = { viewModel.setRommConfigUrl(it) },
-                label = { Text(stringResource(R.string.settings_romm_url_label)) },
-                singleLine = true,
-                enabled = !uiState.server.rommConnecting,
-                isError = uiState.server.rommConfigError != null,
-                supportingText = {
-                    Text(
-                        text = uiState.server.rommConfigError
-                            ?: stringResource(R.string.settings_romm_url_subtitle),
-                        color = if (uiState.server.rommConfigError != null) MaterialTheme.colorScheme.error
-                            else MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Done),
-                keyboardActions = KeyboardActions(onDone = { keyboard?.hide() }),
-                colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
-                    unfocusedBorderColor = if (isFocused(item)) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.outline
-                ),
-                modifier = Modifier.fillMaxWidth().focusRequester(urlFocusRequester)
-            )
-
-            RomMItem.SaveServerUrl -> ActionPreference(
-                title = stringResource(
-                    if (uiState.server.rommConnecting) R.string.settings_romm_url_saving
-                    else R.string.settings_romm_url_save
-                ),
-                subtitle = "",
-                isFocused = isFocused(item),
-                isEnabled = !uiState.server.rommConnecting && uiState.server.rommConfigUrl.isNotBlank(),
-                onClick = { viewModel.saveRommUrl() }
             )
 
             RomMItem.Accounts -> NavigationPreference(

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -2139,6 +2139,13 @@
     <!-- Row naming the game server. "Rom Manager" is what the server software calls itself in
          full; leave it untranslated. -->
     <string name="settings_romm_server_title">Rom Manager</string>
+    <string name="settings_romm_url_label">Server URL</string>
+    <string name="settings_romm_url_subtitle">Change the address of this RomM instance without signing out.</string>
+    <string name="settings_romm_url_save">Save URL</string>
+    <string name="settings_romm_url_saving">Validating URL...</string>
+    <string name="settings_romm_url_sign_in_again">Credentials rejected. Sign in again through Rom Manager, then retry. The saved URL has not changed.</string>
+    <string name="settings_romm_url_account_mismatch">This address belongs to a different account. The saved URL has not changed.</string>
+    <string name="settings_romm_url_failed">Could not validate this address. Check the URL and connection, then retry. The saved URL has not changed.</string>
     <!-- Second line of that row while Argosy is testing the connection. -->
     <string name="settings_romm_server_checking">Checking connection...</string>
     <!-- Second line of that row when the server answers but has no address to show. -->

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -2139,11 +2139,11 @@
     <!-- Row naming the game server. "Rom Manager" is what the server software calls itself in
          full; leave it untranslated. -->
     <string name="settings_romm_server_title">Rom Manager</string>
-    <string name="settings_romm_url_label">Server URL</string>
     <string name="settings_romm_url_subtitle">Change the address of this RomM instance without signing out.</string>
     <string name="settings_romm_url_save">Save URL</string>
     <string name="settings_romm_url_saving">Validating URL...</string>
-    <string name="settings_romm_url_sign_in_again">Credentials rejected. Sign in again through Rom Manager, then retry. The saved URL has not changed.</string>
+    <string name="settings_romm_url_saved">Server URL updated.</string>
+    <string name="settings_romm_url_sign_in_again">Credentials rejected. Sign in again, then retry. The saved URL has not changed.</string>
     <string name="settings_romm_url_account_mismatch">This address belongs to a different account. The saved URL has not changed.</string>
     <string name="settings_romm_url_failed">Could not validate this address. Check the URL and connection, then retry. The saved URL has not changed.</string>
     <!-- Second line of that row while Argosy is testing the connection. -->

--- a/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/RomMServerUrlTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/data/remote/romm/RomMServerUrlTest.kt
@@ -1,0 +1,119 @@
+package com.nendo.argosy.data.remote.romm
+
+import com.nendo.argosy.data.preferences.UserPreferences
+import com.nendo.argosy.data.preferences.UserPreferencesRepository
+import com.nendo.argosy.data.repository.RomMAccountRepository
+import dagger.Lazy
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+
+class RomMServerUrlTest {
+    private val oldUrl = "http://192.168.1.100:7676/"
+    private val newUrl = "https://romm.example.com/"
+    private val preferences = mockk<UserPreferencesRepository>()
+    private val accounts = mockk<RomMAccountRepository>(relaxed = true)
+    private val factory = mockk<RomMApiFactory>()
+    private val oldApi = mockk<RomMApi>()
+    private val newApi = mockk<RomMApi>()
+    private val heartbeat = Response.success(RomMHeartbeatResponse())
+    private val user = RomMUser(7, "player", true, "viewer")
+    private val manager = RomMConnectionManager(
+        mockk(relaxed = true), preferences, Lazy { mockk(relaxed = true) },
+        mockk(relaxed = true), Lazy { accounts }, Lazy { mockk(relaxed = true) },
+        Lazy { mockk(relaxed = true) }, Lazy { mockk(relaxed = true) }, factory
+    )
+
+    init {
+        every { preferences.preferences } returns flowOf(
+            UserPreferences(rommBaseUrl = oldUrl, rommToken = "saved-token", rommUserId = user.id, rommDeviceId = "existing-device")
+        )
+        every { factory.create(oldUrl, any()) } returns oldApi
+        every { factory.create(newUrl, any()) } returns newApi
+        coEvery { oldApi.heartbeat() } returns heartbeat
+        coEvery { oldApi.getCurrentUser() } returns Response.success(user)
+        coEvery { newApi.heartbeat() } returns heartbeat
+        coEvery { newApi.getCurrentUser() } returns Response.success(user)
+    }
+
+    @Test
+    fun `valid address replaces the connection using saved authentication`() = runTest {
+        manager.connect(oldUrl, "saved-token")
+
+        assertTrue(manager.updateServerUrl("  https://romm.example.com  ") is RomMResult.Success)
+
+        assertEquals(newUrl, manager.getBaseUrl())
+        assertSame(newApi, manager.getApi())
+        coVerify { accounts.updateServerUrl(oldUrl, newUrl, "saved-token") }
+    }
+
+    @Test
+    fun `rejected credentials preserve the old connection and stored address`() = runTest {
+        manager.connect(oldUrl, "saved-token")
+        val previousState = manager.connectionState.value
+        coEvery { newApi.getCurrentUser() } returns Response.error(401, "".toResponseBody())
+
+        val result = manager.updateServerUrl(newUrl) as RomMResult.Error
+
+        assertEquals(401, result.code)
+        assertEquals(oldUrl, manager.getBaseUrl())
+        assertSame(oldApi, manager.getApi())
+        assertEquals(previousState, manager.connectionState.value)
+        coVerify(exactly = 0) { accounts.updateServerUrl(any(), any(), any()) }
+    }
+
+    @Test
+    fun `unreachable address preserves the old connection`() = runTest {
+        manager.connect(oldUrl, "saved-token")
+        coEvery { newApi.heartbeat() } throws java.io.IOException("unreachable")
+
+        assertTrue(manager.updateServerUrl(newUrl) is RomMResult.Error)
+
+        assertEquals(oldUrl, manager.getBaseUrl())
+        assertSame(oldApi, manager.getApi())
+        coVerify(exactly = 0) { accounts.updateServerUrl(any(), any(), any()) }
+    }
+
+    @Test
+    fun `different user cannot replace the existing library connection`() = runTest {
+        manager.connect(oldUrl, "saved-token")
+        coEvery { newApi.getCurrentUser() } returns Response.success(user.copy(id = 8))
+
+        assertTrue(manager.updateServerUrl(newUrl) is RomMResult.Error)
+
+        assertSame(oldApi, manager.getApi())
+        coVerify(exactly = 0) { accounts.updateServerUrl(any(), any(), any()) }
+    }
+
+    @Test
+    fun `fresh pairing can move the address when the registered device still exists`() = runTest {
+        coEvery { newApi.getDevices() } returns Response.success(
+            listOf(RomMDevice("existing-device", null, null, null, null))
+        )
+
+        assertTrue(manager.connectWithToken(newUrl, "fresh-token") is RomMResult.Success)
+
+        assertEquals(newUrl, manager.getBaseUrl())
+        coVerify { accounts.updateServerUrl(oldUrl, newUrl, "fresh-token") }
+    }
+
+    @Test
+    fun `fresh pairing at a different instance cannot move the address`() = runTest {
+        manager.connect(oldUrl, "saved-token")
+        coEvery { newApi.getDevices() } returns Response.success(emptyList())
+
+        assertTrue(manager.connectWithToken(newUrl, "fresh-token") is RomMResult.Error)
+
+        assertSame(oldApi, manager.getApi())
+        coVerify(exactly = 0) { accounts.updateServerUrl(any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary

Add Save URL to the existing Server URL field in Settings > RomM > Rom Manager. Validate the replacement address using saved authentication before updating the connection, following [Grout's implementation](https://github.com/rommapp/grout/commit/da091e2db44795d9ea2d0dd49402e3d74100efc3).

Closes #424.

## Behavior changes

- Save a replacement address without signing out. Show validation progress, success, or an inline error; editing clears previous feedback.
- Failed validation preserves the saved URL and live connection. Matching account URLs update in place, preserving account/device IDs and inactive credentials.
- Reauthentication at a replacement address must match the existing user and registered device.
- Reuse the existing Rom Manager field and controller navigation. No duplicate URL controls on the main RomM page.

## Hot paths

No new launch, frame, or sync I/O. Validation and persistence run only when saving an address or completing authentication at a replacement address.

## Testing evidence

Tested on Samsung Galaxy S23 Ultra (SM-S918U1) using the debug APK and isolated local HTTP endpoints with dummy credentials:

- Existing URL field and Save URL appear inside Rom Manager; duplicate controls absent from parent page.
- Touch and ADB-injected gamepad D-pad/A save successfully. Success message appears and clears on editing.
- Unauthorized, wrong-user, and unreachable destinations show inline errors without replacing the saved URL.
- Valid URL, saved token, and device ID survive app restart; authenticated requests use the updated endpoint.

Six RomMServerUrlTest regression cases passed through direct JUnit execution (1.4 seconds). Gradle's test worker was blocked by a Windows/JBR loopback connection error.

Latest UI APK compiled and packaged in 3m 1s using a local-only broad Compose stability override for iteration. That override is outside Git and is not part of this PR; it can affect recomposition, so these device results describe that iteration APK. The latest UI was not fully built with the normal compiler configuration. No real RomM library migration, physical controller, TV, or dual-screen hardware test was performed. The shared settings form retains both input routes; second-screen hardware validation is deferred because the attached phone has one display.

Earlier checks passed: actual DAO SQL preservation/rollback against temporary SQLite data, resource XML parsing, repository agentic-smell and coupling checks. Current diff passes whitespace validation. Independent review found no actionable issues in UI placement, controller indices, or feedback-state resets.

## AI assistance

Research, implementation, regression tests, and review were performed primarily by OpenAI Codex following the requested scope and linked Grout implementation.

## Checklist

- [x] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
