### PR TITLE
ui: add companion save slot rename and delete actions

### DIFF
--- a/app/src/main/kotlin/com/nendo/argosy/DualScreenManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/DualScreenManager.kt
@@ -128,6 +128,10 @@ class DualScreenManager(
         com.nendo.argosy.domain.usecase.savechannel.CreateSaveChannelUseCase,
     private val copySaveChannelUseCase:
         com.nendo.argosy.domain.usecase.savechannel.CopySaveChannelUseCase,
+    private val renameSaveChannelUseCase:
+        com.nendo.argosy.domain.usecase.savechannel.RenameSaveChannelUseCase,
+    private val deleteSaveChannelUseCase:
+        com.nendo.argosy.domain.usecase.savechannel.DeleteSaveChannelUseCase,
     private val restoreStateUseCase:
         com.nendo.argosy.domain.usecase.state.RestoreStateUseCase,
     private val emulatorResolver: EmulatorResolver,
@@ -1780,6 +1784,8 @@ class DualScreenManager(
             "HIDE" -> handleDualHide(gameId)
             "UNHIDE" -> handleDualUnhide(gameId)
             "SAVE_SWITCH_CHANNEL" -> handleSaveSwitchChannel(gameId, channelName)
+            "SAVE_RENAME_CHANNEL" -> openSaveChannelAction(gameId, channelName, false)
+            "SAVE_DELETE_CHANNEL" -> openSaveChannelAction(gameId, channelName, true)
             "SAVE_SET_RESTORE_POINT" -> handleSaveSetRestorePoint(gameId, channelName, timestamp ?: 0L)
             "DOWNLOAD_UPDATE_FILE" -> {
                 val fileId = channelName?.toLongOrNull()
@@ -2461,6 +2467,47 @@ class DualScreenManager(
         )
     }
 
+    private fun openSaveChannelAction(gameId: Long, channelName: String?, delete: Boolean) {
+        if (channelName == null || isReservedSaveSlotName(channelName)) return
+        scope.launch {
+            val manageable = kotlinx.coroutines.withContext(Dispatchers.IO) {
+                getUnifiedSavesUseCase(gameId, expandHistory = true).any {
+                    it.channelName == channelName && it.isLocked
+                }
+            }
+            if (!manageable || _dualGameDetailState.value?.gameId != gameId) return@launch
+            _dualGameDetailState.update {
+                it?.copy(
+                    modalType = if (delete) ActiveModal.SAVE_DELETE else ActiveModal.SAVE_NAME,
+                    saveNamePromptAction = "RENAME_SLOT",
+                    saveChannelName = channelName,
+                    saveNameText = channelName,
+                    saveDeleteFocusIndex = 0
+                )
+            }
+            refocusMain()
+        }
+    }
+
+    fun moveDualSaveDeleteFocus(delta: Int) {
+        _dualGameDetailState.update {
+            it?.copy(saveDeleteFocusIndex = (it.saveDeleteFocusIndex + delta).coerceIn(0, 1))
+        }
+    }
+
+    fun confirmDualSaveDelete(confirm: Boolean = _dualGameDetailState.value?.saveDeleteFocusIndex == 1) {
+        val state = _dualGameDetailState.value ?: return
+        if (state.modalType != ActiveModal.SAVE_DELETE) return
+        val channelName = state.saveChannelName ?: return
+        dismissDualModal()
+        if (!confirm) return
+        scope.launch(Dispatchers.IO) {
+            deleteSaveChannelUseCase(state.gameId, channelName)
+            broadcastUnifiedSaves(state.gameId)
+            broadcastUnifiedStates(state.gameId)
+        }
+    }
+
     fun updateDualSaveNameText(text: String) {
         _dualGameDetailState.update { it?.copy(saveNameText = text) }
     }
@@ -2483,6 +2530,14 @@ class DualScreenManager(
         val gameId = state.gameId
 
         when (state.saveNamePromptAction) {
+            "RENAME_SLOT" -> {
+                val oldName = state.saveChannelName ?: return
+                scope.launch(Dispatchers.IO) {
+                    renameSaveChannelUseCase(gameId, oldName, name)
+                    broadcastUnifiedSaves(gameId)
+                    broadcastUnifiedStates(gameId)
+                }
+            }
             "CREATE_SLOT" -> handleCreateSlot(gameId, name)
             "LOCK_AS_SLOT" -> handleLockAsSlot(
                 gameId, state.saveNameCacheId, name

--- a/app/src/main/kotlin/com/nendo/argosy/DualScreenManager.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/DualScreenManager.kt
@@ -1234,9 +1234,13 @@ class DualScreenManager(
 
     var onOverlayFocusChanged: ((Boolean) -> Unit)? = null
     var isOverlayFocused = false
+        get() {
+            val modal = _dualGameDetailState.value?.modalType
+            return field || (!isRolesSwapped.value && modal != null && modal != ActiveModal.NONE)
+        }
         set(value) {
             field = value
-            onOverlayFocusChanged?.invoke(value)
+            onOverlayFocusChanged?.invoke(isOverlayFocused)
         }
     var swappedDualHomeViewModel: DualHomeViewModel? = null
         private set

--- a/app/src/main/kotlin/com/nendo/argosy/MainActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/MainActivity.kt
@@ -135,6 +135,10 @@ class MainActivity : ComponentActivity() {
         com.nendo.argosy.domain.usecase.savechannel.CreateSaveChannelUseCase
     @Inject lateinit var copySaveChannelUseCase:
         com.nendo.argosy.domain.usecase.savechannel.CopySaveChannelUseCase
+    @Inject lateinit var renameSaveChannelUseCase:
+        com.nendo.argosy.domain.usecase.savechannel.RenameSaveChannelUseCase
+    @Inject lateinit var deleteSaveChannelUseCase:
+        com.nendo.argosy.domain.usecase.savechannel.DeleteSaveChannelUseCase
     @Inject lateinit var restoreStateUseCase:
         com.nendo.argosy.domain.usecase.state.RestoreStateUseCase
     @Inject lateinit var prefetchGameSaveDataUseCase:
@@ -380,6 +384,8 @@ class MainActivity : ComponentActivity() {
                 restoreSaveChannelPointUseCase = restoreSaveChannelPointUseCase,
                 createSaveChannelUseCase = createSaveChannelUseCase,
                 copySaveChannelUseCase = copySaveChannelUseCase,
+                renameSaveChannelUseCase = renameSaveChannelUseCase,
+                deleteSaveChannelUseCase = deleteSaveChannelUseCase,
                 restoreStateUseCase = restoreStateUseCase,
                 prefetchGameSaveDataUseCase = prefetchGameSaveDataUseCase,
                 emulatorResolver = emulatorResolver,

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeActivity.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeActivity.kt
@@ -1069,7 +1069,7 @@ class SecondaryHomeActivity :
                 vm.loadGame(vm.uiState.value.gameId)
                 refocusSelf()
             }
-            ActiveModal.SAVE_NAME.name, ActiveModal.REVIEW_EDITOR.name -> refocusSelf()
+            ActiveModal.SAVE_NAME.name, ActiveModal.SAVE_DELETE.name, ActiveModal.REVIEW_EDITOR.name -> refocusSelf()
             ActiveModal.COLLECTION.name -> {
                 if (collectionCreateName != null) {
                     vm.createAndAddToCollection(collectionCreateName)

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeBroadcastHelper.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeBroadcastHelper.kt
@@ -19,6 +19,11 @@ class SecondaryHomeBroadcastHelper(
         dsm.handleGameDetailOpened(gameId)
     }
 
+    fun updateSaveName(text: String) = dsm.updateDualSaveNameText(text)
+    fun confirmSaveName() = dsm.confirmDualSaveName()
+    fun moveSaveDeleteFocus(delta: Int) = dsm.moveDualSaveDeleteFocus(delta)
+    fun confirmSaveDelete(confirm: Boolean) = dsm.confirmDualSaveDelete(confirm)
+
     fun broadcastGameDetailClosed() {
         dsm.onGameDetailClosed()
     }

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeComposables.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeComposables.kt
@@ -388,6 +388,7 @@ fun ShowcaseRoleContent(
                         onModalCollectionCreateDismiss = showcaseViewModel::onModalCollectionCreateDismiss,
                         onSaveNameTextChange = showcaseViewModel::onSaveNameTextChange,
                         onSaveNameConfirm = showcaseViewModel::onSaveNameConfirm,
+                        onSaveDeleteConfirm = showcaseViewModel::onSaveDeleteConfirm,
                         onDiscSelect = showcaseViewModel::onDiscSelect,
                         onModalSteamInstallSelect = showcaseViewModel::onModalSteamInstallSelect,
                         onModalDismiss = showcaseViewModel::onModalDismiss,
@@ -557,11 +558,16 @@ fun DualGameDetailContent(
         onDimTapped = onDimTapped,
         onTabChanged = { viewModel.setTab(it) },
         onSlotTapped = { index ->
+            viewModel.focusSlotsColumn()
             viewModel.moveSlotSelection(index - viewModel.selectedSlotIndex.value)
         },
         onHistoryTapped = { index ->
+            viewModel.focusHistoryColumn()
             viewModel.moveHistorySelection(index - viewModel.selectedHistoryIndex.value)
         },
+        canManageSaveChannel = viewModel.manageableSaveChannel != null,
+        onRenameSaveChannel = viewModel::renameSelectedSaveChannel,
+        onDeleteSaveChannel = viewModel::deleteSelectedSaveChannel,
         onStateTapped = { index -> viewModel.tapStateEntry(index) },
         onStateMenuSelect = { index ->
             viewModel.setStateMenuFocus(index)

--- a/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeInputHandler.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/hardware/SecondaryHomeInputHandler.kt
@@ -489,7 +489,13 @@ class SecondaryHomeInputHandler(
             }
             GamepadEvent.ContextMenu -> {
                 when (vm.uiState.value.currentTab) {
-                    DualGameDetailTab.SAVES -> handleSaveLockAsSlot(vm)
+                    DualGameDetailTab.SAVES -> {
+                        if (vm.uiState.value.saveFocusColumn == SaveFocusColumn.SLOTS) {
+                            vm.renameSelectedSaveChannel()
+                        } else {
+                            handleSaveLockAsSlot(vm)
+                        }
+                    }
                     DualGameDetailTab.STATES -> {
                         val entry = vm.getFocusedStateEntry()
                         if (entry?.screenshotPath != null) {
@@ -501,6 +507,9 @@ class SecondaryHomeInputHandler(
                 InputResult.HANDLED
             }
             GamepadEvent.SecondaryAction -> {
+                if (vm.uiState.value.currentTab == DualGameDetailTab.SAVES) {
+                    vm.deleteSelectedSaveChannel()
+                }
                 if (vm.uiState.value.currentTab == DualGameDetailTab.STATES) {
                     vm.promptStateDelete()
                 }
@@ -1528,7 +1537,7 @@ class SecondaryHomeInputHandler(
                 }
                 return InputResult.HANDLED
             }
-            ActiveModal.SAVE_NAME, ActiveModal.NONE -> {}
+            ActiveModal.SAVE_NAME, ActiveModal.SAVE_DELETE, ActiveModal.NONE -> {}
         }
 
         return InputResult.HANDLED

--- a/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/ArgosyApp.kt
@@ -618,6 +618,8 @@ fun ArgosyApp(
                     }
                 } else if (state?.modalType == ActiveModal.COVER_PICKER) {
                     activity?.moveDualCoverPickerFocus(-1)
+                } else if (state?.modalType == ActiveModal.SAVE_DELETE) {
+                    activity?.dualScreenManager?.moveDualSaveDeleteFocus(-1)
                 } else if (state?.modalType == ActiveModal.REVIEW_EDITOR) {
                     activity?.adjustDualReviewEditor(-1)
                 }
@@ -635,6 +637,8 @@ fun ArgosyApp(
                     }
                 } else if (state?.modalType == ActiveModal.COVER_PICKER) {
                     activity?.moveDualCoverPickerFocus(1)
+                } else if (state?.modalType == ActiveModal.SAVE_DELETE) {
+                    activity?.dualScreenManager?.moveDualSaveDeleteFocus(1)
                 } else if (state?.modalType == ActiveModal.REVIEW_EDITOR) {
                     activity?.adjustDualReviewEditor(1)
                 }
@@ -699,6 +703,7 @@ fun ArgosyApp(
                     ActiveModal.COLLECTION -> activity?.toggleDualCollectionAtFocus()
                     ActiveModal.STEAM_INSTALL -> activity?.confirmDualSteamInstallSelection()
                     ActiveModal.SAVE_NAME -> activity?.confirmDualSaveName()
+                    ActiveModal.SAVE_DELETE -> activity?.dualScreenManager?.confirmDualSaveDelete()
                     ActiveModal.FILE_PICKER -> activity?.activateDualFilePickerFocused()
                     ActiveModal.COVER_PICKER -> activity?.confirmDualCoverAtFocus()
                     ActiveModal.REVIEW_EDITOR -> activity?.confirmDualReviewEditor()
@@ -1326,6 +1331,9 @@ fun ArgosyApp(
                             },
                             onSaveNameConfirm = {
                                 activity?.confirmDualSaveName()
+                            },
+                            onSaveDeleteConfirm = {
+                                activity?.dualScreenManager?.confirmDualSaveDelete(true)
                             },
                             onDiscSelect = { index ->
                                 activity?.selectDualDisc(index)

--- a/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelModal.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/common/savechannel/SaveChannelModal.kt
@@ -884,7 +884,7 @@ private fun RestoreConfirmationOverlay() {
 }
 
 @Composable
-private fun RenameChannelOverlay(
+internal fun RenameChannelOverlay(
     mode: RenameMode,
     text: String,
     onTextChange: (String) -> Unit,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/ShowcaseViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/ShowcaseViewModel.kt
@@ -168,10 +168,15 @@ class ShowcaseViewModel(
 
     fun onSaveNameTextChange(text: String) {
         detailState.update { it?.copy(saveNameText = text) }
+        if (isControlActive()) broadcasts.updateSaveName(text)
     }
 
     fun onSaveNameConfirm() {
-        detailState.update { it?.copy(modalType = ActiveModal.NONE) }
+        if (isControlActive()) broadcasts.confirmSaveName()
+    }
+
+    fun onSaveDeleteConfirm() {
+        if (isControlActive()) broadcasts.confirmSaveDelete(true)
     }
 
     fun onDiscSelect(index: Int) {
@@ -414,11 +419,13 @@ class ShowcaseViewModel(
                 if (modal == ActiveModal.RATING || modal == ActiveModal.DIFFICULTY)
                     adjustModalRating(-1)
                 if (modal == ActiveModal.COVER_PICKER) moveCoverPickerFocus(-1)
+                if (modal == ActiveModal.SAVE_DELETE && isControlActive()) broadcasts.moveSaveDeleteFocus(-1)
             }
             is GamepadEvent.Right -> {
                 if (modal == ActiveModal.RATING || modal == ActiveModal.DIFFICULTY)
                     adjustModalRating(1)
                 if (modal == ActiveModal.COVER_PICKER) moveCoverPickerFocus(1)
+                if (modal == ActiveModal.SAVE_DELETE && isControlActive()) broadcasts.moveSaveDeleteFocus(1)
             }
             is GamepadEvent.Up -> {
                 if (state.showCreateDialog) return true
@@ -486,6 +493,9 @@ class ShowcaseViewModel(
                     ActiveModal.STEAM_INSTALL ->
                         onModalSteamInstallSelect(state.steamInstallFocusIndex)
                     ActiveModal.SAVE_NAME -> onSaveNameConfirm()
+                    ActiveModal.SAVE_DELETE -> if (isControlActive()) {
+                        broadcasts.confirmSaveDelete(state.saveDeleteFocusIndex == 1)
+                    }
                     ActiveModal.COVER_PICKER -> onCoverSelect(state.coverPickerFocusIndex)
                     else -> {}
                 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailInputHandler.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailInputHandler.kt
@@ -189,7 +189,13 @@ class DualGameDetailInputHandler(
             }
             GamepadEvent.ContextMenu -> {
                 when (vm.uiState.value.currentTab) {
-                    DualGameDetailTab.SAVES -> handleSaveLockAsSlot(vm)
+                    DualGameDetailTab.SAVES -> {
+                        if (vm.uiState.value.saveFocusColumn == SaveFocusColumn.SLOTS) {
+                            vm.renameSelectedSaveChannel()
+                        } else {
+                            handleSaveLockAsSlot(vm)
+                        }
+                    }
                     DualGameDetailTab.STATES -> {
                         val entry = vm.getFocusedStateEntry()
                         if (entry?.screenshotPath != null) {
@@ -201,6 +207,9 @@ class DualGameDetailInputHandler(
                 InputResult.HANDLED
             }
             GamepadEvent.SecondaryAction -> {
+                if (vm.uiState.value.currentTab == DualGameDetailTab.SAVES) {
+                    vm.deleteSelectedSaveChannel()
+                }
                 if (vm.uiState.value.currentTab == DualGameDetailTab.STATES) {
                     vm.promptStateDelete()
                 }
@@ -564,7 +573,7 @@ class DualGameDetailInputHandler(
                 }
                 return InputResult.HANDLED
             }
-            ActiveModal.SAVE_NAME, ActiveModal.NONE -> {}
+            ActiveModal.SAVE_NAME, ActiveModal.SAVE_DELETE, ActiveModal.NONE -> {}
         }
 
         return InputResult.HANDLED

--- a/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailLowerScreen.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailLowerScreen.kt
@@ -68,8 +68,7 @@ import androidx.compose.ui.draw.clip
 import com.nendo.argosy.ui.components.CustomTileMenuModal
 import com.nendo.argosy.ui.components.InputButton
 import com.nendo.argosy.ui.primitives.ArgosyConfirmModal
-import com.nendo.argosy.ui.primitives.ActionButton
-import com.nendo.argosy.ui.primitives.InputGlyph
+import com.nendo.argosy.ui.components.FooterBar
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import com.nendo.argosy.ui.primitives.ArgosyProgressBar
@@ -369,23 +368,6 @@ private fun SavesTabContent(
             if (isSyncing) {
                 ArgosyProgressBar(progress = null, style = ProgressBarStyle.Working)
             }
-            if (canManageSaveChannel) {
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(Dimens.spacingSm),
-                    horizontalArrangement = Arrangement.spacedBy(Dimens.spacingSm)
-                ) {
-                    ActionButton(onClick = onRenameSaveChannel) {
-                        InputGlyph(InputButton.X)
-                        Spacer(Modifier.width(Dimens.spacingSm))
-                        Text(stringResource(R.string.ui_save_channel_footer_rename), color = theme.textPrimary)
-                    }
-                    ActionButton(onClick = onDeleteSaveChannel) {
-                        InputGlyph(InputButton.Y)
-                        Spacer(Modifier.width(Dimens.spacingSm))
-                        Text(stringResource(R.string.ui_save_channel_footer_delete_slot), color = theme.textPrimary)
-                    }
-                }
-            }
             Row(
                 modifier = Modifier
                     .weight(1f)
@@ -413,6 +395,21 @@ private fun SavesTabContent(
                     modifier = Modifier
                         .weight(0.6f)
                         .fillMaxHeight()
+                )
+            }
+            if (canManageSaveChannel) {
+                FooterBar(
+                    hints = listOf(
+                        InputButton.X to stringResource(R.string.ui_save_channel_footer_rename),
+                        InputButton.Y to stringResource(R.string.ui_save_channel_footer_delete_slot)
+                    ),
+                    onHintClick = { button ->
+                        when (button) {
+                            InputButton.X -> onRenameSaveChannel()
+                            InputButton.Y -> onDeleteSaveChannel()
+                            else -> Unit
+                        }
+                    }
                 )
             }
         }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailLowerScreen.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailLowerScreen.kt
@@ -66,7 +66,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import com.nendo.argosy.ui.components.CustomTileMenuModal
+import com.nendo.argosy.ui.components.InputButton
 import com.nendo.argosy.ui.primitives.ArgosyConfirmModal
+import com.nendo.argosy.ui.primitives.ActionButton
+import com.nendo.argosy.ui.primitives.InputGlyph
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import com.nendo.argosy.ui.primitives.ArgosyProgressBar
@@ -126,6 +129,9 @@ fun DualGameDetailLowerScreen(
     onTabChanged: (DualGameDetailTab) -> Unit,
     onSlotTapped: (Int) -> Unit,
     onHistoryTapped: (Int) -> Unit,
+    canManageSaveChannel: Boolean = false,
+    onRenameSaveChannel: () -> Unit = {},
+    onDeleteSaveChannel: () -> Unit = {},
     onStateTapped: (Int) -> Unit = {},
     onStateMenuSelect: (Int) -> Unit = {},
     onStateMenuDismiss: () -> Unit = {},
@@ -166,7 +172,10 @@ fun DualGameDetailLowerScreen(
                         isApplying = savesApplying,
                         isSyncing = savesSyncing,
                         onSlotTapped = onSlotTapped,
-                        onHistoryTapped = onHistoryTapped
+                        onHistoryTapped = onHistoryTapped,
+                        canManageSaveChannel = canManageSaveChannel,
+                        onRenameSaveChannel = onRenameSaveChannel,
+                        onDeleteSaveChannel = onDeleteSaveChannel
                     )
                     DualGameDetailTab.STATES -> StatesTabContent(
                         entries = stateEntries,
@@ -335,7 +344,10 @@ private fun SavesTabContent(
     isApplying: Boolean,
     isSyncing: Boolean = false,
     onSlotTapped: (Int) -> Unit,
-    onHistoryTapped: (Int) -> Unit
+    onHistoryTapped: (Int) -> Unit,
+    canManageSaveChannel: Boolean,
+    onRenameSaveChannel: () -> Unit,
+    onDeleteSaveChannel: () -> Unit
 ) {
     val theme = LocalArgosyTheme.current
     if (isLoading) {
@@ -356,6 +368,23 @@ private fun SavesTabContent(
         Column(modifier = Modifier.fillMaxSize()) {
             if (isSyncing) {
                 ArgosyProgressBar(progress = null, style = ProgressBarStyle.Working)
+            }
+            if (canManageSaveChannel) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(Dimens.spacingSm),
+                    horizontalArrangement = Arrangement.spacedBy(Dimens.spacingSm)
+                ) {
+                    ActionButton(onClick = onRenameSaveChannel) {
+                        InputGlyph(InputButton.X)
+                        Spacer(Modifier.width(Dimens.spacingSm))
+                        Text(stringResource(R.string.ui_save_channel_footer_rename), color = theme.textPrimary)
+                    }
+                    ActionButton(onClick = onDeleteSaveChannel) {
+                        InputGlyph(InputButton.Y)
+                        Spacer(Modifier.width(Dimens.spacingSm))
+                        Text(stringResource(R.string.ui_save_channel_footer_delete_slot), color = theme.textPrimary)
+                    }
+                }
             }
             Row(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailModels.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailModels.kt
@@ -27,7 +27,7 @@ enum class DualGameDetailTab(@StringRes val labelRes: Int) {
     OPTIONS(R.string.dual_detail_tab_options)
 }
 
-enum class ActiveModal { NONE, RATING, DIFFICULTY, STATUS, EMULATOR, CORE, SAVE_PATH, DISPLAY_TARGET, MEMORY_CARD, COLLECTION, SAVE_NAME, DISC_PICKER, VARIANT_PICKER, STEAM_INSTALL, FILE_PICKER, COVER_PICKER, REVIEW_EDITOR }
+enum class ActiveModal { NONE, RATING, DIFFICULTY, STATUS, EMULATOR, CORE, SAVE_PATH, DISPLAY_TARGET, MEMORY_CARD, COLLECTION, SAVE_NAME, SAVE_DELETE, DISC_PICKER, VARIANT_PICKER, STEAM_INSTALL, FILE_PICKER, COVER_PICKER, REVIEW_EDITOR }
 
 enum class DualStateMenuAction(@StringRes val labelRes: Int) {
     COPY_TO(R.string.dual_state_menu_copy_to),
@@ -223,6 +223,8 @@ data class DualGameDetailUpperState(
     val saveNamePromptAction: String? = null,
     val saveNameCacheId: Long? = null,
     val saveNameText: String = "",
+    val saveChannelName: String? = null,
+    val saveDeleteFocusIndex: Int = 0,
     val updateFiles: List<UpdateFileUi> = emptyList(),
     val dlcFiles: List<UpdateFileUi> = emptyList(),
     val focusedStateEntry: UnifiedStateEntry? = null,

--- a/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailUpperScreen.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailUpperScreen.kt
@@ -55,7 +55,6 @@ import com.nendo.argosy.R
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.nendo.argosy.data.emulator.DiscOption
-import androidx.compose.material3.OutlinedTextField
 import com.nendo.argosy.domain.model.UnifiedStateEntry
 import androidx.compose.foundation.layout.fillMaxHeight
 import com.nendo.argosy.ui.common.displayName
@@ -70,7 +69,8 @@ import com.nendo.argosy.ui.dualscreen.ShowcaseEyebrow
 import com.nendo.argosy.ui.dualscreen.ShowcaseRatingsCluster
 import com.nendo.argosy.ui.dualscreen.ShowcaseStatsRow
 import com.nendo.argosy.ui.dualscreen.ShowcaseTimeToBeatRow
-import com.nendo.argosy.ui.primitives.ActionButton
+import com.nendo.argosy.ui.common.savechannel.RenameChannelOverlay
+import com.nendo.argosy.ui.common.savechannel.RenameMode
 import com.nendo.argosy.ui.primitives.GlassPanel
 import com.nendo.argosy.ui.primitives.RowButton
 import com.nendo.argosy.ui.screens.collections.dialogs.CreateCollectionDialog
@@ -245,12 +245,16 @@ fun DualGameDetailUpperScreen(
                     onDismiss = onModalDismiss
                 )
             }
-            ActiveModal.SAVE_NAME -> DualSaveNamePrompt(
+            ActiveModal.SAVE_NAME -> RenameChannelOverlay(
+                mode = when (state.saveNamePromptAction) {
+                    "RENAME_SLOT" -> RenameMode.RENAME
+                    "LOCK_AS_SLOT" -> RenameMode.SAVE_AS
+                    else -> RenameMode.NEW_SLOT
+                },
                 text = state.saveNameText,
-                isRenaming = state.saveNamePromptAction == "RENAME_SLOT",
                 onTextChange = onSaveNameTextChange,
                 onConfirm = onSaveNameConfirm,
-                onDismiss = onModalDismiss
+                onCancel = onModalDismiss
             )
             ActiveModal.SAVE_DELETE -> com.nendo.argosy.ui.primitives.ArgosyConfirmModal(
                 title = stringResource(R.string.ui_save_channel_delete_slot_title),
@@ -1230,66 +1234,5 @@ private fun StatePreviewDisplay(
         )
 
         footerHints()
-    }
-}
-
-@Composable
-private fun DualSaveNamePrompt(
-    text: String,
-    isRenaming: Boolean,
-    onTextChange: (String) -> Unit,
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    val theme = LocalArgosyTheme.current
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.6f))
-            .touchOnly { onDismiss() },
-        contentAlignment = Alignment.Center
-    ) {
-        GlassPanel(
-            modifier = Modifier
-                .fillMaxWidth(0.5f)
-                .touchOnly { }
-        ) {
-            Column(
-                modifier = Modifier.padding(Dimens.spacingLg),
-                verticalArrangement = Arrangement.spacedBy(Dimens.spacingMd)
-            ) {
-                Text(
-                    text = stringResource(if (isRenaming) R.string.ui_save_channel_rename_title_rename else R.string.dual_detail_save_name_heading),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = theme.textPrimary
-                )
-
-                OutlinedTextField(
-                    value = text,
-                    onValueChange = onTextChange,
-                    label = { Text(stringResource(R.string.dual_detail_save_name_field_label)) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    ActionButton(
-                        label = stringResource(R.string.dual_detail_save_name_cancel),
-                        onClick = onDismiss
-                    )
-                    Spacer(modifier = Modifier.width(Dimens.spacingSm))
-                    ActionButton(
-                        label = stringResource(if (isRenaming) R.string.ui_save_channel_rename_confirm_rename else R.string.dual_detail_save_name_create),
-                        onClick = onConfirm,
-                        primary = true
-                    )
-                }
-            }
-        }
     }
 }

--- a/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailUpperScreen.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailUpperScreen.kt
@@ -106,6 +106,7 @@ fun DualGameDetailUpperScreen(
     onModalCollectionCreateDismiss: () -> Unit = {},
     onSaveNameTextChange: (String) -> Unit = {},
     onSaveNameConfirm: () -> Unit = {},
+    onSaveDeleteConfirm: () -> Unit = {},
     onDiscSelect: (Int) -> Unit = {},
     onModalSteamInstallSelect: (Int) -> Unit = {},
     onModalDismiss: () -> Unit = {},
@@ -246,9 +247,19 @@ fun DualGameDetailUpperScreen(
             }
             ActiveModal.SAVE_NAME -> DualSaveNamePrompt(
                 text = state.saveNameText,
+                isRenaming = state.saveNamePromptAction == "RENAME_SLOT",
                 onTextChange = onSaveNameTextChange,
                 onConfirm = onSaveNameConfirm,
                 onDismiss = onModalDismiss
+            )
+            ActiveModal.SAVE_DELETE -> com.nendo.argosy.ui.primitives.ArgosyConfirmModal(
+                title = stringResource(R.string.ui_save_channel_delete_slot_title),
+                message = stringResource(R.string.ui_save_channel_delete_slot_message, state.saveChannelName.orEmpty()),
+                confirmLabel = stringResource(R.string.ui_save_channel_delete_slot_confirm),
+                onConfirm = onSaveDeleteConfirm,
+                onDismiss = onModalDismiss,
+                focusedIndex = state.saveDeleteFocusIndex,
+                destructive = true
             )
             ActiveModal.DISC_PICKER -> DualDiscPickerContent(
                 discs = state.discPickerOptions,
@@ -1225,6 +1236,7 @@ private fun StatePreviewDisplay(
 @Composable
 private fun DualSaveNamePrompt(
     text: String,
+    isRenaming: Boolean,
     onTextChange: (String) -> Unit,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit
@@ -1247,7 +1259,7 @@ private fun DualSaveNamePrompt(
                 verticalArrangement = Arrangement.spacedBy(Dimens.spacingMd)
             ) {
                 Text(
-                    text = stringResource(R.string.dual_detail_save_name_heading),
+                    text = stringResource(if (isRenaming) R.string.ui_save_channel_rename_title_rename else R.string.dual_detail_save_name_heading),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     color = theme.textPrimary
@@ -1272,7 +1284,7 @@ private fun DualSaveNamePrompt(
                     )
                     Spacer(modifier = Modifier.width(Dimens.spacingSm))
                     ActionButton(
-                        label = stringResource(R.string.dual_detail_save_name_create),
+                        label = stringResource(if (isRenaming) R.string.ui_save_channel_rename_confirm_rename else R.string.dual_detail_save_name_create),
                         onClick = onConfirm,
                         primary = true
                     )

--- a/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailViewModel.kt
+++ b/app/src/main/kotlin/com/nendo/argosy/ui/dualscreen/gamedetail/DualGameDetailViewModel.kt
@@ -105,6 +105,28 @@ class DualGameDetailViewModel(
 
     private var _rawEntries: List<SaveEntryData> = emptyList()
 
+    val manageableSaveChannel: String?
+        get() {
+            val state = _uiState.value
+            if (state.currentTab != DualGameDetailTab.SAVES ||
+                state.saveFocusColumn != SaveFocusColumn.SLOTS ||
+                _savesLoading.value || _savesApplying.value
+            ) return null
+            val slot = _saveSlots.value.getOrNull(_selectedSlotIndex.value) ?: return null
+            if (slot.isCreateAction || slot.channelName == null) return null
+            return slot.channelName.takeIf { channel ->
+                _rawEntries.any { it.channelName == channel && it.isLocked }
+            }
+        }
+
+    fun renameSelectedSaveChannel() {
+        manageableSaveChannel?.let { stateDirectAction("SAVE_RENAME_CHANNEL", it) }
+    }
+
+    fun deleteSelectedSaveChannel() {
+        manageableSaveChannel?.let { stateDirectAction("SAVE_DELETE_CHANNEL", it) }
+    }
+
     private val _savesLoading = MutableStateFlow(true)
     val savesLoading: StateFlow<Boolean> = _savesLoading.asStateFlow()
 
@@ -377,7 +399,7 @@ class DualGameDetailViewModel(
             ActiveModal.EMULATOR, ActiveModal.CORE, ActiveModal.COLLECTION,
             ActiveModal.SAVE_PATH, ActiveModal.DISPLAY_TARGET,
             ActiveModal.MEMORY_CARD,
-            ActiveModal.SAVE_NAME,
+            ActiveModal.SAVE_NAME, ActiveModal.SAVE_DELETE,
             ActiveModal.DISC_PICKER, ActiveModal.VARIANT_PICKER,
             ActiveModal.STEAM_INSTALL, ActiveModal.REVIEW_EDITOR -> return
             ActiveModal.FILE_PICKER, ActiveModal.COVER_PICKER -> {}

--- a/app/src/test/kotlin/com/nendo/argosy/ui/dualscreen/ShowcaseSaveChannelTest.kt
+++ b/app/src/test/kotlin/com/nendo/argosy/ui/dualscreen/ShowcaseSaveChannelTest.kt
@@ -1,0 +1,44 @@
+package com.nendo.argosy.ui.dualscreen
+
+import com.nendo.argosy.hardware.SecondaryHomeBroadcastHelper
+import com.nendo.argosy.ui.dualscreen.gamedetail.ActiveModal
+import com.nendo.argosy.ui.dualscreen.gamedetail.DualGameDetailUpperState
+import com.nendo.argosy.ui.input.GamepadEvent
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+
+class ShowcaseSaveChannelTest {
+    @Test
+    fun `delete confirmation honors cancel focus on the swapped display`() {
+        val broadcasts = mockk<SecondaryHomeBroadcastHelper>(relaxed = true)
+        val state = MutableStateFlow<DualGameDetailUpperState?>(
+            DualGameDetailUpperState(modalType = ActiveModal.SAVE_DELETE)
+        )
+        val viewModel = ShowcaseViewModel(state, broadcasts) { true }
+
+        viewModel.handleModalGamepadEvent(GamepadEvent.Confirm)
+        verify(exactly = 1) { broadcasts.confirmSaveDelete(false) }
+        verify(exactly = 0) { broadcasts.confirmSaveDelete(true) }
+
+        state.value = state.value?.copy(saveDeleteFocusIndex = 1)
+        viewModel.handleModalGamepadEvent(GamepadEvent.Confirm)
+        verify(exactly = 1) { broadcasts.confirmSaveDelete(true) }
+    }
+
+    @Test
+    fun `rename on the swapped display forwards the edited name and confirmation`() {
+        val broadcasts = mockk<SecondaryHomeBroadcastHelper>(relaxed = true)
+        val state = MutableStateFlow<DualGameDetailUpperState?>(
+            DualGameDetailUpperState(modalType = ActiveModal.SAVE_NAME)
+        )
+        val viewModel = ShowcaseViewModel(state, broadcasts) { true }
+
+        viewModel.onSaveNameTextChange("Renamed slot")
+        viewModel.handleModalGamepadEvent(GamepadEvent.Confirm)
+
+        verify(exactly = 1) { broadcasts.updateSaveName("Renamed slot") }
+        verify(exactly = 1) { broadcasts.confirmSaveName() }
+    }
+}


### PR DESCRIPTION
## Summary

Expose Rename and Delete for locked save channels in dual-screen game details. Fixes #403.

## Behavior changes

- Show clickable X/Rename and Y/Delete actions in the existing footer bar below the save list. History retains its existing lock-as-slot action.
- Reuse the shared save-channel name editor, including its text-field focus request, and existing rename/delete use cases. Delete opens a confirmation with Cancel selected by default.
- Route edits and confirmations through the shared display manager in normal and swapped roles, then refresh saves and states. Active top-screen dialogs retain controller input instead of forwarding it to the companion.
- Tapping a slot or history entry also selects its input column.

Emulator save-state actions and save synchronization implementations are unchanged.

## Hot paths

No new work on launch, frames, or idle input. Explicit management actions validate the selected locked channel and run existing save operations on Dispatchers.IO. UI state remains owned by the shared display manager.

## Testing evidence

- Offline debug iteration build passed in 3m 07s with the agreed local Compose stability override and five-minute cutoff. The override is outside this PR; a normal production-configuration build is not claimed.
- 20 focused Kotlin/JUnit tests passed: new swapped-display rename/cancel-delete routing checks plus existing save-channel delegate and save/state parity tests.
- Smell and staged coupling checks passed. Separate static review checked both display roles and confirmation routing.
- Debug APK installed on AYN Thor with two disposable app-private save slots. Human testing confirmed Delete transfers focus to the upper dialog, then confirmed the updated Rename behavior works successfully on the Thor. Production Argosy and its data were preserved; no Odin 3 commands were issued.
- Fixture code is temporary debug-only setup and is excluded from the PR. It exercises local UI/use-case integration, not server-side deletion. Full Gradle unit suite and lint were not run.

## AI assistance

OpenAI Codex performed most research, implementation, tests, and PR drafting, with separate AI research and static review. The contributor verified the updated behavior on the Thor and confirmed the checklist.

## Checklist

- [x] I've tested the changes on real hardware
- [x] I've added or updated unit tests covering the changes
- [x] I've personally reviewed and understand the code being submitted
