### PR TITLE
Fix Display Roles carousel cycling through all options

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouter.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouter.kt
@@ -471,13 +471,7 @@ internal fun routeSetDualScreenEnabled(vm: SettingsViewModel, enabled: Boolean) 
 internal fun routeCycleDisplayRoleOverride(vm: SettingsViewModel, direction: Int) {
     val entries = com.nendo.argosy.data.preferences.DisplayRoleOverride.entries
     val current = vm._uiState.value.display.displayRoleOverride
-    val currentSwapped = com.nendo.argosy.DualScreenManagerHolder.instance?.isRolesSwapped?.value
-        ?: overrideResolvesToSwapped(vm, current)
-    val next = (1..entries.size)
-        .asSequence()
-        .map { step -> entries[(current.ordinal + direction * step).mod(entries.size)] }
-        .firstOrNull { overrideResolvesToSwapped(vm, it) != currentSwapped }
-        ?: return
+    val next = entries[(current.ordinal + direction).mod(entries.size)]
     routeSetDisplayRoleOverride(vm, next)
 }
 
@@ -503,17 +497,6 @@ internal fun routeSetDisplayRoleOverride(
             dsm.companionHost?.onRoleSwapped(newSwapped)
         }
     }
-}
-
-private fun overrideResolvesToSwapped(
-    vm: SettingsViewModel,
-    value: com.nendo.argosy.data.preferences.DisplayRoleOverride
-): Boolean = when (value) {
-    com.nendo.argosy.data.preferences.DisplayRoleOverride.SWAPPED -> true
-    com.nendo.argosy.data.preferences.DisplayRoleOverride.STANDARD -> false
-    com.nendo.argosy.data.preferences.DisplayRoleOverride.AUTO ->
-        vm.displayAffinityHelper.secondaryDisplayType ==
-            com.nendo.argosy.util.SecondaryDisplayType.EXTERNAL
 }
 
 // --- Gradient cycle methods ---

--- a/app/src/test/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouterTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouterTest.kt
@@ -1,6 +1,9 @@
 package com.nendo.argosy.ui.screens.settings
 
 import com.nendo.argosy.data.preferences.DisplayRoleOverride
+import com.nendo.argosy.data.preferences.DisplayRoleOverride.AUTO
+import com.nendo.argosy.data.preferences.DisplayRoleOverride.STANDARD
+import com.nendo.argosy.data.preferences.DisplayRoleOverride.SWAPPED
 import com.nendo.argosy.util.SecondaryDisplayType
 import io.mockk.every
 import io.mockk.mockk
@@ -22,14 +25,19 @@ class SettingsGeneralRouterTest {
         mockkStatic(::routeSetDisplayRoleOverride)
         try {
             every { routeSetDisplayRoleOverride(vm, capture(selected)) } returns Unit
-            val options = listOf(DisplayRoleOverride.AUTO, DisplayRoleOverride.STANDARD, DisplayRoleOverride.SWAPPED)
-            for (direction in listOf(-1, 1)) {
-                for ((index, current) in options.withIndex()) {
-                    state.value = state.value.copy(display = state.value.display.copy(displayRoleOverride = current))
-                    selected.clear()
-                    routeCycleDisplayRoleOverride(vm, direction)
-                    assertEquals("$current, direction $direction", options[(index + direction).mod(options.size)], selected.captured)
-                }
+            val transitions = listOf(
+                Triple(AUTO, 1, STANDARD),
+                Triple(STANDARD, 1, SWAPPED),
+                Triple(SWAPPED, 1, AUTO),
+                Triple(AUTO, -1, SWAPPED),
+                Triple(SWAPPED, -1, STANDARD),
+                Triple(STANDARD, -1, AUTO)
+            )
+            for ((current, direction, expected) in transitions) {
+                state.value = state.value.copy(display = state.value.display.copy(displayRoleOverride = current))
+                selected.clear()
+                routeCycleDisplayRoleOverride(vm, direction)
+                assertEquals("$current, direction $direction", expected, selected.captured)
             }
         } finally {
             unmockkStatic(::routeSetDisplayRoleOverride)

--- a/app/src/test/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouterTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/ui/screens/settings/SettingsGeneralRouterTest.kt
@@ -1,0 +1,38 @@
+package com.nendo.argosy.ui.screens.settings
+
+import com.nendo.argosy.data.preferences.DisplayRoleOverride
+import com.nendo.argosy.util.SecondaryDisplayType
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SettingsGeneralRouterTest {
+    @Test
+    fun `display role carousel visits every option in both directions`() {
+        val state = MutableStateFlow(SettingsUiState())
+        val vm = mockk<SettingsViewModel>()
+        every { vm._uiState } returns state
+        every { vm.displayAffinityHelper.secondaryDisplayType } returns SecondaryDisplayType.EXTERNAL
+        val selected = slot<DisplayRoleOverride>()
+        mockkStatic(::routeSetDisplayRoleOverride)
+        try {
+            every { routeSetDisplayRoleOverride(vm, capture(selected)) } returns Unit
+            val options = listOf(DisplayRoleOverride.AUTO, DisplayRoleOverride.STANDARD, DisplayRoleOverride.SWAPPED)
+            for (direction in listOf(-1, 1)) {
+                for ((index, current) in options.withIndex()) {
+                    state.value = state.value.copy(display = state.value.display.copy(displayRoleOverride = current))
+                    selected.clear()
+                    routeCycleDisplayRoleOverride(vm, direction)
+                    assertEquals("$current, direction $direction", options[(index + direction).mod(options.size)], selected.captured)
+                }
+            }
+        } finally {
+            unmockkStatic(::routeSetDisplayRoleOverride)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Display Roles skipped choices whose resolved screen arrangement matched the current one. Cycle through AUTO, STANDARD, and SWAPPED directly with wraparound in either direction; remove the unused skip helper. Downstream setting application remains unchanged.

Closes #405.

## Testing evidence

- Regression test invokes the actual carousel router for all three states in both directions, intercepting the downstream setter. Failed against old code (AUTO left selected STANDARD); passes with fix in 1.4 seconds via direct JUnit.
- Galaxy S23 Ultra: touch arrows and ADB-injected gamepad left/right each traverse Standard → Swapped → Auto forward and Swapped → Standard → Auto backward. Original Auto selection and disabled dual-screen setting restored after testing.
- Debug APK built in 4m 50s with the agreed local-only Compose stability override and five-minute cutoff. Override is outside Git, absent from this PR, and can affect recomposition. Normal full compiler build was not repeated.
- Whitespace, agentic-smell, and coupling checks passed; independent review found no actionable issues.

Scope is carousel selection only. Physical dual-screen role changes, AYN Thor behavior, and TV hardware were not tested; downstream logic and shared input routes are unchanged.

## Hot paths

No new I/O. Replaces the candidate scan with one indexed enum lookup.

## AI assistance

Implementation, focused tests, and independent review assisted by OpenAI Codex.

## Checklist

- [x] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
